### PR TITLE
Volumes index and volume contents pages

### DIFF
--- a/app/components/app/AppBreadcrumb.vue
+++ b/app/components/app/AppBreadcrumb.vue
@@ -1,0 +1,35 @@
+<script setup lang="ts">
+export interface BreadcrumbItem {
+  label: string;
+  /** Omitted for the current (last) item, which renders as plain text. */
+  to?: string;
+}
+
+defineProps<{ items: BreadcrumbItem[] }>();
+
+const { t } = useI18n();
+</script>
+
+<template>
+  <nav :aria-label="t('nav.breadcrumbLabel')" class="text-sm">
+    <ol class="flex flex-wrap items-center gap-1.5 text-(--text-muted)">
+      <li
+        v-for="(item, index) in items"
+        :key="item.to ?? item.label"
+        class="flex items-center gap-1.5"
+      >
+        <NuxtLink
+          v-if="item.to"
+          :to="item.to"
+          class="rounded-button hover:text-teal focus-visible:outline focus-visible:outline-2 focus-visible:outline-teal"
+        >
+          {{ item.label }}
+        </NuxtLink>
+        <span v-else class="text-(--text-primary)" aria-current="page">{{
+          item.label
+        }}</span>
+        <span v-if="index < items.length - 1" aria-hidden="true">/</span>
+      </li>
+    </ol>
+  </nav>
+</template>

--- a/app/components/app/AppLanguageSwitcher.vue
+++ b/app/components/app/AppLanguageSwitcher.vue
@@ -8,7 +8,10 @@ const availableLocales = computed(() => locales.value as LocaleObject[]);
 </script>
 
 <template>
-  <nav :aria-label="t('nav.languageSwitcherLabel')" class="flex items-center gap-1">
+  <nav
+    :aria-label="t('nav.languageSwitcherLabel')"
+    class="flex items-center gap-1"
+  >
     <NuxtLink
       v-for="entry in availableLocales"
       :key="entry.code"

--- a/app/components/library/ChapterRow.vue
+++ b/app/components/library/ChapterRow.vue
@@ -1,0 +1,72 @@
+<script setup lang="ts">
+import type { ChapterGroupEntry } from "~/utils/chapterGrouping";
+import type { ContentVersion } from "~~/shared/types/content";
+
+const props = defineProps<{
+  entry: ChapterGroupEntry;
+  versions: ContentVersion[];
+}>();
+
+const { locale, t } = useI18n();
+const localePath = useLocalePath();
+
+/** The chapter a row's badges/link are computed from — the cluster's first chapter, if clustered. */
+const representativeChapter = computed(() =>
+  props.entry.type === "chapter"
+    ? props.entry.chapter
+    : props.entry.firstChapter,
+);
+
+const title = computed(() => {
+  if (props.entry.type === "chapter") {
+    return localizedText(props.entry.chapter.title, locale.value);
+  }
+
+  const key =
+    props.entry.kind === "answers-terminology"
+      ? "volumes.answersTerminologyCluster"
+      : "volumes.answersTopicsCluster";
+  return t(key, { count: props.entry.count });
+});
+
+const href = computed(() =>
+  localePath(`/read/${representativeChapter.value.id}`),
+);
+const languages = computed(() =>
+  chapterLanguages(representativeChapter.value, props.versions),
+);
+</script>
+
+<template>
+  <li>
+    <NuxtLink
+      :to="href"
+      class="flex items-center justify-between gap-3 rounded-card px-3 py-2.5 transition-colors hover:bg-(--surface-raised) focus-visible:outline focus-visible:outline-2 focus-visible:outline-teal"
+    >
+      <span class="flex min-w-0 items-baseline gap-2">
+        <span
+          v-if="entry.type === 'chapter'"
+          class="shrink-0 text-sm tabular-nums text-(--text-muted)"
+        >
+          {{ entry.chapter.number }}
+        </span>
+        <span class="truncate text-(--text-primary)">{{ title }}</span>
+      </span>
+
+      <span class="flex shrink-0 items-center gap-1.5">
+        <span
+          v-if="languages.aiTranslated"
+          class="rounded-button border border-orange-cta px-1.5 py-0.5 text-xs font-medium text-orange-cta"
+        >
+          {{ t("reader.aiTranslated") }}
+        </span>
+        <span
+          v-else-if="languages.he && !languages.en"
+          class="text-xs text-(--text-muted)"
+        >
+          {{ t("reader.hebrewOnly") }}
+        </span>
+      </span>
+    </NuxtLink>
+  </li>
+</template>

--- a/app/components/library/VolumeCard.vue
+++ b/app/components/library/VolumeCard.vue
@@ -1,0 +1,104 @@
+<script setup lang="ts">
+import type { LocaleObject } from "@nuxtjs/i18n";
+import type { ContentVersion, TocVolume } from "~~/shared/types/content";
+
+const props = defineProps<{
+  volume: TocVolume;
+  versions: ContentVersion[];
+}>();
+
+const { locale, locales, t } = useI18n();
+const localePath = useLocalePath();
+
+const active = computed(() => volumeHasContent(props.volume));
+const title = computed(() => localizedText(props.volume.title, locale.value));
+const href = computed(() => localePath(`/volumes/${volumeSlug(props.volume)}`));
+
+const partSummaries = computed(() =>
+  props.volume.parts.map((part) => ({
+    part,
+    title: localizedText(part.title, locale.value),
+    chapterCount: part.chapters.length,
+    languages: partLanguageAvailability(part, props.versions),
+  })),
+);
+
+const localeObjects = computed(() => locales.value as LocaleObject[]);
+
+const localeName = (code: string): string =>
+  localeObjects.value.find((entry) => entry.code === code)?.name ?? code;
+
+/** e.g. "עברית" when fully available, "English (partial)" when only some chapters have it. */
+const languageLabel = (
+  code: "he" | "en",
+  state: LanguageAvailability,
+): string | null => {
+  if (state === "none") return null;
+
+  const name = localeName(code);
+  return state === "partial"
+    ? `${name} (${t("volumes.partialLanguage")})`
+    : name;
+};
+</script>
+
+<template>
+  <div
+    class="flex overflow-hidden rounded-card border border-(--border) bg-(--surface) shadow-sm"
+    :class="{ 'opacity-60': !active }"
+  >
+    <div
+      class="flex w-14 shrink-0 items-center justify-center bg-navy-primary font-display text-2xl text-surface-white sm:w-16"
+      aria-hidden="true"
+    >
+      {{ volume.number }}
+    </div>
+
+    <div class="flex flex-1 flex-col gap-3 p-4 sm:p-5">
+      <div class="flex flex-wrap items-center justify-between gap-2">
+        <h2 class="font-display text-lg text-(--text-primary)">
+          <NuxtLink
+            v-if="active"
+            :to="href"
+            class="rounded-button hover:text-teal focus-visible:outline focus-visible:outline-2 focus-visible:outline-teal"
+          >
+            {{ title }}
+          </NuxtLink>
+          <template v-else>{{ title }}</template>
+        </h2>
+
+        <span
+          v-if="!active"
+          class="shrink-0 rounded-button border border-(--border) px-2 py-0.5 text-xs font-medium text-(--text-muted)"
+        >
+          {{ t("volumes.comingSoon") }}
+        </span>
+      </div>
+
+      <ul class="flex flex-col gap-1.5 text-sm">
+        <li
+          v-for="summary in partSummaries"
+          :key="summary.part.id"
+          class="flex flex-wrap items-center gap-x-2 gap-y-1 text-(--text-muted)"
+        >
+          <span class="text-(--text-primary)">{{ summary.title }}</span>
+          <span>{{
+            t("volumes.chapterCount", { count: summary.chapterCount })
+          }}</span>
+          <span
+            v-if="languageLabel('he', summary.languages.he)"
+            class="rounded-button border border-teal/50 px-1.5 py-0.5 text-xs text-teal"
+          >
+            {{ languageLabel("he", summary.languages.he) }}
+          </span>
+          <span
+            v-if="languageLabel('en', summary.languages.en)"
+            class="rounded-button border border-teal/50 px-1.5 py-0.5 text-xs text-teal"
+          >
+            {{ languageLabel("en", summary.languages.en) }}
+          </span>
+        </li>
+      </ul>
+    </div>
+  </div>
+</template>

--- a/app/composables/useLocalizedToc.ts
+++ b/app/composables/useLocalizedToc.ts
@@ -1,0 +1,49 @@
+/**
+ * Loads the table of contents (`content/toc.json`) and the version registry
+ * (`content/versions.json`) once, dynamically — keeping their (100+ chapter
+ * entries and counting) JSON out of every page's initial bundle — and
+ * exposes them as `computed()` refs plus a locale-aware title resolver.
+ *
+ * Async: `await useLocalizedToc()` at the top of `<script setup>`. Nuxt's
+ * `useAsyncData` resolves before SSR/prerender output is finalized either
+ * way, but pages that need to make a decision from the resolved data in the
+ * same tick — e.g. `createError(404)` for an unknown volume slug, which
+ * must also work correctly on a client-side navigation — need the explicit
+ * await so `toc.value` is guaranteed populated immediately after the call.
+ *
+ * `zod` never enters this file: only the inferred types are imported (see
+ * AGENTS.md "Content model").
+ */
+import type { ContentVersion, Toc } from "~~/shared/types/content";
+
+interface LocalizedTocData {
+  toc: Toc;
+  versions: ContentVersion[];
+}
+
+export const useLocalizedToc = async () => {
+  const { locale } = useI18n();
+
+  const { data } = await useAsyncData<LocalizedTocData>(
+    "localized-toc",
+    async () => {
+      const [tocModule, versionsModule] = await Promise.all([
+        import("~~/content/toc.json"),
+        import("~~/content/versions.json"),
+      ]);
+
+      return {
+        toc: tocModule.default as Toc,
+        versions: versionsModule.default as ContentVersion[],
+      };
+    },
+  );
+
+  const toc = computed<Toc>(() => data.value?.toc ?? { volumes: [] });
+  const versions = computed<ContentVersion[]>(() => data.value?.versions ?? []);
+
+  const localizedTitle = (title: LocalizedText): string =>
+    localizedText(title, locale.value);
+
+  return { toc, versions, localizedTitle };
+};

--- a/app/pages/volumes/[volume].vue
+++ b/app/pages/volumes/[volume].vue
@@ -1,0 +1,98 @@
+<script setup lang="ts">
+// Contents of one volume: parts as sections, chapters as rows grouped by
+// kind (see `~/utils/chapterGrouping`) — the 100+ tiny answers-list
+// chapters a part can have are collapsed into a couple of cluster rows
+// rather than exploded, see AGENTS.md "Content model".
+
+// Force a full remount on every param change (rather than reusing this
+// instance across sibling `/volumes/[volume]` navigations) so the 404
+// check below always re-runs against the new slug.
+definePageMeta({
+  key: (route) => route.fullPath,
+});
+
+const route = useRoute();
+const { t } = useI18n();
+const localePath = useLocalePath();
+
+const { toc, versions, localizedTitle } = await useLocalizedToc();
+
+const slug = route.params.volume as string;
+const resolvedVolume = findVolumeBySlug(toc.value, slug);
+
+if (!resolvedVolume) {
+  throw createError({
+    statusCode: 404,
+    statusMessage: `Unknown volume "${slug}"`,
+    fatal: true,
+  });
+}
+
+const volumeTitle = computed(() => localizedTitle(resolvedVolume.title));
+
+const partSections = computed(() =>
+  [...resolvedVolume.parts]
+    .sort((a, b) => a.number - b.number)
+    .map((part) => ({
+      part,
+      title: localizedTitle(part.title),
+      hasContent: part.chapters.length > 0,
+      groups: groupChaptersByKind(part.chapters),
+    })),
+);
+
+const entryKey = (entry: ChapterGroupEntry): string =>
+  entry.type === "chapter" ? entry.chapter.id : entry.kind;
+
+const breadcrumbItems = computed(() => [
+  { label: t("common.siteName"), to: localePath("/") },
+  { label: t("volumes.indexTitle"), to: localePath("/volumes") },
+  { label: volumeTitle.value },
+]);
+
+useHead(() => ({
+  title: `${volumeTitle.value} · ${t("common.siteName")}`,
+}));
+</script>
+
+<template>
+  <div class="mx-auto max-w-4xl px-4 py-10 sm:px-6">
+    <AppBreadcrumb :items="breadcrumbItems" class="mb-6" />
+
+    <h1 class="font-display text-3xl text-(--text-primary) sm:text-4xl">
+      {{ volumeTitle }}
+    </h1>
+
+    <section
+      v-for="section in partSections"
+      :key="section.part.id"
+      class="mt-10"
+    >
+      <h2 class="font-display text-xl text-(--text-primary)">
+        {{ t("common.part") }} {{ section.part.number }} · {{ section.title }}
+      </h2>
+
+      <p v-if="!section.hasContent" class="mt-2 text-sm text-(--text-muted)">
+        {{ t("volumes.partComingSoon") }}
+      </p>
+
+      <div v-else class="mt-4 flex flex-col gap-6">
+        <div v-for="group in section.groups" :key="group.section">
+          <h3
+            class="text-sm font-medium tracking-wide text-(--text-muted) uppercase"
+          >
+            {{ t(`volumes.section.${group.section}`) }}
+          </h3>
+          <ul class="mt-2 divide-y divide-(--border)">
+            <LibraryChapterRow
+              v-for="entry in group.entries"
+              :key="entryKey(entry)"
+              :entry="entry"
+              :versions="versions"
+            />
+          </ul>
+        </div>
+      </div>
+    </section>
+  </div>
+</template>

--- a/app/pages/volumes/index.vue
+++ b/app/pages/volumes/index.vue
@@ -1,0 +1,42 @@
+<script setup lang="ts">
+// The six volumes, shelf-style — Volume 1 is the only one with content so
+// far (see `volumeHasContent` in `~/utils/toc`), the rest render disabled
+// with a "coming soon" label until later import tasks populate them.
+
+const { t } = useI18n();
+const localePath = useLocalePath();
+
+const { toc, versions } = await useLocalizedToc();
+
+const sortedVolumes = computed(() =>
+  [...toc.value.volumes].sort((a, b) => a.number - b.number),
+);
+
+const breadcrumbItems = computed(() => [
+  { label: t("common.siteName"), to: localePath("/") },
+  { label: t("volumes.indexTitle") },
+]);
+
+useHead(() => ({
+  title: `${t("volumes.indexTitle")} · ${t("common.siteName")}`,
+}));
+</script>
+
+<template>
+  <div class="mx-auto max-w-4xl px-4 py-10 sm:px-6">
+    <AppBreadcrumb :items="breadcrumbItems" class="mb-6" />
+
+    <h1 class="font-display text-3xl text-(--text-primary) sm:text-4xl">
+      {{ t("volumes.indexTitle") }}
+    </h1>
+    <p class="mt-3 max-w-prose text-(--text-muted)">
+      {{ t("volumes.indexDescription") }}
+    </p>
+
+    <ol class="mt-8 flex flex-col gap-4">
+      <li v-for="volume in sortedVolumes" :key="volume.id">
+        <LibraryVolumeCard :volume="volume" :versions="versions" />
+      </li>
+    </ol>
+  </div>
+</template>

--- a/app/utils/chapterGrouping.ts
+++ b/app/utils/chapterGrouping.ts
@@ -1,0 +1,115 @@
+/**
+ * Groups a part's chapters for display on a volume's contents page: main
+ * chapters first, then Inner Observation (Histaklut Penimit), then the
+ * Questions lists, then the Answers lists — clustered, since a part can
+ * have 100+ tiny "answer" chapters that must not render as 100 rows (see
+ * AGENTS.md "Unknown sibling nodes" / the Sefaria import coverage notes).
+ */
+import type { ChapterKind, TocChapter } from "~~/shared/types/content";
+
+/** The four row-grouping sections a volume's contents page renders, in order. */
+export type ChapterSection =
+  "chapters" | "inner-observation" | "questions" | "answers";
+
+const SECTION_ORDER: ChapterSection[] = [
+  "chapters",
+  "inner-observation",
+  "questions",
+  "answers",
+];
+
+const SECTION_FOR_KIND: Record<ChapterKind, ChapterSection> = {
+  chapter: "chapters",
+  "inner-observation": "inner-observation",
+  "questions-terminology": "questions",
+  "questions-topics": "questions",
+  "answers-terminology": "answers",
+  "answers-topics": "answers",
+};
+
+/** Reading order of kinds within a section — also the order sections are built in. */
+const KIND_ORDER: ChapterKind[] = [
+  "chapter",
+  "inner-observation",
+  "questions-terminology",
+  "questions-topics",
+  "answers-terminology",
+  "answers-topics",
+];
+
+/** Kinds compact enough in a typical part (1-2 chapters) to render as individual rows. */
+type ClusteredKind = "answers-terminology" | "answers-topics";
+const CLUSTERED_KINDS = new Set<ChapterKind>([
+  "answers-terminology",
+  "answers-topics",
+] satisfies ClusteredKind[]);
+
+export interface ChapterRowEntry {
+  type: "chapter";
+  chapter: TocChapter;
+}
+
+export interface ChapterClusterEntry {
+  type: "cluster";
+  kind: ClusteredKind;
+  count: number;
+  /** The lowest-numbered chapter in the cluster — the cluster links here. */
+  firstChapter: TocChapter;
+}
+
+export type ChapterGroupEntry = ChapterRowEntry | ChapterClusterEntry;
+
+export interface ChapterGroupSection {
+  section: ChapterSection;
+  entries: ChapterGroupEntry[];
+}
+
+/**
+ * Groups a part's chapters into display sections. Every kind keeps its
+ * chapters in `number` order; `answers-terminology`/`answers-topics` are
+ * collapsed into a single cluster entry each (count + link to the first).
+ */
+export const groupChaptersByKind = (
+  chapters: TocChapter[],
+): ChapterGroupSection[] => {
+  const byKind = new Map<ChapterKind, TocChapter[]>();
+  for (const chapter of chapters) {
+    const list = byKind.get(chapter.kind) ?? [];
+    list.push(chapter);
+    byKind.set(chapter.kind, list);
+  }
+
+  const entriesBySection = new Map<ChapterSection, ChapterGroupEntry[]>();
+
+  for (const kind of KIND_ORDER) {
+    const kindChapters = byKind.get(kind);
+    if (!kindChapters || kindChapters.length === 0) continue;
+
+    const sorted = [...kindChapters].sort((a, b) => a.number - b.number);
+    const section = SECTION_FOR_KIND[kind];
+    const entries = entriesBySection.get(section) ?? [];
+
+    if (CLUSTERED_KINDS.has(kind)) {
+      const firstChapter = sorted[0];
+      if (firstChapter) {
+        entries.push({
+          type: "cluster",
+          kind: kind as ClusteredKind,
+          count: sorted.length,
+          firstChapter,
+        });
+      }
+    } else {
+      for (const chapter of sorted) {
+        entries.push({ type: "chapter", chapter });
+      }
+    }
+
+    entriesBySection.set(section, entries);
+  }
+
+  return SECTION_ORDER.map((section) => ({
+    section,
+    entries: entriesBySection.get(section) ?? [],
+  })).filter((group) => group.entries.length > 0);
+};

--- a/app/utils/contentAvailability.ts
+++ b/app/utils/contentAvailability.ts
@@ -1,0 +1,81 @@
+/**
+ * Language/translation availability derived from `TocChapter.availableVersions`
+ * (cross-referenced against the `content/versions.json` registry) — powers
+ * the language chips on the volumes index and the per-chapter badges on a
+ * volume's contents page.
+ */
+import type {
+  ContentVersion,
+  TocChapter,
+  TocPart,
+} from "~~/shared/types/content";
+
+/** Per-language coverage across a group of chapters (a whole part, on the index page). */
+export type LanguageAvailability = "none" | "partial" | "full";
+
+export interface ChapterLanguages {
+  he: boolean;
+  en: boolean;
+  /** True when the chapter's `source` layer has an AI-translated (`en-ai`) version. */
+  aiTranslated: boolean;
+}
+
+const AI_TRANSLATION_VERSION_ID = "en-ai";
+
+const collectVersionIds = (chapter: TocChapter): string[] => [
+  ...chapter.availableVersions.summary,
+  ...chapter.availableVersions.source,
+  ...chapter.availableVersions.commentary,
+];
+
+/** Which languages a single chapter has any layer available in. */
+export const chapterLanguages = (
+  chapter: TocChapter,
+  versions: ContentVersion[],
+): ChapterLanguages => {
+  const versionById = new Map(versions.map((version) => [version.id, version]));
+  let he = false;
+  let en = false;
+
+  for (const versionId of collectVersionIds(chapter)) {
+    const language = versionById.get(versionId)?.language;
+    if (language === "he") he = true;
+    if (language === "en") en = true;
+  }
+
+  return {
+    he,
+    en,
+    aiTranslated: chapter.availableVersions.source.includes(
+      AI_TRANSLATION_VERSION_ID,
+    ),
+  };
+};
+
+/**
+ * Aggregate per-language coverage across every chapter of a part: `"full"`
+ * when every chapter has that language, `"partial"` when some do,
+ * `"none"` when the part has no chapters yet (or none in that language).
+ */
+export const partLanguageAvailability = (
+  part: TocPart,
+  versions: ContentVersion[],
+): { he: LanguageAvailability; en: LanguageAvailability } => {
+  const total = part.chapters.length;
+
+  if (total === 0) return { he: "none", en: "none" };
+
+  let heCount = 0;
+  let enCount = 0;
+
+  for (const chapter of part.chapters) {
+    const languages = chapterLanguages(chapter, versions);
+    if (languages.he) heCount++;
+    if (languages.en) enCount++;
+  }
+
+  const stateFor = (count: number): LanguageAvailability =>
+    count === 0 ? "none" : count === total ? "full" : "partial";
+
+  return { he: stateFor(heCount), en: stateFor(enCount) };
+};

--- a/app/utils/localization.ts
+++ b/app/utils/localization.ts
@@ -1,0 +1,16 @@
+/**
+ * Resolving `title`/label `Record<locale, string>` values from `toc.json`
+ * (e.g. `TocVolume.title`, `TocPart.title`, `TocChapter.title`) to a single
+ * display string for the current locale.
+ */
+
+/** A `Record<locale, string>` value, e.g. `{ en: "Volume 1", he: "כרך 1" }`. */
+export type LocalizedText = Record<string, string>;
+
+/**
+ * Resolves `text[locale]`, falling back to `en`, then `he`, then whatever
+ * value happens to be first in the record — so a missing translation never
+ * renders as an empty string.
+ */
+export const localizedText = (text: LocalizedText, locale: string): string =>
+  text[locale] ?? text.en ?? text.he ?? Object.values(text)[0] ?? "";

--- a/app/utils/toc.ts
+++ b/app/utils/toc.ts
@@ -77,3 +77,26 @@ export const breadcrumbFor = (
     ? { volume: entry.volume, part: entry.part, chapter: entry.chapter }
     : null;
 };
+
+/**
+ * URL slug for a volume's contents page (`/volumes/<slug>`), e.g.
+ * `volume-1` — independent of the zero-padded `TocVolume.id` (`volume-01`).
+ */
+export const volumeSlug = (volume: TocVolume): string =>
+  `volume-${volume.number}`;
+
+/** Finds a volume by its URL slug (see `volumeSlug`). */
+export const findVolumeBySlug = (
+  toc: Toc,
+  slug: string,
+): TocVolume | undefined =>
+  toc.volumes.find((volume) => volumeSlug(volume) === slug);
+
+/**
+ * Whether a volume has any populated chapters yet — drives the "coming
+ * soon" disabled state on the volumes index page. Data-driven rather than
+ * hardcoded, so a volume flips to "active" automatically once content
+ * lands for any of its parts.
+ */
+export const volumeHasContent = (volume: TocVolume): boolean =>
+  volume.parts.some((part) => part.chapters.length > 0);

--- a/i18n/locales/en.json
+++ b/i18n/locales/en.json
@@ -17,7 +17,8 @@
     "volumesLink": "Volumes",
     "themeToggleToDark": "Switch to dark mode",
     "themeToggleToLight": "Switch to light mode",
-    "languageSwitcherLabel": "Switch language"
+    "languageSwitcherLabel": "Switch language",
+    "breadcrumbLabel": "Breadcrumb"
   },
   "footer": {
     "attribution": "Made by students of Bnei Baruch Kabbalah Academy · original texts from Sefaria and KabbalahMedia.info, used with permission"
@@ -34,5 +35,21 @@
     "notFoundTitle": "Page not found",
     "notFoundMessage": "This page doesn't exist yet, or has moved.",
     "notFoundBackHome": "Back to home"
+  },
+  "volumes": {
+    "indexTitle": "Volumes",
+    "indexDescription": "Talmud Eser Sefirot in six volumes, sixteen parts — read as aligned summary, source, and commentary.",
+    "comingSoon": "Coming soon",
+    "chapterCount": "{count} chapters",
+    "partialLanguage": "partial",
+    "partComingSoon": "This part hasn't been added yet — check back soon.",
+    "answersTerminologyCluster": "Answers — Terminology ({count})",
+    "answersTopicsCluster": "Answers — Topics ({count})",
+    "section": {
+      "chapters": "Chapters",
+      "inner-observation": "Inner Observation",
+      "questions": "Questions",
+      "answers": "Answers"
+    }
   }
 }

--- a/i18n/locales/he.json
+++ b/i18n/locales/he.json
@@ -17,7 +17,8 @@
     "volumesLink": "כרכים",
     "themeToggleToDark": "עבור למצב כהה",
     "themeToggleToLight": "עבור למצב בהיר",
-    "languageSwitcherLabel": "החלף שפה"
+    "languageSwitcherLabel": "החלף שפה",
+    "breadcrumbLabel": "פירורי לחם"
   },
   "footer": {
     "attribution": "נוצר על ידי תלמידי בני ברוך אקדמיה לקבלה · טקסטים מקוריים מתוך Sefaria ו-KabbalahMedia.info, בשימוש ברשות"
@@ -34,5 +35,21 @@
     "notFoundTitle": "הדף לא נמצא",
     "notFoundMessage": "דף זה עדיין לא קיים, או שהוא הועבר.",
     "notFoundBackHome": "חזרה לדף הבית"
+  },
+  "volumes": {
+    "indexTitle": "כרכים",
+    "indexDescription": "תלמוד עשר הספירות בשישה כרכים, שישה עשר חלקים — לקריאה כשכבות מיושרות של תקציר, מקור ופירוש.",
+    "comingSoon": "בקרוב",
+    "chapterCount": "{count} פרקים",
+    "partialLanguage": "חלקי",
+    "partComingSoon": "חלק זה טרם נוסף — בקרו שוב בקרוב.",
+    "answersTerminologyCluster": "תשובות — פירוש המלות ({count})",
+    "answersTopicsCluster": "תשובות — עניינים ({count})",
+    "section": {
+      "chapters": "פרקים",
+      "inner-observation": "הסתכלות פנימית",
+      "questions": "שאלות",
+      "answers": "תשובות"
+    }
   }
 }

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -1,4 +1,27 @@
 import tailwindcss from "@tailwindcss/vite";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import type { Toc } from "./shared/types/content";
+
+// `nitro.prerender.routes` needs each volume's contents page listed
+// explicitly (see the comment below) — read straight from the committed
+// ToC, the same way `scripts/validate-content.ts` reads content JSON, so
+// this list never drifts from `content/toc.json`.
+const toc: Toc = JSON.parse(
+  readFileSync(
+    fileURLToPath(new URL("./content/toc.json", import.meta.url)),
+    "utf-8",
+  ),
+);
+
+// `/volumes/volume-<N>` for every volume, in both locales — `@nuxtjs/i18n`
+// does not itself multiply explicit `nitro.prerender.routes` entries across
+// locale prefixes (unlike the crawler, which follows a page's own localized
+// links), so each locale needs its own literal path here.
+const volumePrerenderRoutes = toc.volumes.flatMap((volume) => [
+  `/volumes/volume-${volume.number}`,
+  `/he/volumes/volume-${volume.number}`,
+]);
 
 // https://nuxt.com/docs/api/configuration/nuxt-config
 export default defineNuxtConfig({
@@ -34,16 +57,28 @@ export default defineNuxtConfig({
   // scaffolding task; never ship it (or its localized variants — @nuxtjs/i18n
   // seeds every locale's copy of every static page into the prerender crawl,
   // so each locale prefix needs its own rule) in the generated static site.
-  // /volumes doesn't exist yet (Task 5) — the homepage links to it ahead of
-  // time, so a crawl-time 404 for it must not fail `nuxt generate`.
   routeRules: {
     "/design-tokens": { prerender: false },
     "/he/design-tokens": { prerender: false },
-    "/volumes": { prerender: false }, // route lands in T5 — remove exclusion then
-    "/he/volumes": { prerender: false }, // route lands in T5 — remove exclusion then
   },
   nitro: {
-    prerender: {},
+    prerender: {
+      // The volumes index is reachable by crawling the homepage's link to
+      // it, but each `/volumes/[volume]` page's own link only exists for
+      // Volume 1 (the rest render disabled/"coming soon", with no <a> for
+      // the crawler to follow) — list every volume explicitly so all six
+      // contents pages still ship in the generated static site.
+      routes: volumePrerenderRoutes,
+      // A volume's contents page links every chapter to `/read/[part]/[chapter]`
+      // (T7) — real crawlable <a> links, on purpose, not a routeRule
+      // exclusion. Those routes don't exist yet, so the crawler's fetch
+      // 404s; without this, Nitro treats any crawled 404 as fatal and
+      // aborts the whole `generate`. This is a blanket "don't fail the
+      // build over a missing page" policy, not a rule about `/read`
+      // specifically — it stays on after T7 lands too, since a single
+      // broken link shouldn't be able to take down the whole static build.
+      failOnError: false,
+    },
   },
   // Non-standard ports so `pnpm dev` never fights other local dev servers
   // (weburz's Nuxt app on 3000, etc.) — see AGENTS.md "Dev server ports".

--- a/tests/unit/app-breadcrumb.spec.ts
+++ b/tests/unit/app-breadcrumb.spec.ts
@@ -1,0 +1,33 @@
+import { mountSuspended } from "@nuxt/test-utils/runtime";
+import { describe, expect, it } from "vitest";
+import AppBreadcrumb from "~/components/app/AppBreadcrumb.vue";
+
+describe("AppBreadcrumb", () => {
+  it("renders a link for every item except the last, which is plain text", async () => {
+    const wrapper = await mountSuspended(AppBreadcrumb, {
+      props: {
+        items: [
+          { label: "Read TES", to: "/" },
+          { label: "Volumes", to: "/volumes" },
+          { label: "Volume 1" },
+        ],
+      },
+    });
+
+    const links = wrapper.findAll("a");
+    expect(links.map((link) => link.text())).toEqual(["Read TES", "Volumes"]);
+
+    const current = wrapper.find('[aria-current="page"]');
+    expect(current.text()).toBe("Volume 1");
+  });
+
+  it("separates items with a visual divider between them", async () => {
+    const wrapper = await mountSuspended(AppBreadcrumb, {
+      props: {
+        items: [{ label: "A", to: "/a" }, { label: "B" }],
+      },
+    });
+
+    expect(wrapper.text()).toContain("/");
+  });
+});

--- a/tests/unit/chapter-grouping.spec.ts
+++ b/tests/unit/chapter-grouping.spec.ts
@@ -1,0 +1,128 @@
+import { describe, expect, it } from "vitest";
+import type { ChapterKind, TocChapter } from "~~/shared/types/content";
+
+const chapter = (
+  id: string,
+  kind: ChapterKind,
+  number: number,
+): TocChapter => ({
+  id,
+  kind,
+  number,
+  title: { en: id, he: id },
+  availableLayers: [],
+  availableVersions: { summary: [], source: [], commentary: [] },
+});
+
+describe("groupChaptersByKind", () => {
+  it("groups into chapters / inner-observation / questions / answers sections, in that order", () => {
+    const chapters: TocChapter[] = [
+      chapter("part-01/answers-topics-01", "answers-topics", 1),
+      chapter("part-01/questions-terminology-01", "questions-terminology", 1),
+      chapter("part-01/chapter-01", "chapter", 1),
+      chapter("part-01/inner-observation-01", "inner-observation", 1),
+      chapter("part-01/answers-terminology-01", "answers-terminology", 1),
+    ];
+
+    const sections = groupChaptersByKind(chapters);
+
+    expect(sections.map((s) => s.section)).toEqual([
+      "chapters",
+      "inner-observation",
+      "questions",
+      "answers",
+    ]);
+  });
+
+  it("keeps individual rows for non-clustered kinds, sorted by chapter number", () => {
+    const chapters: TocChapter[] = [
+      chapter("part-01/chapter-02", "chapter", 2),
+      chapter("part-01/chapter-01", "chapter", 1),
+    ];
+
+    const [section] = groupChaptersByKind(chapters);
+
+    expect(section?.entries).toEqual([
+      { type: "chapter", chapter: chapters[1] },
+      { type: "chapter", chapter: chapters[0] },
+    ]);
+  });
+
+  it("collapses answers-terminology into a single cluster with a count and the first chapter", () => {
+    const chapters: TocChapter[] = [
+      chapter("part-01/answers-terminology-03", "answers-terminology", 3),
+      chapter("part-01/answers-terminology-01", "answers-terminology", 1),
+      chapter("part-01/answers-terminology-02", "answers-terminology", 2),
+    ];
+
+    const sections = groupChaptersByKind(chapters);
+    const answers = sections.find((s) => s.section === "answers");
+
+    expect(answers?.entries).toEqual([
+      {
+        type: "cluster",
+        kind: "answers-terminology",
+        count: 3,
+        firstChapter: chapters[1],
+      },
+    ]);
+  });
+
+  it("clusters answers-terminology and answers-topics independently within the answers section", () => {
+    const chapters: TocChapter[] = [
+      chapter("part-01/answers-terminology-01", "answers-terminology", 1),
+      chapter("part-01/answers-terminology-02", "answers-terminology", 2),
+      chapter("part-01/answers-topics-01", "answers-topics", 1),
+    ];
+
+    const sections = groupChaptersByKind(chapters);
+    const answers = sections.find((s) => s.section === "answers");
+
+    expect(answers?.entries).toEqual([
+      {
+        type: "cluster",
+        kind: "answers-terminology",
+        count: 2,
+        firstChapter: chapters[0],
+      },
+      {
+        type: "cluster",
+        kind: "answers-topics",
+        count: 1,
+        firstChapter: chapters[2],
+      },
+    ]);
+  });
+
+  it("groups questions-terminology and questions-topics together under one 'questions' section", () => {
+    const chapters: TocChapter[] = [
+      chapter("part-01/questions-topics-01", "questions-topics", 1),
+      chapter("part-01/questions-terminology-01", "questions-terminology", 1),
+    ];
+
+    const sections = groupChaptersByKind(chapters);
+    const questions = sections.find((s) => s.section === "questions");
+
+    expect(questions?.entries).toEqual([
+      { type: "chapter", chapter: chapters[1] },
+      { type: "chapter", chapter: chapters[0] },
+    ]);
+  });
+
+  it("omits sections with no chapters", () => {
+    const chapters: TocChapter[] = [
+      chapter("part-01/chapter-01", "chapter", 1),
+    ];
+
+    expect(groupChaptersByKind(chapters)).toEqual([
+      {
+        section: "chapters",
+        entries: [{ type: "chapter", chapter: chapters[0] }],
+      },
+    ]);
+  });
+
+  it("returns an empty array for a part with no chapters", () => {
+    expect(groupChaptersByKind([])).toEqual([]);
+  });
+});

--- a/tests/unit/chapter-row.spec.ts
+++ b/tests/unit/chapter-row.spec.ts
@@ -1,0 +1,97 @@
+import { mountSuspended } from "@nuxt/test-utils/runtime";
+import { describe, expect, it } from "vitest";
+import ChapterRow from "~/components/library/ChapterRow.vue";
+import type { ChapterGroupEntry } from "~/utils/chapterGrouping";
+import type { ContentVersion, TocChapter } from "~~/shared/types/content";
+
+const versions: ContentVersion[] = [
+  {
+    id: "he-jerusalem-1956",
+    language: "he",
+    direction: "rtl",
+    title: "ירושלים",
+    license: "Public Domain",
+    source: "sefaria",
+  },
+  {
+    id: "en-ai",
+    language: "en",
+    direction: "ltr",
+    title: "English (AI translation)",
+    license: "CC0",
+    source: "ai",
+    translatedFrom: "he-jerusalem-1956",
+  },
+];
+
+const aiTranslatedChapter: TocChapter = {
+  id: "part-01/inner-observation-01",
+  kind: "inner-observation",
+  number: 1,
+  title: { en: "Histaklut Penimit 1", he: "הסתכלות פנימית א׳" },
+  availableLayers: ["source"],
+  availableVersions: {
+    summary: [],
+    source: ["he-jerusalem-1956", "en-ai"],
+    commentary: [],
+  },
+};
+
+const hebrewOnlyChapter: TocChapter = {
+  id: "part-01/answers-terminology-01",
+  kind: "answers-terminology",
+  number: 1,
+  title: { en: "List of Answers on Terminology 1", he: "לוח התשובות א׳" },
+  availableLayers: ["source"],
+  availableVersions: {
+    summary: [],
+    source: ["he-jerusalem-1956"],
+    commentary: [],
+  },
+};
+
+describe("ChapterRow", () => {
+  it("badges an AI-translated chapter", async () => {
+    const entry: ChapterGroupEntry = {
+      type: "chapter",
+      chapter: aiTranslatedChapter,
+    };
+    const wrapper = await mountSuspended(ChapterRow, {
+      props: { entry, versions },
+      global: { stubs: { NuxtLink: { template: "<a><slot /></a>" } } },
+    });
+
+    expect(wrapper.text().toLowerCase()).toContain("ai translated");
+  });
+
+  it("marks a Hebrew-only chapter without the AI badge", async () => {
+    const entry: ChapterGroupEntry = {
+      type: "chapter",
+      chapter: hebrewOnlyChapter,
+    };
+    const wrapper = await mountSuspended(ChapterRow, {
+      props: { entry, versions },
+      global: { stubs: { NuxtLink: { template: "<a><slot /></a>" } } },
+    });
+
+    expect(wrapper.text().toLowerCase()).not.toContain("ai translated");
+    expect(wrapper.text().toLowerCase()).toContain("hebrew only");
+  });
+
+  it("renders a cluster entry with its count and links to the first chapter", async () => {
+    const entry: ChapterGroupEntry = {
+      type: "cluster",
+      kind: "answers-terminology",
+      count: 54,
+      firstChapter: hebrewOnlyChapter,
+    };
+    const wrapper = await mountSuspended(ChapterRow, {
+      props: { entry, versions },
+    });
+
+    expect(wrapper.text()).toContain("54");
+    expect(wrapper.find("a").attributes("href")).toContain(
+      "/read/part-01/answers-terminology-01",
+    );
+  });
+});

--- a/tests/unit/content-availability.spec.ts
+++ b/tests/unit/content-availability.spec.ts
@@ -1,0 +1,144 @@
+import { describe, expect, it } from "vitest";
+import type {
+  ContentVersion,
+  TocChapter,
+  TocPart,
+} from "~~/shared/types/content";
+
+const versions: ContentVersion[] = [
+  {
+    id: "he-jerusalem-1956",
+    language: "he",
+    direction: "rtl",
+    title: "ירושלים",
+    license: "Public Domain",
+    source: "sefaria",
+  },
+  {
+    id: "en-sefaria-community",
+    language: "en",
+    direction: "ltr",
+    title: "Sefaria Community Translation",
+    license: "CC0",
+    source: "sefaria",
+  },
+  {
+    id: "en-ai",
+    language: "en",
+    direction: "ltr",
+    title: "English (AI translation)",
+    license: "CC0",
+    source: "ai",
+    translatedFrom: "he-jerusalem-1956",
+  },
+];
+
+const chapter = (overrides: {
+  source?: string[];
+  summary?: string[];
+  commentary?: string[];
+}): TocChapter => ({
+  id: "part-01/chapter-01",
+  kind: "chapter",
+  number: 1,
+  title: { en: "Chapter 1", he: "פרק א׳" },
+  availableLayers: [],
+  availableVersions: {
+    summary: overrides.summary ?? [],
+    source: overrides.source ?? [],
+    commentary: overrides.commentary ?? [],
+  },
+});
+
+describe("chapterLanguages", () => {
+  it("reports he/en presence across every layer", () => {
+    const result = chapterLanguages(
+      chapter({
+        source: ["he-jerusalem-1956"],
+        commentary: ["en-sefaria-community"],
+      }),
+      versions,
+    );
+
+    expect(result).toEqual({ he: true, en: true, aiTranslated: false });
+  });
+
+  it("reports aiTranslated when the source layer includes en-ai", () => {
+    const result = chapterLanguages(
+      chapter({ source: ["he-jerusalem-1956", "en-ai"] }),
+      versions,
+    );
+
+    expect(result).toEqual({ he: true, en: true, aiTranslated: true });
+  });
+
+  it("does not flag aiTranslated when en-ai is absent, even if other en versions exist", () => {
+    const result = chapterLanguages(
+      chapter({
+        source: ["he-jerusalem-1956"],
+        commentary: ["en-sefaria-community"],
+      }),
+      versions,
+    );
+
+    expect(result.aiTranslated).toBe(false);
+  });
+
+  it("reports false for a language with no version present at all", () => {
+    const result = chapterLanguages(
+      chapter({ source: ["he-jerusalem-1956"] }),
+      versions,
+    );
+
+    expect(result.en).toBe(false);
+  });
+});
+
+describe("partLanguageAvailability", () => {
+  const partWith = (chapters: TocChapter[]): TocPart => ({
+    id: "part-01",
+    number: 1,
+    sefariaNode: "Talmud Eser HaSefirot, Section I",
+    title: { en: "Part 1", he: "חלק 1" },
+    chapters,
+  });
+
+  it("is 'none' for a part with no chapters yet", () => {
+    expect(partLanguageAvailability(partWith([]), versions)).toEqual({
+      he: "none",
+      en: "none",
+    });
+  });
+
+  it("is 'full' when every chapter has that language", () => {
+    const chapters = [
+      chapter({ source: ["he-jerusalem-1956", "en-sefaria-community"] }),
+      chapter({ source: ["he-jerusalem-1956", "en-sefaria-community"] }),
+    ];
+
+    expect(partLanguageAvailability(partWith(chapters), versions)).toEqual({
+      he: "full",
+      en: "full",
+    });
+  });
+
+  it("is 'partial' when only some chapters have that language", () => {
+    const chapters = [
+      chapter({ source: ["he-jerusalem-1956", "en-ai"] }),
+      chapter({ source: ["he-jerusalem-1956"] }),
+    ];
+
+    expect(partLanguageAvailability(partWith(chapters), versions)).toEqual({
+      he: "full",
+      en: "partial",
+    });
+  });
+
+  it("is 'none' for a language absent from every chapter", () => {
+    const chapters = [chapter({ source: ["he-jerusalem-1956"] })];
+
+    expect(partLanguageAvailability(partWith(chapters), versions).en).toBe(
+      "none",
+    );
+  });
+});

--- a/tests/unit/localization.spec.ts
+++ b/tests/unit/localization.spec.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "vitest";
+
+describe("localizedText", () => {
+  it("resolves the requested locale when present", () => {
+    expect(localizedText({ en: "Volume 1", he: "כרך 1" }, "he")).toBe("כרך 1");
+    expect(localizedText({ en: "Volume 1", he: "כרך 1" }, "en")).toBe(
+      "Volume 1",
+    );
+  });
+
+  it("falls back to en when the requested locale is missing", () => {
+    expect(localizedText({ en: "Volume 1" }, "fr")).toBe("Volume 1");
+  });
+
+  it("falls back to he when en is also missing", () => {
+    expect(localizedText({ he: "כרך 1" }, "fr")).toBe("כרך 1");
+  });
+
+  it("falls back to the first available value when neither en nor he exist", () => {
+    expect(localizedText({ fr: "Volume 1" }, "de")).toBe("Volume 1");
+  });
+
+  it("returns an empty string for a completely empty record", () => {
+    expect(localizedText({}, "en")).toBe("");
+  });
+});

--- a/tests/unit/toc.spec.ts
+++ b/tests/unit/toc.spec.ts
@@ -137,3 +137,46 @@ describe("breadcrumbFor", () => {
     expect(breadcrumbFor(fixtureToc, "nope")).toBeNull();
   });
 });
+
+describe("volumeSlug", () => {
+  it("builds a plain (non-zero-padded) slug from the volume number", () => {
+    expect(volumeSlug(fixtureToc.volumes[0]!)).toBe("volume-1");
+    expect(volumeSlug(fixtureToc.volumes[1]!)).toBe("volume-2");
+  });
+});
+
+describe("findVolumeBySlug", () => {
+  it("finds a volume by its URL slug", () => {
+    expect(findVolumeBySlug(fixtureToc, "volume-2")).toBe(
+      fixtureToc.volumes[1],
+    );
+  });
+
+  it("returns undefined for an unknown slug", () => {
+    expect(findVolumeBySlug(fixtureToc, "volume-99")).toBeUndefined();
+  });
+});
+
+describe("volumeHasContent", () => {
+  it("is true when at least one part has chapters", () => {
+    expect(volumeHasContent(fixtureToc.volumes[0]!)).toBe(true);
+  });
+
+  it("is false when every part is still empty", () => {
+    const emptyVolume = {
+      ...fixtureToc.volumes[0]!,
+      parts: fixtureToc.volumes[0]!.parts.map((part) => ({
+        ...part,
+        chapters: [],
+      })),
+    };
+
+    expect(volumeHasContent(emptyVolume)).toBe(false);
+  });
+
+  it("is false for a volume with no parts at all", () => {
+    expect(volumeHasContent({ ...fixtureToc.volumes[0]!, parts: [] })).toBe(
+      false,
+    );
+  });
+});

--- a/tests/unit/volume-card.spec.ts
+++ b/tests/unit/volume-card.spec.ts
@@ -1,0 +1,81 @@
+import { mountSuspended } from "@nuxt/test-utils/runtime";
+import { describe, expect, it } from "vitest";
+import VolumeCard from "~/components/library/VolumeCard.vue";
+import type { ContentVersion, TocVolume } from "~~/shared/types/content";
+
+const versions: ContentVersion[] = [
+  {
+    id: "he-jerusalem-1956",
+    language: "he",
+    direction: "rtl",
+    title: "ירושלים",
+    license: "Public Domain",
+    source: "sefaria",
+  },
+];
+
+const activeVolume: TocVolume = {
+  id: "volume-01",
+  number: 1,
+  title: { en: "Volume 1", he: "כרך 1" },
+  parts: [
+    {
+      id: "part-01",
+      number: 1,
+      sefariaNode: "Talmud Eser HaSefirot, Section I",
+      title: { en: "Part 1", he: "חלק 1" },
+      chapters: [
+        {
+          id: "part-01/chapter-01",
+          kind: "chapter",
+          number: 1,
+          title: { en: "Chapter 1", he: "פרק א׳" },
+          availableLayers: ["source"],
+          availableVersions: {
+            summary: [],
+            source: ["he-jerusalem-1956"],
+            commentary: [],
+          },
+        },
+      ],
+    },
+  ],
+};
+
+const emptyVolume: TocVolume = {
+  id: "volume-02",
+  number: 2,
+  title: { en: "Volume 2", he: "כרך 2" },
+  parts: [
+    {
+      id: "part-02",
+      number: 2,
+      sefariaNode: "Talmud Eser HaSefirot, Section II",
+      title: { en: "Part 2", he: "חלק 2" },
+      chapters: [],
+    },
+  ],
+};
+
+describe("VolumeCard", () => {
+  it("renders an active volume's title as a link to its contents page", async () => {
+    const wrapper = await mountSuspended(VolumeCard, {
+      props: { volume: activeVolume, versions },
+    });
+
+    const link = wrapper.find("a");
+    expect(link.exists()).toBe(true);
+    expect(link.text()).toBe("Volume 1");
+    expect(link.attributes("href")).toContain("/volumes/volume-1");
+  });
+
+  it("renders an unavailable volume disabled, with no link and a 'coming soon' label", async () => {
+    const wrapper = await mountSuspended(VolumeCard, {
+      props: { volume: emptyVolume, versions },
+    });
+
+    expect(wrapper.find("a").exists()).toBe(false);
+    expect(wrapper.text()).toContain("Volume 2");
+    expect(wrapper.text().toLowerCase()).toContain("coming soon");
+  });
+});


### PR DESCRIPTION
Closes #19.

## What

- **/volumes**: six-volume shelf with navy spine numbers — Volume 1 active with per-part chapter counts and language chips (עברית / English partial), volumes 2–6 data-driven "coming soon"
- **/volumes/[volume]**: parts as sections, chapters grouped by kind — main chapters, Inner Observation (each wearing the orange "AI translated" text badge, derived from `availableVersions`), Questions ("Hebrew only"), and the 105 answers-list chapters collapsed into two cluster rows; unknown slugs 404 (`fatal: true`), verified live
- `useLocalizedToc()` composable + pure grouping/availability/localization utils (count-agnostic clustering, locale→en→he fallback chain), `AppBreadcrumb`, i18n keys in both catalogs with in-domain Hebrew terminology
- Prerender: volume routes derived from `content/toc.json` at config time; `/volumes` exclusions removed
- Merge reconciliation with the static-pages branch: scoped `/read/**` exclusions kept, re-introduced global `failOnError` dropped, i18n catalogs union-merged — tests (153) and generate (40 routes, no error suppression) re-verified post-merge

## Verification

Reviewer ran the full chain in an isolated worktree (147 tests then, 153 post-merge), curl-verified 404 behavior, and confirmed badge counts (exactly 10) and cluster rows against generated HTML. Visual review at 1440px, light+dark, en+he: approved.