### PR TITLE
AI translation: Ohr Pnimi commentary on chapter 2 (en-ai edition)

### DIFF
--- a/content/parts/part-01/chapters/chapter-02/commentary.en-ai.json
+++ b/content/parts/part-01/chapters/chapter-02/commentary.en-ai.json
@@ -1,0 +1,152 @@
+{
+  "chapterId": "part-01/chapter-02",
+  "layer": "commentary",
+  "versionId": "en-ai",
+  "sefariaRef": "Ohr Penimi on Talmud Eser HaSefirot 1:2",
+  "items": [
+    {
+      "anchorId": "op-1",
+      "order": 1,
+      "label": {
+        "he": "א",
+        "en": "1"
+      },
+      "sefariaRef": "Ohr Penimi on Talmud Eser HaSefirot 1:2:1",
+      "targetSeif": 1,
+      "section": "ohr-pnimi",
+      "html": "Do not mistakenly think that because of the restriction of the Light from the middle point there was any change in Ein Sof, God forbid. For there is no absence or exchange in spirituality, and needless to say in this exalted place (as above, page 1, beginning with \"We must know\" — see there). Rather, the restriction spoken of became a new essence, additional to Ein Sof — such that Ein Sof remained in all its simple oneness exactly as it was before the restriction, in the secret of \"He and His Name are One,\" while the matter of the restriction, made upon the middle point, is understood as the emergence of a new world: the Light departed from there and a vacant, empty place remained, in the way clarified above. And in that vacant place all the worlds, all of them, were emanated, as will be written before us."
+    },
+    {
+      "anchorId": "op-2",
+      "order": 2,
+      "label": {
+        "he": "ב",
+        "en": "2"
+      },
+      "sefariaRef": "Ohr Penimi on Talmud Eser HaSefirot 1:2:2",
+      "targetSeif": 1,
+      "section": "ohr-pnimi",
+      "html": "This operation must not be understood in its surface sense, after the manner of a human operation — first acting one way, then acting another way and departing from the first operation — for there is no greater materialization than that. He is not subject to incident and change, God forbid, as it is written, \"I the Lord have not changed.\" And although we speak not of His Essence but only of the Light that expands from Him, nevertheless, since there is no change, incident, or motion in His Essence — He being in absolute rest — the same must necessarily hold in the Light that expands from Him, so long as it has not reached the discernment of the emanated; that is, so long as it has not come to clothe in vessels, for only then does it depart from His Essence into the discernment of the renewed emanated that receives from Him. And we have already clarified that all this newness rests chiefly upon the vessel of the emanated, namely the \"desire to receive\" in the emanated: this desire, though spiritual, is certainly a novelty of form and an \"incident,\" since it does not necessarily apply in His Essence — unlike the Light that clothes in it, which is not new, for it extends from His Essence as \"existence from existence.\" Nevertheless, the activation of the upper Light in the measure of the vessel — that is, the aspect in which the vessel is activated by and receives from the upper Light — also carries a discernment of newness, which is necessarily an \"incident,\" as is understood. And know that all the novelties and the cascading of the degrees spoken of above deal only with the value of the vessel's activation and its reception from the upper Light, for this alone receives the changes and the multiplicities; but the Light in itself stands always in absolute rest, as it expands from His Essence. Understand this well, and remember it throughout the whole study of this wisdom, in every single word.<br>By what has been clarified you will well understand that the upper Light does not cease shining upon the emanated even for a moment, and does not fall, God forbid, under incident and novelty; rather, it is in the state of absolute rest, and the whole matter of the restriction and the departure of the Light spoken of here is said only with respect to the activation and reception of the vessel, namely the middle point. That is: although the upper Light did not cease shining, nevertheless the vessel now received nothing of its illumination, because it diminished itself — diminished the \"desire to receive\" in it — so as not to receive in the fourth phase, which is the middle point itself, but only in the three preceding phases in it, where the desire to receive is faint and the desire to bestow governs more (as above, item 50, beginning with \"Now you will understand\"). Thus the upper Light was not activated at all by the restriction and did not change its way, God forbid: exactly as it shines in Ein Sof, so it shines at the time of the restriction and after the restriction, in all the worlds — even in the world of Assiya — without any interruption even for a moment. The vessels themselves make all these changes, for they receive only according to their measure, namely the \"measure of the desire to receive\" in them, as clarified.<br>From what has been said you will understand that when the Rav writes, \"He extended from the Light of Ein Sof one line,\" the meaning is that the place of the vacuum itself — the vessel that was emptied of the Light of Ein Sof — itself caused the extension of the line from the Light of Ein Sof, by reason of the diminution newly made in the \"desire to receive\" in it. For the measure of its reception now, after the restriction of its fourth phase, is designated by the name \"line\" relative to its former reception in the fourth phase, which filled the entire place. But now, having not that great desire to receive but only the three preceding phases of the desire, in which the desire to receive is faint, as above, that vessel is discerned as receiving from the Light of Ein Sof no more than a single line of Light, and the whole place of the vessel remains empty and vacant of the Light — for the thin Light it now receives does not suffice to fill the whole of the vessel's place, this having come upon it through the lack of the fourth phase, which it diminished, as above. Thus it is clarified that the upper Light was not interrupted at all by reason of the restriction, nor did it change at all so as to extend the Light as a single line; rather, this whole great change was made by reason of the vessels of reception, which were diminished, so that now they can receive of the Light of Ein Sof only a very small measure, called a line — that is, according to the measure of its desire, for it will not desire more than that measure. Understand this well."
+    },
+    {
+      "anchorId": "op-3",
+      "order": 3,
+      "label": {
+        "he": "ג",
+        "en": "3"
+      },
+      "sefariaRef": "Ohr Penimi on Talmud Eser HaSefirot 1:2:3",
+      "targetSeif": 1,
+      "section": "ohr-pnimi",
+      "html": "The meaning of the image of the circle has already been clarified above (Chapter One, item 100). It teaches us here that even after the restriction the upper Light remained in the image of a circle — meaning without distinction of degrees, all four phases being equal in rank before it (as above, Chapter One, item 100). And the reason is as written above (in the adjacent entry): novelty and incident do not apply, God forbid, in the upper Light — see there — and all the kinds of renewal spoken of are only the relations of the vessels alone."
+    },
+    {
+      "anchorId": "op-4",
+      "order": 4,
+      "label": {
+        "he": "ד",
+        "en": "4"
+      },
+      "sefariaRef": "Ohr Penimi on Talmud Eser HaSefirot 1:2:4",
+      "targetSeif": 1,
+      "section": "ohr-pnimi",
+      "html": "Do not forget that the intention is not, God forbid, upon imagined concepts of corporeal place; rather, the purest is designated \"above\" and the coarsest and most degraded is designated \"below.\" As above (Chapter One, item 6): everything that can be understood in the expansion of the Light from the Emanator and its coming to the discernment of an emanated lies chiefly in the novelty of the disparity of form present in the emanated — namely the \"desire to receive\" newly made in it, which is not found in the Emanator. On account of this, the emanated is discerned as distant, coarse, low, and beneath, relative to the Emanator, for the disparity of form from the Emanator makes all these and separates it from the discernment of Emanator into the discernment of emanated. You also know that this disparity of form, the \"desire to receive,\" is not revealed at once but is woven little by little, in the order of four phases, its form completed in its utmost greatness only in the fourth phase.<br>It therefore follows that the fainter the form of its desire to receive — namely the first of the four phases — the closer it is discerned to the Emanator, and the more important, purer, and higher it is, for the disparity of form in it is not as great as in the three phases after it. And the second phase, whose desire is greater than the first's, is discerned as more distant from the Emanator, coarser, lower, and further beneath than the first phase — until the fourth phase, which is the most distant from the Emanator of them all, and the coarsest, lowest, and furthest beneath of them all. This is what the Rav means in saying that the line extends \"from above downward\": from the first phase down to the fourth phase (up to, but not including), which is the lowest of them all. And this matter of \"above\" and \"below\" was newly made now, with the emergence of the line; for before the line shone — that is, at the time of the restriction — no above and below were discerned there, as above (Chapter One, item 100). But after it received the Light as a line only — meaning it did not receive it in all four phases but only in its first three, and the fourth phase remained darkness without Light — only now was the fourth phase revealed as a low, coarse, and nether discernment, against which the three phases preceding it are also ranked according to how much purer and closer to the Emanator they are, as above. Whereas at the time of the restriction, when the Light departed from all four phases at once, this distinction among the phases did not yet exist, as above (Chapter One, item 100)."
+    },
+    {
+      "anchorId": "op-5",
+      "order": 5,
+      "label": {
+        "he": "ה",
+        "en": "5"
+      },
+      "sefariaRef": "Ohr Penimi on Talmud Eser HaSefirot 1:2:5",
+      "targetSeif": 2,
+      "section": "ohr-pnimi",
+      "html": "That is, the first of the four phases, as above in the adjacent entry."
+    },
+    {
+      "anchorId": "op-6",
+      "order": 6,
+      "label": {
+        "he": "ו",
+        "en": "6"
+      },
+      "sefariaRef": "Ohr Penimi on Talmud Eser HaSefirot 1:2:6",
+      "targetSeif": 2,
+      "section": "ohr-pnimi",
+      "html": "For the first phase, which is the upper head, is the closest to Ein Sof — that is, to the Emanator — and is therefore regarded as though touching it, since the difference of the disparity of form in the first phase is not discernible enough to separate it from the Emanator, as above."
+    },
+    {
+      "anchorId": "op-7",
+      "order": 7,
+      "label": {
+        "he": "ז",
+        "en": "7"
+      },
+      "sefariaRef": "Ohr Penimi on Talmud Eser HaSefirot 1:2:7",
+      "targetSeif": 2,
+      "section": "ohr-pnimi",
+      "html": "\"Below, at its end\" indicates the fourth phase, which is the most distant of them all and the furthest beneath of them all, as above (Chapter Two, item 4) — it does not now receive the upper Light, and is therefore found not to touch the Light of Ein Sof, but to be separated from it."
+    },
+    {
+      "anchorId": "op-8",
+      "order": 8,
+      "label": {
+        "he": "ח",
+        "en": "8"
+      },
+      "sefariaRef": "Ohr Penimi on Talmud Eser HaSefirot 1:2:8",
+      "targetSeif": 4,
+      "section": "ohr-pnimi",
+      "html": "This alludes to the four worlds, called Atzilut, Beria, Yetzira, and Assiya, which include all the worlds — countless in their particulars. These four worlds extend from the four phases spoken of above: from the first phase, Atzilut; from the second phase, Beria; from the third phase, Yetzira; from the fourth phase, Assiya."
+    },
+    {
+      "anchorId": "op-9",
+      "order": 9,
+      "label": {
+        "he": "ט",
+        "en": "9"
+      },
+      "sefariaRef": "Ohr Penimi on Talmud Eser HaSefirot 1:2:9",
+      "targetSeif": 5,
+      "section": "ohr-pnimi",
+      "html": "Called Atzilut, Beria, Yetzira, Assiya, as above (in the adjacent entry), which include all the worlds, all of them. Before all these — that is, before the restriction — these four phases were not discerned as one above the other, as above (Chapter Two, item 4), but stood in the secret of the simple oneness, as above (Chapter One, item 30, beginning with \"By what has been clarified\"), without any difference between the degrees or between Light and vessel — in the secret of \"He and His Name are One,\" as above; see there."
+    },
+    {
+      "anchorId": "op-10",
+      "order": 10,
+      "label": {
+        "he": "י",
+        "en": "10"
+      },
+      "sefariaRef": "Ohr Penimi on Talmud Eser HaSefirot 1:2:10",
+      "targetSeif": 5,
+      "section": "ohr-pnimi",
+      "html": "\"He\" indicates the upper Light, and \"His Name\" indicates the discernment of the desire to receive that is necessarily found there, as above (Chapter One, item 30, beginning with \"One should not wonder\" — see there). \"His Name\" [Shmo] in Gematria is \"desire\" [Ratzon], alluding to the \"desire to receive.\""
+    },
+    {
+      "anchorId": "op-11",
+      "order": 11,
+      "label": {
+        "he": "כ",
+        "en": "11"
+      },
+      "sefariaRef": "Ohr Penimi on Talmud Eser HaSefirot 1:2:11",
+      "targetSeif": 5,
+      "section": "ohr-pnimi",
+      "html": "That is: now, after the worlds were created, even the angels — the creatures closest in their spirituality — have no attainment in Ein Sof."
+    },
+    {
+      "anchorId": "op-12",
+      "order": 12,
+      "label": {
+        "he": "ל",
+        "en": "12"
+      },
+      "sefariaRef": "Ohr Penimi on Talmud Eser HaSefirot 1:2:12",
+      "targetSeif": 5,
+      "section": "ohr-pnimi",
+      "html": "For since there, in Ein Sof, is the secret of \"He and His Name are One,\" and no place or vessel is discernible there at all, as written above, therefore no created intellect can attain it — for there is no attainment in Light without a vessel."
+    }
+  ]
+}

--- a/content/toc.json
+++ b/content/toc.json
@@ -63,7 +63,8 @@
                   "he-jerusalem-1956"
                 ],
                 "commentary": [
-                  "he-jerusalem-1956"
+                  "he-jerusalem-1956",
+                  "en-ai"
                 ]
               }
             },


### PR DESCRIPTION
With this, both main chapters of Part 1 read fully in English — source and Ohr Pnimi — with every anchor clickable in both languages.

## What

- `commentary.en-ai.json` for `part-01/chapter-02` — all 12 items translated from the public-domain Hebrew
- `toc.json`: en-ai commentary availability registered

## Quality gate

Independent item-by-item fidelity review: approved, no defects — including a full audit of the internal cross-references (Hebrew letter-numerals ק=100, נ=50, ל=30, ו=6 all converted correctly) and the directive register. `pnpm validate:content` + 153 tests green.