### PR TITLE
Reader: three-pane reading with two-way anchor sync

### DIFF
--- a/app/assets/css/main.css
+++ b/app/assets/css/main.css
@@ -58,3 +58,67 @@
   --text-muted: #a9b4bd;
   --border: #1f3a52;
 }
+
+/*
+ * Reader anchor chips + cross-pane highlight flash (`useHighlightedAnchor`).
+ *
+ * `.tes-anchor` is Sefaria's inline commentary marker, normalized at import
+ * time (`app/utils/anchors.ts`) into `<a class="tes-anchor" data-anchor="op-N">` —
+ * styled here, unobtrusively: small, teal, superscript-scale, never
+ * shouting over the source text it's inset into.
+ *
+ * `.reader-anchor-target` is the class the reader components apply to their
+ * own jump targets (commentary items, source segments) so the same
+ * highlight-flash rules apply uniformly regardless of which pane it lands
+ * in. The transition lives on the base (unhighlighted) rule so JS can flash
+ * the "on" state instantly (by disabling the transition for one frame) and
+ * let only the fade-OUT animate — see `useHighlightedAnchor`.
+ */
+.tes-anchor,
+.reader-anchor-target {
+  transition:
+    background-color 2000ms ease-out,
+    color 2000ms ease-out;
+  border-radius: 4px;
+}
+
+/*
+ * `.tes-anchor` is applied both to the sanitized `<a>` markers inside source
+ * segment HTML and to the `<button>` commentary-item label chips
+ * (`CommentaryPane`) — the reset properties below only matter for the
+ * latter (a bare `<a>` has none of this chrome to begin with).
+ */
+.tes-anchor {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border: none;
+  margin: 0;
+  padding-inline: 0.15em;
+  font: inherit;
+  font-size: 0.7em;
+  font-weight: 600;
+  line-height: 1;
+  vertical-align: super;
+  background: none;
+  color: var(--color-teal);
+  text-decoration: none;
+  cursor: pointer;
+}
+
+.tes-anchor:hover,
+.tes-anchor:focus-visible {
+  text-decoration: underline;
+}
+
+.tes-anchor:focus-visible {
+  outline: 2px solid var(--color-teal);
+  outline-offset: 1px;
+}
+
+.tes-anchor.is-highlighted,
+.tes-anchor.is-highlighted-instant,
+.reader-anchor-target.is-highlighted,
+.reader-anchor-target.is-highlighted-instant {
+  background-color: color-mix(in srgb, var(--color-teal) 35%, transparent);
+}

--- a/app/components/reader/CommentaryPane.vue
+++ b/app/components/reader/CommentaryPane.vue
@@ -1,0 +1,56 @@
+<script setup lang="ts">
+// Renders a chapter's commentary items, grouped under "Inner Light"
+// (Ohr Pnimi) / "Inner Observation" (Histaklut Pnimit) section headings —
+// only the groups that actually have items render (see
+// `groupCommentaryBySection`). The "not available in this edition" toast
+// for a source anchor missing from this version lives in the reader page
+// (via `ReaderPane`'s `#toast` slot), not here — this component only
+// renders whatever items it's given.
+import type { CommentaryItem } from "~~/shared/types/content";
+
+const props = defineProps<{ items: CommentaryItem[] }>();
+
+const { locale, t } = useI18n();
+const { activateAnchor } = useReaderState();
+const containerRef = useReaderPaneContainer();
+useHighlightedAnchor("commentary", containerRef);
+
+const groups = computed(() => groupCommentaryBySection(props.items));
+</script>
+
+<template>
+  <div v-if="groups.length > 0" class="flex flex-col gap-8">
+    <section
+      v-for="group in groups"
+      :key="group.section"
+      class="flex flex-col gap-4"
+    >
+      <h3
+        class="font-display text-sm tracking-wide text-(--text-muted) uppercase"
+      >
+        {{ t(`reader.commentarySection.${group.section}`) }}
+      </h3>
+
+      <ol class="flex flex-col gap-5">
+        <li
+          v-for="item in group.items"
+          :id="item.anchorId"
+          :key="item.anchorId"
+          class="reader-anchor-target scroll-mt-4 rounded-card p-1 leading-relaxed text-(--text-primary)"
+        >
+          <button
+            type="button"
+            class="tes-anchor"
+            @click="activateAnchor(item.anchorId, 'commentary')"
+          >
+            {{ localizedText(item.label, locale) }}
+          </button>
+          <span v-html="item.html" />
+        </li>
+      </ol>
+    </section>
+  </div>
+  <p v-else class="text-sm text-(--text-muted)">
+    {{ t("reader.commentaryEmpty") }}
+  </p>
+</template>

--- a/app/components/reader/ReaderPane.vue
+++ b/app/components/reader/ReaderPane.vue
@@ -1,0 +1,89 @@
+<script setup lang="ts">
+// Generic pane chrome shared by the summary/source/commentary panes: a
+// header (layer title + version <select> when there's more than one + the
+// "AI translated" badge) above a scroll container that carries the
+// version's `dir`/`lang` — the actual pane content (SourcePane etc.) is
+// slotted in, and grabs this container via `useReaderPaneContainer()` for
+// its own `useHighlightedAnchor`.
+import type { ContentVersion } from "~~/shared/types/content";
+
+export interface ReaderVersionOption {
+  id: string;
+  label: string;
+}
+
+const props = defineProps<{
+  title: string;
+  versionOptions: ReaderVersionOption[];
+  modelValue: string | null;
+  meta: ContentVersion | null;
+}>();
+
+const emit = defineEmits<{ "update:modelValue": [value: string] }>();
+
+const { t } = useI18n();
+
+const selectId = useId();
+const isAiTranslated = computed(() => props.meta?.source === "ai");
+
+const onVersionChange = (event: Event) => {
+  const value = (event.target as HTMLSelectElement).value;
+  emit("update:modelValue", value);
+};
+
+const containerRef = provideReaderPaneContainer();
+</script>
+
+<template>
+  <section class="flex flex-col lg:h-full lg:min-h-0">
+    <header
+      class="flex shrink-0 flex-wrap items-center justify-between gap-2 border-b border-(--border) px-4 py-2.5"
+    >
+      <h2
+        class="font-display text-sm tracking-wide text-(--text-muted) uppercase"
+      >
+        {{ title }}
+      </h2>
+
+      <div class="flex items-center gap-2">
+        <span
+          v-if="isAiTranslated"
+          class="rounded-button border border-orange-cta px-1.5 py-0.5 text-xs font-medium text-orange-cta"
+        >
+          {{ t("reader.aiTranslated") }}
+        </span>
+
+        <template v-if="versionOptions.length > 1">
+          <label :for="selectId" class="sr-only">{{
+            t("reader.versionLabel")
+          }}</label>
+          <select
+            :id="selectId"
+            class="rounded-input border border-(--border) bg-(--surface) px-2 py-1 text-xs text-(--text-primary)"
+            :value="modelValue ?? ''"
+            @change="onVersionChange"
+          >
+            <option
+              v-for="option in versionOptions"
+              :key="option.id"
+              :value="option.id"
+            >
+              {{ option.label }}
+            </option>
+          </select>
+        </template>
+      </div>
+
+      <slot name="toast" />
+    </header>
+
+    <div
+      ref="containerRef"
+      class="flex-1 px-4 py-4 lg:min-h-0 lg:overflow-y-auto"
+      :dir="meta?.direction ?? 'ltr'"
+      :lang="meta?.language"
+    >
+      <slot />
+    </div>
+  </section>
+</template>

--- a/app/components/reader/ReaderShell.vue
+++ b/app/components/reader/ReaderShell.vue
@@ -1,0 +1,41 @@
+<script setup lang="ts">
+// Orchestrator for the three-pane reader. Provides the shared
+// `useReaderState()` (every pane beneath it, however deeply slotted,
+// injects the same instance — see the provide/inject notes there).
+//
+// >=1024px: a fixed-viewport CSS grid (`[280px_1fr_1.1fr]`, summary | source
+// | commentary) — the toolbar stays put and each pane scrolls independently
+// within the viewport (see `layouts/reader.vue` for the outer `h-dvh`).
+// <1024px, for this task: the same three panes simply stacked in normal
+// document flow, no fixed height — a later task (T8) replaces this with a
+// real mobile study/panes mode; the state above already doesn't assume a
+// desktop-only shape (`activePane` exists precisely so that task can plug
+// into it).
+useReaderState();
+</script>
+
+<template>
+  <div class="flex flex-col lg:h-full lg:min-h-0">
+    <div class="shrink-0">
+      <slot name="toolbar" />
+    </div>
+
+    <div
+      class="flex flex-1 flex-col gap-8 px-4 py-6 sm:px-6 lg:grid lg:min-h-0 lg:grid-cols-[280px_1fr_1.1fr] lg:gap-0 lg:overflow-hidden lg:p-0"
+    >
+      <div
+        class="lg:flex lg:h-full lg:min-h-0 lg:flex-col lg:border-e lg:border-(--border)"
+      >
+        <slot name="summary" />
+      </div>
+      <div
+        class="lg:flex lg:h-full lg:min-h-0 lg:flex-col lg:border-e lg:border-(--border)"
+      >
+        <slot name="source" />
+      </div>
+      <div class="lg:flex lg:h-full lg:min-h-0 lg:flex-col">
+        <slot name="commentary" />
+      </div>
+    </div>
+  </div>
+</template>

--- a/app/components/reader/ReaderToolbar.vue
+++ b/app/components/reader/ReaderToolbar.vue
@@ -1,0 +1,65 @@
+<script setup lang="ts">
+// Breadcrumb ("Six volumes › Volume N › Part N · Chapter title") + prev/next
+// chapter links, disabled at the corpus edges. `prev`/`next` come straight
+// from `prevNextChapter` (`~/utils/toc`) — this component only renders.
+import type { BreadcrumbItem } from "~/components/app/AppBreadcrumb.vue";
+import type { FlattenedChapter } from "~/utils/toc";
+
+defineProps<{
+  breadcrumbItems: BreadcrumbItem[];
+  prev: FlattenedChapter | null;
+  next: FlattenedChapter | null;
+}>();
+
+const { t, locale } = useI18n();
+const localePath = useLocalePath();
+</script>
+
+<template>
+  <div class="flex flex-col gap-3 border-b border-(--border) px-4 py-3 sm:px-6">
+    <AppBreadcrumb :items="breadcrumbItems" />
+
+    <nav
+      :aria-label="t('reader.chapterNav')"
+      class="flex items-center justify-between gap-3 text-sm"
+    >
+      <NuxtLink
+        v-if="prev"
+        :to="localePath(`/read/${prev.chapter.id}`)"
+        class="inline-flex min-w-0 items-center gap-1.5 rounded-button px-2 py-1 text-(--text-primary) hover:text-teal focus-visible:outline focus-visible:outline-2 focus-visible:outline-teal"
+      >
+        <span aria-hidden="true" class="rtl:rotate-180">&larr;</span>
+        <span class="truncate">{{
+          localizedText(prev.chapter.title, locale)
+        }}</span>
+      </NuxtLink>
+      <span
+        v-else
+        aria-disabled="true"
+        class="inline-flex items-center gap-1.5 px-2 py-1 text-(--text-muted) opacity-50"
+      >
+        <span aria-hidden="true" class="rtl:rotate-180">&larr;</span>
+        {{ t("reader.prevChapter") }}
+      </span>
+
+      <NuxtLink
+        v-if="next"
+        :to="localePath(`/read/${next.chapter.id}`)"
+        class="inline-flex min-w-0 items-center gap-1.5 rounded-button px-2 py-1 text-end text-(--text-primary) hover:text-teal focus-visible:outline focus-visible:outline-2 focus-visible:outline-teal"
+      >
+        <span class="truncate">{{
+          localizedText(next.chapter.title, locale)
+        }}</span>
+        <span aria-hidden="true" class="rtl:rotate-180">&rarr;</span>
+      </NuxtLink>
+      <span
+        v-else
+        aria-disabled="true"
+        class="inline-flex items-center gap-1.5 px-2 py-1 text-(--text-muted) opacity-50"
+      >
+        {{ t("reader.nextChapter") }}
+        <span aria-hidden="true" class="rtl:rotate-180">&rarr;</span>
+      </span>
+    </nav>
+  </div>
+</template>

--- a/app/components/reader/SourcePane.vue
+++ b/app/components/reader/SourcePane.vue
@@ -34,9 +34,24 @@ const anchorIdFromEvent = (event: Event): string | undefined => {
   return anchor?.dataset.anchor;
 };
 
+// A focused `<a href>`'s native Enter activation fires both this `keydown`
+// (which handles it, since Space also needs handling here and anchors don't
+// natively activate on Space) and a browser-synthesized `click` right after
+// — without a guard, that click re-runs `activateAnchor` for the same Enter
+// press. `suppressNextClickId` records the id an Enter keydown just
+// activated so the following synthetic click for that same id is a no-op;
+// it's cleared on a microtask so it can never suppress a later *real*
+// click if the browser's `click` doesn't materialize (e.g. `preventDefault`
+// already stopped it upstream).
+let suppressNextClickId: string | null = null;
+
 const onContainerClick = (event: MouseEvent) => {
   const id = anchorIdFromEvent(event);
   if (!id) return;
+  if (suppressNextClickId === id) {
+    suppressNextClickId = null;
+    return;
+  }
   event.preventDefault();
   activateAnchor(id, "source");
 };
@@ -47,6 +62,13 @@ const onContainerKeydown = (event: KeyboardEvent) => {
   if (!id) return;
   event.preventDefault();
   activateAnchor(id, "source");
+
+  if (event.key === "Enter") {
+    suppressNextClickId = id;
+    queueMicrotask(() => {
+      if (suppressNextClickId === id) suppressNextClickId = null;
+    });
+  }
 };
 
 watchEffect((onCleanup) => {

--- a/app/components/reader/SourcePane.vue
+++ b/app/components/reader/SourcePane.vue
@@ -1,0 +1,88 @@
+<script setup lang="ts">
+// Renders a chapter's source segments. Anchor clicks (`a.tes-anchor[data-anchor]`,
+// Sefaria's inline commentary markers, normalized at import time — see
+// `app/utils/anchors.ts`) are caught via a single delegated listener on the
+// scroll container, bound imperatively (not a template `@click`) so a
+// non-interactive container isn't flagged by
+// `vuejs-accessibility/no-static-element-interactions` — the actual
+// interactive elements are the `<a>` tags themselves, which already have a
+// working `href="#op-N"` no-JS fallback; this only intercepts to run the
+// reader's own highlight/scroll behaviour instead of a plain in-page jump.
+import type { SourceSegment } from "~~/shared/types/content";
+
+defineProps<{ segments: SourceSegment[] }>();
+
+const { t } = useI18n();
+const { activateAnchor } = useReaderState();
+const containerRef = useReaderPaneContainer();
+useHighlightedAnchor("source", containerRef);
+
+// `rewriteLegacySefariaRelativeHrefs` patches a data quirk in already-
+// committed content: some Questions/Answers chapters' Hebrew source has
+// Sefaria's own site-relative cross-reference links (`href="/Talmud_..."`),
+// which don't resolve on this site — see `app/utils/sanitizeHtml.ts`.
+const displayHtml = (segment: SourceSegment): string =>
+  rewriteLegacySefariaRelativeHrefs(
+    stripLeadingSeifNumber(segment.html, segment.n),
+  );
+
+const anchorIdFromEvent = (event: Event): string | undefined => {
+  const target = event.target as HTMLElement | null;
+  const anchor = target?.closest<HTMLAnchorElement>(
+    "a.tes-anchor[data-anchor]",
+  );
+  return anchor?.dataset.anchor;
+};
+
+const onContainerClick = (event: MouseEvent) => {
+  const id = anchorIdFromEvent(event);
+  if (!id) return;
+  event.preventDefault();
+  activateAnchor(id, "source");
+};
+
+const onContainerKeydown = (event: KeyboardEvent) => {
+  if (event.key !== "Enter" && event.key !== " ") return;
+  const id = anchorIdFromEvent(event);
+  if (!id) return;
+  event.preventDefault();
+  activateAnchor(id, "source");
+};
+
+watchEffect((onCleanup) => {
+  const container = containerRef.value;
+  if (!container) return;
+
+  container.addEventListener("click", onContainerClick);
+  container.addEventListener("keydown", onContainerKeydown);
+  onCleanup(() => {
+    container.removeEventListener("click", onContainerClick);
+    container.removeEventListener("keydown", onContainerKeydown);
+  });
+});
+</script>
+
+<template>
+  <ol
+    v-if="segments.length > 0"
+    class="mx-auto flex max-w-[65ch] flex-col gap-6"
+  >
+    <li
+      v-for="segment in segments"
+      :id="`seif-${segment.n}`"
+      :key="segment.n"
+      class="reader-anchor-target scroll-mt-4 text-lg leading-relaxed text-(--text-primary)"
+    >
+      <span
+        class="me-2 inline-flex h-5 min-w-5 items-center justify-center rounded-full bg-(--surface-raised) px-1 align-middle text-xs tabular-nums text-(--text-muted)"
+        aria-hidden="true"
+      >
+        {{ segment.n }}
+      </span>
+      <span v-html="displayHtml(segment)" />
+    </li>
+  </ol>
+  <p v-else class="text-sm text-(--text-muted)">
+    {{ t("reader.sourceEmpty") }}
+  </p>
+</template>

--- a/app/components/reader/SummaryPane.vue
+++ b/app/components/reader/SummaryPane.vue
@@ -1,0 +1,68 @@
+<script setup lang="ts">
+// Renders the chapter's curated summary when it has one — most chapters
+// don't (only chapter-01 does, so far): the pane instead shows the
+// chapter's `heading`s extracted from its source segments as a mini
+// table-of-contents, so the third pane is never an empty box. Each mini-toc
+// entry jumps the source pane to that seif (`seif-N`, `useHighlightedAnchor`
+// on `SourcePane`) — the summary pane itself is never a highlight target,
+// only an anchor *origin*.
+import type { SourceSegment, SummaryItem } from "~~/shared/types/content";
+
+const props = defineProps<{
+  summaryItems: SummaryItem[];
+  sourceSegments: SourceSegment[];
+}>();
+
+const { t } = useI18n();
+const { activateAnchor } = useReaderState();
+
+const hasSummary = computed(() => props.summaryItems.length > 0);
+
+const miniToc = computed(() =>
+  sourceMiniTocEntries(props.sourceSegments, (n) =>
+    t("reader.seifLabel", { n }),
+  ),
+);
+
+const onMiniTocEntryClick = (anchorId: string) => {
+  activateAnchor(anchorId, "summary");
+};
+</script>
+
+<template>
+  <div v-if="hasSummary" class="flex flex-col gap-6">
+    <article
+      v-for="item in summaryItems"
+      :key="item.id"
+      class="leading-relaxed text-(--text-primary)"
+    >
+      <h3 class="font-display text-base text-(--text-primary)">
+        {{ item.heading }}
+      </h3>
+      <div class="mt-1 text-sm text-(--text-muted)" v-html="item.html" />
+    </article>
+  </div>
+
+  <nav v-else-if="miniToc.length > 0" :aria-label="t('reader.miniTocTitle')">
+    <h3
+      class="font-display text-sm tracking-wide text-(--text-muted) uppercase"
+    >
+      {{ t("reader.miniTocTitle") }}
+    </h3>
+    <ol class="mt-3 flex flex-col gap-1">
+      <li v-for="entry in miniToc" :key="entry.anchorId">
+        <button
+          type="button"
+          class="rounded-button px-2 py-1 text-start text-sm text-(--text-primary) hover:text-teal focus-visible:outline focus-visible:outline-2 focus-visible:outline-teal"
+          @click="onMiniTocEntryClick(entry.anchorId)"
+        >
+          {{ entry.label }}
+        </button>
+      </li>
+    </ol>
+  </nav>
+
+  <p v-else class="text-sm text-(--text-muted)">
+    {{ t("reader.summaryEmpty") }}
+  </p>
+</template>

--- a/app/composables/useChapterContent.ts
+++ b/app/composables/useChapterContent.ts
@@ -1,0 +1,151 @@
+/**
+ * Loads a chapter's layer/version content files. Only the specific files a
+ * chapter actually has (per `toc.json`'s `availableVersions`) are ever
+ * fetched — `import.meta.glob(..., { lazy: default })` over every content
+ * file under `content/parts/**` gives each one its own dynamically-imported
+ * chunk, so a chapter's route bundle never pulls in the other 500+ files.
+ *
+ * All of a chapter's available versions (not just the currently-selected
+ * one) are loaded up front: the reader is a static site, there is no
+ * "fetch on version switch" — switching the version `<select>` just swaps
+ * which already-loaded object a pane renders, so it's instant offline too.
+ *
+ * SSG-safe via `useAsyncData` (resolves during prerender, payload-extracted
+ * for hydration). A missing layer/version file resolves to `null`, never a
+ * throw — most chapters simply don't have every layer/version.
+ *
+ * Takes the chapter's `availableVersions` as a plain argument (rather than
+ * re-resolving `useLocalizedToc()`/`findChapter` internally) so this
+ * composable's first statement is its own `useAsyncData` call: a Nuxt
+ * composable called *after* an `await` inside a plain (non-`<script setup>`)
+ * composable function can lose its Nuxt app context during prerendering —
+ * the reader page already has the chapter's toc entry (and so its
+ * `availableVersions`) resolved by the time it calls this.
+ */
+import type { ComputedRef } from "vue";
+import type {
+  ChapterLayerFile,
+  CommentaryItem,
+  LayerItem,
+  LayerKind,
+  SourceSegment,
+  SummaryItem,
+  TocChapter,
+} from "~~/shared/types/content";
+
+type AvailableVersions = TocChapter["availableVersions"];
+
+// A relative path, not the `~~` alias: `import.meta.glob` patterns are
+// statically analyzed (by Vite's own glob-import plugin) rather than run
+// through normal module resolution, so a plain relative path is the safest
+// choice — verified against the actual generated output, not assumed.
+const chapterLayerModules = import.meta.glob<{ default: unknown }>(
+  "../../content/parts/**/*.json",
+);
+
+const findLoader = (
+  partId: string,
+  chapterSlug: string,
+  layer: LayerKind,
+  versionId: string,
+) => {
+  const suffix = `/parts/${partId}/chapters/${chapterSlug}/${layer}.${versionId}.json`;
+  const key = Object.keys(chapterLayerModules).find((candidate) =>
+    candidate.endsWith(suffix),
+  );
+  return key ? chapterLayerModules[key] : undefined;
+};
+
+const loadLayerFile = async <T extends LayerItem>(
+  partId: string,
+  chapterSlug: string,
+  layer: LayerKind,
+  versionId: string,
+): Promise<ChapterLayerFile<T> | null> => {
+  const loader = findLoader(partId, chapterSlug, layer, versionId);
+  if (!loader) return null;
+
+  const mod = await loader();
+  return (mod as { default: ChapterLayerFile<T> }).default;
+};
+
+const loadAllVersions = async <T extends LayerItem>(
+  partId: string,
+  chapterSlug: string,
+  layer: LayerKind,
+  versionIds: string[],
+): Promise<Record<string, ChapterLayerFile<T> | null>> => {
+  const entries = await Promise.all(
+    versionIds.map(async (versionId) => {
+      const file = await loadLayerFile<T>(
+        partId,
+        chapterSlug,
+        layer,
+        versionId,
+      );
+      return [versionId, file] as const;
+    }),
+  );
+
+  return Object.fromEntries(entries);
+};
+
+export interface ChapterContent {
+  sourceVersions: ComputedRef<string[]>;
+  commentaryVersions: ComputedRef<string[]>;
+  summaryVersions: ComputedRef<string[]>;
+  sourceByVersion: ComputedRef<
+    Record<string, ChapterLayerFile<SourceSegment> | null>
+  >;
+  commentaryByVersion: ComputedRef<
+    Record<string, ChapterLayerFile<CommentaryItem> | null>
+  >;
+  summaryByVersion: ComputedRef<
+    Record<string, ChapterLayerFile<SummaryItem> | null>
+  >;
+}
+
+export const useChapterContent = async (
+  partId: string,
+  chapterSlug: string,
+  availableVersions: AvailableVersions,
+): Promise<ChapterContent> => {
+  const chapterId = `${partId}/${chapterSlug}`;
+
+  const { data } = await useAsyncData(
+    `chapter-content:${chapterId}`,
+    async () => {
+      const [source, commentary, summary] = await Promise.all([
+        loadAllVersions<SourceSegment>(
+          partId,
+          chapterSlug,
+          "source",
+          availableVersions.source,
+        ),
+        loadAllVersions<CommentaryItem>(
+          partId,
+          chapterSlug,
+          "commentary",
+          availableVersions.commentary,
+        ),
+        loadAllVersions<SummaryItem>(
+          partId,
+          chapterSlug,
+          "summary",
+          availableVersions.summary,
+        ),
+      ]);
+
+      return { source, commentary, summary };
+    },
+  );
+
+  return {
+    sourceVersions: computed(() => availableVersions.source),
+    commentaryVersions: computed(() => availableVersions.commentary),
+    summaryVersions: computed(() => availableVersions.summary),
+    sourceByVersion: computed(() => data.value?.source ?? {}),
+    commentaryByVersion: computed(() => data.value?.commentary ?? {}),
+    summaryByVersion: computed(() => data.value?.summary ?? {}),
+  };
+};

--- a/app/composables/useHighlightedAnchor.ts
+++ b/app/composables/useHighlightedAnchor.ts
@@ -61,21 +61,33 @@ export const useHighlightedAnchor = (
   paneId: PaneId,
   containerRef: Ref<HTMLElement | null | undefined>,
 ): void => {
-  const { activeAnchor, anchorOrigin } = useReaderState();
+  const { activeAnchor, anchorOrigin, activationSeq } = useReaderState();
 
-  watch([activeAnchor, anchorOrigin], ([anchorId, origin]) => {
-    if (!anchorId || origin === paneId) return;
+  // Watches `activationSeq` alongside the anchor id/origin so the highlight
+  // re-fires on events that don't change those values themselves: re-
+  // clicking the same anchor (`activateAnchor` always bumps the sequence),
+  // and a version switch reconciling which element the current anchor now
+  // targets (`reactivateAnchor`). `flush: "post"` runs the callback after
+  // the DOM has been patched, so a version switch's newly-rendered element
+  // (e.g. the commentary item that only exists once the Hebrew version
+  // loads) is present in the container by the time this queries for it.
+  watch(
+    [activeAnchor, anchorOrigin, activationSeq],
+    ([anchorId, origin]) => {
+      if (!anchorId || origin === paneId) return;
 
-    const container = containerRef.value;
-    if (!container) return;
+      const container = containerRef.value;
+      if (!container) return;
 
-    const target = findAnchorElement(container, anchorId);
-    if (!target) return;
+      const target = findAnchorElement(container, anchorId);
+      if (!target) return;
 
-    target.scrollIntoView({
-      block: "center",
-      behavior: prefersReducedMotion() ? "auto" : "smooth",
-    });
-    flashHighlight(target);
-  });
+      target.scrollIntoView({
+        block: "center",
+        behavior: prefersReducedMotion() ? "auto" : "smooth",
+      });
+      flashHighlight(target);
+    },
+    { flush: "post" },
+  );
 };

--- a/app/composables/useHighlightedAnchor.ts
+++ b/app/composables/useHighlightedAnchor.ts
@@ -1,0 +1,81 @@
+/**
+ * Runs a single pane's side of the reader's two-way anchor sync: watches
+ * the shared `activeAnchor`/`anchorOrigin`, and — only when the anchor
+ * didn't originate in this pane — finds the target element inside this
+ * pane's OWN container (never another pane's DOM), scrolls it into view,
+ * and flashes a fading highlight.
+ *
+ * Anchor grammar per the content model: source uses `[data-anchor="id"]`
+ * (the inline `<a class="tes-anchor">` marker); commentary items and the
+ * summary mini-toc's `seif-N` source targets use a plain `id="…"` on the
+ * item/segment element itself.
+ */
+import type { Ref } from "vue";
+import type { PaneId } from "~/utils/readerAnchorState";
+
+const findAnchorElement = (
+  container: HTMLElement,
+  anchorId: string,
+): HTMLElement | null => {
+  const escaped =
+    typeof CSS !== "undefined" && "escape" in CSS
+      ? CSS.escape(anchorId)
+      : anchorId;
+
+  return (
+    container.querySelector<HTMLElement>(`[data-anchor="${escaped}"]`) ??
+    container.querySelector<HTMLElement>(`#${escaped}`)
+  );
+};
+
+const prefersReducedMotion = (): boolean =>
+  typeof window !== "undefined" &&
+  window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+
+/**
+ * Flashes `.is-highlighted` on `el`, then fades it back out over ~2s via
+ * the CSS transition defined on `.reader-anchor-target` (see main.css).
+ * Disabling the transition while applying the "on" state (then re-enabling
+ * it a frame later, right before removing the class) makes the highlight
+ * appear instantly and only the fade-out animate — a plain class toggle
+ * would animate the fade-IN too.
+ */
+const flashHighlight = (el: HTMLElement) => {
+  if (prefersReducedMotion()) {
+    el.classList.add("is-highlighted-instant");
+    setTimeout(() => el.classList.remove("is-highlighted-instant"), 900);
+    return;
+  }
+
+  el.style.transition = "none";
+  el.classList.add("is-highlighted");
+  requestAnimationFrame(() => {
+    requestAnimationFrame(() => {
+      el.style.transition = "";
+      el.classList.remove("is-highlighted");
+    });
+  });
+};
+
+export const useHighlightedAnchor = (
+  paneId: PaneId,
+  containerRef: Ref<HTMLElement | null | undefined>,
+): void => {
+  const { activeAnchor, anchorOrigin } = useReaderState();
+
+  watch([activeAnchor, anchorOrigin], ([anchorId, origin]) => {
+    if (!anchorId || origin === paneId) return;
+
+    const container = containerRef.value;
+    if (!container) return;
+
+    const target = findAnchorElement(container, anchorId);
+    if (!target) return;
+
+    target.scrollIntoView({
+      block: "center",
+      behavior: prefersReducedMotion() ? "auto" : "smooth",
+    });
+    flashHighlight(target);
+  });
+};

--- a/app/composables/useReaderPaneContainer.ts
+++ b/app/composables/useReaderPaneContainer.ts
@@ -1,0 +1,29 @@
+/**
+ * Provides a `ReaderPane`'s scroll container element to whatever pane
+ * content (`SourcePane`/`CommentaryPane`/`SummaryPane`) it wraps, so those
+ * components can pass it to `useHighlightedAnchor` without `ReaderPane`
+ * needing to know anything about anchor highlighting itself.
+ */
+import type { InjectionKey, Ref } from "vue";
+
+const READER_PANE_CONTAINER_KEY: InjectionKey<Ref<HTMLElement | null>> = Symbol(
+  "reader-pane-container",
+);
+
+/** Called once by `ReaderPane` itself. */
+export const provideReaderPaneContainer = (): Ref<HTMLElement | null> => {
+  const containerRef = ref<HTMLElement | null>(null);
+  provide(READER_PANE_CONTAINER_KEY, containerRef);
+  return containerRef;
+};
+
+/** Called by the pane content rendered inside a `ReaderPane`. */
+export const useReaderPaneContainer = (): Ref<HTMLElement | null> => {
+  const containerRef = inject(READER_PANE_CONTAINER_KEY, null);
+  if (!containerRef) {
+    throw new Error(
+      "useReaderPaneContainer() called without a ReaderPane ancestor",
+    );
+  }
+  return containerRef;
+};

--- a/app/composables/useReaderState.ts
+++ b/app/composables/useReaderState.ts
@@ -1,0 +1,82 @@
+/**
+ * The reader's cross-pane anchor sync state, shared by `ReaderShell` and
+ * every pane beneath it via provide/inject — no event bus, no cross-pane
+ * DOM reach. Each pane's own `useHighlightedAnchor(paneId, containerRef)`
+ * watches `activeAnchor`/`anchorOrigin` and only reacts when it isn't the
+ * origin pane.
+ *
+ * `activePane` exists (even though this task is desktop-first, all three
+ * panes always visible) so a later single-pane mobile mode (T8) can plug
+ * into the same state without a desktop-only assumption baked in here.
+ */
+import type { InjectionKey, Ref } from "vue";
+import {
+  activateAnchorState,
+  clearAnchorState,
+  initialReaderAnchorState,
+  type PaneId,
+} from "~/utils/readerAnchorState";
+
+export interface ReaderState {
+  activeAnchor: Ref<string | null>;
+  anchorOrigin: Ref<PaneId | null>;
+  activePane: Ref<PaneId>;
+  activateAnchor: (id: string, origin: PaneId) => void;
+  clearAnchor: () => void;
+}
+
+const READER_STATE_KEY: InjectionKey<ReaderState> = Symbol("reader-state");
+
+const createReaderState = (): ReaderState => {
+  const initial = initialReaderAnchorState();
+  const activeAnchor = ref<string | null>(initial.activeAnchor);
+  const anchorOrigin = ref<PaneId | null>(initial.anchorOrigin);
+  const activePane = ref<PaneId>(initial.activePane);
+
+  const activateAnchor = (id: string, origin: PaneId) => {
+    const next = activateAnchorState(
+      {
+        activeAnchor: activeAnchor.value,
+        anchorOrigin: anchorOrigin.value,
+        activePane: activePane.value,
+      },
+      id,
+      origin,
+    );
+    activeAnchor.value = next.activeAnchor;
+    anchorOrigin.value = next.anchorOrigin;
+    activePane.value = next.activePane;
+  };
+
+  const clearAnchor = () => {
+    const next = clearAnchorState({
+      activeAnchor: activeAnchor.value,
+      anchorOrigin: anchorOrigin.value,
+      activePane: activePane.value,
+    });
+    activeAnchor.value = next.activeAnchor;
+    anchorOrigin.value = next.anchorOrigin;
+  };
+
+  return {
+    activeAnchor,
+    anchorOrigin,
+    activePane,
+    activateAnchor,
+    clearAnchor,
+  };
+};
+
+/**
+ * Called by `ReaderShell` (provides a fresh state) and by every pane beneath
+ * it (injects the same instance) — whichever component calls this first in
+ * a given reader page's tree creates and provides the state.
+ */
+export const useReaderState = (): ReaderState => {
+  const existing = inject(READER_STATE_KEY, null);
+  if (existing) return existing;
+
+  const state = createReaderState();
+  provide(READER_STATE_KEY, state);
+  return state;
+};

--- a/app/composables/useReaderState.ts
+++ b/app/composables/useReaderState.ts
@@ -14,6 +14,7 @@ import {
   activateAnchorState,
   clearAnchorState,
   initialReaderAnchorState,
+  reactivateAnchorState,
   type PaneId,
 } from "~/utils/readerAnchorState";
 
@@ -21,7 +22,17 @@ export interface ReaderState {
   activeAnchor: Ref<string | null>;
   anchorOrigin: Ref<PaneId | null>;
   activePane: Ref<PaneId>;
+  /**
+   * Bumped by `activateAnchor` and `reactivateAnchor`. Watch this alongside
+   * `activeAnchor` (see `useHighlightedAnchor`) to re-fire on events that
+   * don't change the anchor id/origin themselves — a repeat click, or a
+   * version switch that changes which element the current anchor resolves
+   * to.
+   */
+  activationSeq: Ref<number>;
   activateAnchor: (id: string, origin: PaneId) => void;
+  /** Re-fires the highlight/scroll for the *current* anchor without changing it. */
+  reactivateAnchor: () => void;
   clearAnchor: () => void;
 }
 
@@ -32,6 +43,7 @@ const createReaderState = (): ReaderState => {
   const activeAnchor = ref<string | null>(initial.activeAnchor);
   const anchorOrigin = ref<PaneId | null>(initial.anchorOrigin);
   const activePane = ref<PaneId>(initial.activePane);
+  const activationSeq = ref<number>(initial.activationSeq);
 
   const activateAnchor = (id: string, origin: PaneId) => {
     const next = activateAnchorState(
@@ -39,6 +51,7 @@ const createReaderState = (): ReaderState => {
         activeAnchor: activeAnchor.value,
         anchorOrigin: anchorOrigin.value,
         activePane: activePane.value,
+        activationSeq: activationSeq.value,
       },
       id,
       origin,
@@ -46,6 +59,17 @@ const createReaderState = (): ReaderState => {
     activeAnchor.value = next.activeAnchor;
     anchorOrigin.value = next.anchorOrigin;
     activePane.value = next.activePane;
+    activationSeq.value = next.activationSeq;
+  };
+
+  const reactivateAnchor = () => {
+    const next = reactivateAnchorState({
+      activeAnchor: activeAnchor.value,
+      anchorOrigin: anchorOrigin.value,
+      activePane: activePane.value,
+      activationSeq: activationSeq.value,
+    });
+    activationSeq.value = next.activationSeq;
   };
 
   const clearAnchor = () => {
@@ -53,6 +77,7 @@ const createReaderState = (): ReaderState => {
       activeAnchor: activeAnchor.value,
       anchorOrigin: anchorOrigin.value,
       activePane: activePane.value,
+      activationSeq: activationSeq.value,
     });
     activeAnchor.value = next.activeAnchor;
     anchorOrigin.value = next.anchorOrigin;
@@ -62,7 +87,9 @@ const createReaderState = (): ReaderState => {
     activeAnchor,
     anchorOrigin,
     activePane,
+    activationSeq,
     activateAnchor,
+    reactivateAnchor,
     clearAnchor,
   };
 };

--- a/app/composables/useReaderVersions.ts
+++ b/app/composables/useReaderVersions.ts
@@ -1,0 +1,69 @@
+/**
+ * Per-layer version selection state for the reader: which version of the
+ * source/commentary/summary layer is currently shown. Defaults follow
+ * `resolveDefaultVersion` (`~/utils/readerVersions`); the user's last choice
+ * persists via `localStorage`, keyed per LAYER (not per chapter) — picking
+ * Hebrew source once keeps defaulting to Hebrew source on later chapters
+ * too, until overridden again — falling back to the default rule whenever
+ * the persisted choice isn't among the current chapter's available
+ * versions for that layer.
+ */
+import { useLocalStorage } from "@vueuse/core";
+import type { ComputedRef } from "vue";
+import {
+  buildVersionsById,
+  resolveDefaultVersion,
+} from "~/utils/readerVersions";
+import type {
+  ContentVersion,
+  LayerKind,
+  TocChapter,
+} from "~~/shared/types/content";
+
+type ReaderVersionPrefs = Record<LayerKind, string | null>;
+
+const STORAGE_KEY = "readtes:reader-versions";
+const DEFAULT_PREFS: ReaderVersionPrefs = {
+  source: null,
+  commentary: null,
+  summary: null,
+};
+
+export interface ReaderVersions {
+  source: ComputedRef<string | null>;
+  commentary: ComputedRef<string | null>;
+  summary: ComputedRef<string | null>;
+  setVersion: (layer: LayerKind, versionId: string) => void;
+}
+
+export const useReaderVersions = (
+  chapter: TocChapter,
+  versions: ContentVersion[],
+): ReaderVersions => {
+  const { locale } = useI18n();
+  const versionsById = computed(() => buildVersionsById(versions));
+
+  const prefs = useLocalStorage<ReaderVersionPrefs>(STORAGE_KEY, {
+    ...DEFAULT_PREFS,
+  });
+
+  const resolvedFor = (layer: LayerKind): ComputedRef<string | null> =>
+    computed(() => {
+      const available = chapter.availableVersions[layer];
+      const preferred = prefs.value[layer];
+
+      if (preferred && available.includes(preferred)) return preferred;
+      return resolveDefaultVersion(available, locale.value, versionsById.value);
+    });
+
+  const setVersion = (layer: LayerKind, versionId: string) => {
+    prefs.value = { ...prefs.value, [layer]: versionId };
+  };
+
+  return {
+    source: resolvedFor("source"),
+    commentary: resolvedFor("commentary"),
+    summary: resolvedFor("summary"),
+    setVersion,
+  };
+};

--- a/app/composables/useReaderVersions.ts
+++ b/app/composables/useReaderVersions.ts
@@ -7,6 +7,15 @@
  * too, until overridden again — falling back to the default rule whenever
  * the persisted choice isn't among the current chapter's available
  * versions for that layer.
+ *
+ * Hydration note: `useLocalStorage` reads `localStorage` synchronously in
+ * `setup`, but prerendering has no `localStorage` and always resolves via
+ * `resolveDefaultVersion`. Consulting the persisted prefs immediately would
+ * make a returning visitor's first client render (used for hydration)
+ * diverge from the prerendered HTML - a hydration mismatch + content flash.
+ * `hydrated` gates persisted reads until `onMounted`, so the very first
+ * render (server and client alike) always resolves via the default rule;
+ * the persisted override reconciles in right after mount.
  */
 import { useLocalStorage } from "@vueuse/core";
 import type { ComputedRef } from "vue";
@@ -47,10 +56,19 @@ export const useReaderVersions = (
     ...DEFAULT_PREFS,
   });
 
+  // Gates persisted-preference reads until after mount so the first render
+  // (SSR and the client's pre-mount render alike) always matches the
+  // default-rule resolution baked into the prerendered HTML. See the
+  // module-doc hydration note above.
+  const hydrated = ref(false);
+  onMounted(() => {
+    hydrated.value = true;
+  });
+
   const resolvedFor = (layer: LayerKind): ComputedRef<string | null> =>
     computed(() => {
       const available = chapter.availableVersions[layer];
-      const preferred = prefs.value[layer];
+      const preferred = hydrated.value ? prefs.value[layer] : null;
 
       if (preferred && available.includes(preferred)) return preferred;
       return resolveDefaultVersion(available, locale.value, versionsById.value);

--- a/app/pages/read/[part]/[chapter].vue
+++ b/app/pages/read/[part]/[chapter].vue
@@ -1,0 +1,198 @@
+<script setup lang="ts">
+// The reader: three aligned layers (summary | source | commentary) for one
+// chapter, with two-way anchor sync. Resolves the chapter from
+// `content/toc.json` by route params — an unknown id 404s, the same way
+// `/volumes/[volume]` does.
+definePageMeta({
+  layout: "reader",
+  // Full remount on every param change (not just on prop update) so the
+  // 404 check below always re-runs against the new ids, and so
+  // `useReaderVersions`' locale-dependent defaults are recomputed fresh.
+  key: (route) => route.fullPath,
+});
+
+const route = useRoute();
+const { t } = useI18n();
+const localePath = useLocalePath();
+
+const partId = route.params.part as string;
+const chapterSlug = route.params.chapter as string;
+const chapterId = `${partId}/${chapterSlug}`;
+
+const { toc, versions, localizedTitle } = await useLocalizedToc();
+const entry = findChapter(toc.value, chapterId);
+
+if (!entry) {
+  throw createError({
+    statusCode: 404,
+    statusMessage: `Unknown chapter "${chapterId}"`,
+    fatal: true,
+  });
+}
+
+const HEBREW_VERSION_ID = "he-jerusalem-1956";
+
+const {
+  sourceVersions,
+  commentaryVersions,
+  summaryVersions,
+  sourceByVersion,
+  commentaryByVersion,
+  summaryByVersion,
+} = await useChapterContent(
+  partId,
+  chapterSlug,
+  entry.chapter.availableVersions,
+);
+
+const readerVersions = useReaderVersions(entry.chapter, versions.value);
+const versionsById = computed(() => buildVersionsById(versions.value));
+
+const versionOptions = (ids: string[]) =>
+  ids.map((id) => ({
+    id,
+    label: versionsById.value.get(id)?.title ?? id,
+  }));
+
+const sourceVersionOptions = computed(() =>
+  versionOptions(sourceVersions.value),
+);
+const commentaryVersionOptions = computed(() =>
+  versionOptions(commentaryVersions.value),
+);
+const summaryVersionOptions = computed(() =>
+  versionOptions(summaryVersions.value),
+);
+
+const metaFor = (versionId: string | null) =>
+  versionId ? (versionsById.value.get(versionId) ?? null) : null;
+
+const sourceMeta = computed(() => metaFor(readerVersions.source.value));
+const commentaryMeta = computed(() => metaFor(readerVersions.commentary.value));
+const summaryMeta = computed(() => metaFor(readerVersions.summary.value));
+
+const sourceFile = computed(() =>
+  readerVersions.source.value
+    ? (sourceByVersion.value[readerVersions.source.value] ?? null)
+    : null,
+);
+const commentaryFile = computed(() =>
+  readerVersions.commentary.value
+    ? (commentaryByVersion.value[readerVersions.commentary.value] ?? null)
+    : null,
+);
+const summaryFile = computed(() =>
+  readerVersions.summary.value
+    ? (summaryByVersion.value[readerVersions.summary.value] ?? null)
+    : null,
+);
+
+const sourceSegments = computed(() => sourceFile.value?.items ?? []);
+const commentaryItems = computed(() => commentaryFile.value?.items ?? []);
+const summaryItems = computed(() => summaryFile.value?.items ?? []);
+
+const { prev, next } = prevNextChapter(toc.value, chapterId);
+
+const chapterTitle = computed(() => localizedTitle(entry.chapter.title));
+
+const breadcrumbItems = computed(() => [
+  { label: t("common.sixVolumes"), to: localePath("/volumes") },
+  {
+    label: `${t("common.volume")} ${entry.volume.number}`,
+    to: localePath(`/volumes/${volumeSlug(entry.volume)}`),
+  },
+  {
+    label: `${t("common.part")} ${entry.part.number} · ${chapterTitle.value}`,
+  },
+]);
+
+// "Not available in this edition" toast for the commentary pane: a source
+// anchor was activated, but the commentary version currently shown has
+// nothing for it.
+const { activeAnchor, anchorOrigin } = useReaderState();
+
+const missingAnchorNotice = computed(() =>
+  resolveMissingAnchorNotice({
+    activeAnchor: activeAnchor.value,
+    anchorOrigin: anchorOrigin.value,
+    displayedItems: commentaryItems.value,
+    selectedVersionId: readerVersions.commentary.value,
+    hebrewItems: commentaryByVersion.value[HEBREW_VERSION_ID]?.items ?? null,
+    hebrewVersionId: HEBREW_VERSION_ID,
+  }),
+);
+
+const switchCommentaryToHebrew = () => {
+  readerVersions.setVersion("commentary", HEBREW_VERSION_ID);
+};
+
+useSeoMeta({
+  title: () => `${chapterTitle.value} · ${t("common.siteName")}`,
+});
+</script>
+
+<template>
+  <ReaderShell>
+    <template #toolbar>
+      <ReaderToolbar
+        :breadcrumb-items="breadcrumbItems"
+        :prev="prev"
+        :next="next"
+      />
+    </template>
+
+    <template #summary>
+      <ReaderPane
+        :title="t('reader.pane.summary')"
+        :version-options="summaryVersionOptions"
+        :model-value="readerVersions.summary.value"
+        :meta="summaryMeta"
+        @update:model-value="(id) => readerVersions.setVersion('summary', id)"
+      >
+        <ReaderSummaryPane
+          :summary-items="summaryItems"
+          :source-segments="sourceSegments"
+        />
+      </ReaderPane>
+    </template>
+
+    <template #source>
+      <ReaderPane
+        :title="t('reader.pane.source')"
+        :version-options="sourceVersionOptions"
+        :model-value="readerVersions.source.value"
+        :meta="sourceMeta"
+        @update:model-value="(id) => readerVersions.setVersion('source', id)"
+      >
+        <ReaderSourcePane :segments="sourceSegments" />
+      </ReaderPane>
+    </template>
+
+    <template #commentary>
+      <ReaderPane
+        :title="t('reader.pane.commentary')"
+        :version-options="commentaryVersionOptions"
+        :model-value="readerVersions.commentary.value"
+        :meta="commentaryMeta"
+        @update:model-value="
+          (id) => readerVersions.setVersion('commentary', id)
+        "
+      >
+        <template v-if="missingAnchorNotice" #toast>
+          <p class="basis-full text-xs text-orange-cta">
+            {{ t("reader.missingAnchor.message") }}
+            <button
+              v-if="missingAnchorNotice.canSwitchToHebrew"
+              type="button"
+              class="ms-1 underline"
+              @click="switchCommentaryToHebrew"
+            >
+              {{ t("reader.missingAnchor.switchToHebrew") }}
+            </button>
+          </p>
+        </template>
+        <ReaderCommentaryPane :items="commentaryItems" />
+      </ReaderPane>
+    </template>
+  </ReaderShell>
+</template>

--- a/app/pages/read/[part]/[chapter].vue
+++ b/app/pages/read/[part]/[chapter].vue
@@ -109,7 +109,7 @@ const breadcrumbItems = computed(() => [
 // "Not available in this edition" toast for the commentary pane: a source
 // anchor was activated, but the commentary version currently shown has
 // nothing for it.
-const { activeAnchor, anchorOrigin } = useReaderState();
+const { activeAnchor, anchorOrigin, reactivateAnchor } = useReaderState();
 
 const missingAnchorNotice = computed(() =>
   resolveMissingAnchorNotice({
@@ -122,8 +122,15 @@ const missingAnchorNotice = computed(() =>
   }),
 );
 
+// Switching versions doesn't change `activeAnchor`/`anchorOrigin` (the
+// anchor being looked for is the same one), so `useHighlightedAnchor`'s
+// change-based watch wouldn't otherwise re-fire once the Hebrew commentary
+// item — previously absent — renders. `reactivateAnchor` bumps the shared
+// activation sequence so the commentary pane re-runs its scroll/highlight
+// against the newly-rendered item.
 const switchCommentaryToHebrew = () => {
   readerVersions.setVersion("commentary", HEBREW_VERSION_ID);
+  reactivateAnchor();
 };
 
 useSeoMeta({

--- a/app/utils/chapterGrouping.ts
+++ b/app/utils/chapterGrouping.ts
@@ -27,8 +27,16 @@ const SECTION_FOR_KIND: Record<ChapterKind, ChapterSection> = {
   "answers-topics": "answers",
 };
 
-/** Reading order of kinds within a section — also the order sections are built in. */
-const KIND_ORDER: ChapterKind[] = [
+/**
+ * Reading order of kinds within a section — also the order sections are
+ * built in. Exported so `~/utils/toc` (`flattenChapters`) can sort a part's
+ * chapters into true reading order too: a part's `TocChapter.number` is only
+ * unique *within* a kind (e.g. `chapter` chapters 1-2 and
+ * `inner-observation` chapters 1-10 both start their own numbering at 1), so
+ * sorting by `number` alone interleaves kinds instead of reading through one
+ * kind before the next.
+ */
+export const KIND_ORDER: ChapterKind[] = [
   "chapter",
   "inner-observation",
   "questions-terminology",

--- a/app/utils/commentaryGrouping.ts
+++ b/app/utils/commentaryGrouping.ts
@@ -1,0 +1,28 @@
+/**
+ * Groups a commentary layer's items by section for the commentary pane:
+ * "Inner Light" (Ohr Pnimi, the line-by-line commentary on the main
+ * chapters) first, then "Inner Observation" (Histaklut Pnimit) — only
+ * rendering whichever groups actually have items, since a chapter's
+ * commentary is usually one section or the other, never both.
+ */
+import type { CommentaryItem } from "~~/shared/types/content";
+
+export const COMMENTARY_SECTION_ORDER = [
+  "ohr-pnimi",
+  "histaklut-pnimit",
+] as const;
+
+export interface CommentaryGroup {
+  section: CommentaryItem["section"];
+  items: CommentaryItem[];
+}
+
+export const groupCommentaryBySection = (
+  items: CommentaryItem[],
+): CommentaryGroup[] =>
+  COMMENTARY_SECTION_ORDER.map((section) => ({
+    section,
+    items: items
+      .filter((item) => item.section === section)
+      .sort((a, b) => a.order - b.order),
+  })).filter((group) => group.items.length > 0);

--- a/app/utils/commentaryNotice.ts
+++ b/app/utils/commentaryNotice.ts
@@ -1,0 +1,53 @@
+/**
+ * Resolves the commentary pane's "not available in this edition" notice: a
+ * source anchor was activated, but the commentary version currently shown
+ * doesn't have an item for it (e.g. the chapter's English commentary is
+ * missing, or doesn't cover that anchor). Pure and testable independent of
+ * the DOM — `useHighlightedAnchor` finding no matching element would work
+ * too, but can't distinguish "not in this edition" from "not mounted yet".
+ */
+import type { CommentaryItem } from "~~/shared/types/content";
+import type { PaneId } from "./readerAnchorState";
+
+/** Anchor id grammar for Ohr Penimi commentary markers (see AGENTS.md). */
+const isCommentaryAnchor = (id: string): boolean => id.startsWith("op-");
+
+export interface MissingAnchorNotice {
+  anchorId: string;
+  /** Whether the chapter's Hebrew commentary version does have this anchor. */
+  canSwitchToHebrew: boolean;
+}
+
+export const resolveMissingAnchorNotice = (params: {
+  activeAnchor: string | null;
+  anchorOrigin: PaneId | null;
+  /** Items of the commentary version currently displayed (empty if none loaded). */
+  displayedItems: CommentaryItem[];
+  /** The chapter's currently-selected commentary version id, if any. */
+  selectedVersionId: string | null;
+  /** Items of the chapter's `he-jerusalem-1956` commentary version, if it exists. */
+  hebrewItems: CommentaryItem[] | null;
+  hebrewVersionId: string;
+}): MissingAnchorNotice | null => {
+  const { activeAnchor, anchorOrigin } = params;
+
+  // Only a source-originated click is "found nothing in this edition" — a
+  // summary-pane mini-toc jump targets a `seif-N` source id, not a
+  // commentary anchor, and a commentary-originated click can't be missing
+  // from its own pane.
+  if (anchorOrigin !== "source") return null;
+  if (!activeAnchor || !isCommentaryAnchor(activeAnchor)) return null;
+
+  const alreadyShown = params.displayedItems.some(
+    (item) => item.anchorId === activeAnchor,
+  );
+  if (alreadyShown) return null;
+
+  const isHebrewSelected = params.selectedVersionId === params.hebrewVersionId;
+  const hebrewHasAnchor =
+    !isHebrewSelected &&
+    (params.hebrewItems?.some((item) => item.anchorId === activeAnchor) ??
+      false);
+
+  return { anchorId: activeAnchor, canSwitchToHebrew: hebrewHasAnchor };
+};

--- a/app/utils/readerAnchorState.ts
+++ b/app/utils/readerAnchorState.ts
@@ -1,0 +1,45 @@
+/**
+ * Pure state-transition logic for the reader's cross-pane anchor sync
+ * (`useReaderState`). Kept free of Vue reactivity so the activate/clear
+ * rules are unit-testable without mounting anything.
+ */
+
+/** The three aligned reader panes an anchor can originate from / target. */
+export type PaneId = "summary" | "source" | "commentary";
+
+export interface ReaderAnchorState {
+  activeAnchor: string | null;
+  anchorOrigin: PaneId | null;
+  activePane: PaneId;
+}
+
+export const initialReaderAnchorState = (): ReaderAnchorState => ({
+  activeAnchor: null,
+  anchorOrigin: null,
+  activePane: "source",
+});
+
+/**
+ * Activating an anchor from a pane makes that pane the active one (drives
+ * e.g. a mobile single-pane view in a later task) and records where the
+ * anchor came from, so the other panes' `useHighlightedAnchor` know not to
+ * re-highlight their own origin pane.
+ */
+export const activateAnchorState = (
+  _state: ReaderAnchorState,
+  id: string,
+  origin: PaneId,
+): ReaderAnchorState => ({
+  activeAnchor: id,
+  anchorOrigin: origin,
+  activePane: origin,
+});
+
+/** Clears the active anchor without touching which pane is "active" (e.g. for mobile mode). */
+export const clearAnchorState = (
+  state: ReaderAnchorState,
+): ReaderAnchorState => ({
+  ...state,
+  activeAnchor: null,
+  anchorOrigin: null,
+});

--- a/app/utils/readerAnchorState.ts
+++ b/app/utils/readerAnchorState.ts
@@ -11,28 +11,40 @@ export interface ReaderAnchorState {
   activeAnchor: string | null;
   anchorOrigin: PaneId | null;
   activePane: PaneId;
+  /**
+   * Bumped on every activation-worthy event, including ones that don't
+   * change `activeAnchor`/`anchorOrigin` themselves (re-clicking the same
+   * anchor, or a version switch that reconciles which element the current
+   * anchor now resolves to). `useHighlightedAnchor` watches this alongside
+   * the anchor id so it re-fires on those changes too, not just id changes.
+   */
+  activationSeq: number;
 }
 
 export const initialReaderAnchorState = (): ReaderAnchorState => ({
   activeAnchor: null,
   anchorOrigin: null,
   activePane: "source",
+  activationSeq: 0,
 });
 
 /**
  * Activating an anchor from a pane makes that pane the active one (drives
  * e.g. a mobile single-pane view in a later task) and records where the
  * anchor came from, so the other panes' `useHighlightedAnchor` know not to
- * re-highlight their own origin pane.
+ * re-highlight their own origin pane. Always bumps `activationSeq`, even
+ * when re-activating the same id/origin, so a repeat click re-fires the
+ * highlight.
  */
 export const activateAnchorState = (
-  _state: ReaderAnchorState,
+  state: ReaderAnchorState,
   id: string,
   origin: PaneId,
 ): ReaderAnchorState => ({
   activeAnchor: id,
   anchorOrigin: origin,
   activePane: origin,
+  activationSeq: state.activationSeq + 1,
 });
 
 /** Clears the active anchor without touching which pane is "active" (e.g. for mobile mode). */
@@ -42,4 +54,18 @@ export const clearAnchorState = (
   ...state,
   activeAnchor: null,
   anchorOrigin: null,
+});
+
+/**
+ * Bumps `activationSeq` without otherwise touching the state — for paths
+ * that reconcile which element the *current* anchor now targets rather
+ * than activating a new one (e.g. the missing-anchor toast's "Switch to
+ * Hebrew", which changes the commentary version but not the active anchor
+ * id/origin).
+ */
+export const reactivateAnchorState = (
+  state: ReaderAnchorState,
+): ReaderAnchorState => ({
+  ...state,
+  activationSeq: state.activationSeq + 1,
 });

--- a/app/utils/readerVersions.ts
+++ b/app/utils/readerVersions.ts
@@ -1,0 +1,45 @@
+/**
+ * Pure version-default-selection rule for the reader (`useReaderVersions`).
+ *
+ * Rule: Hebrew UI + a Hebrew version available -> Hebrew. Otherwise, the
+ * best English version available -> `en-sefaria-community`, then `en-ai`,
+ * then any other English-language version (covers `en-curated`, the only
+ * version the summary layer ever has). Falls back to Hebrew if no English
+ * version is available at all, then to whatever is first in the list.
+ */
+import type { ContentVersion } from "~~/shared/types/content";
+
+const ENGLISH_PRIORITY_ORDER = ["en-sefaria-community", "en-ai"];
+
+export type VersionsById = Map<string, ContentVersion>;
+
+export const buildVersionsById = (versions: ContentVersion[]): VersionsById =>
+  new Map(versions.map((version) => [version.id, version]));
+
+export const resolveDefaultVersion = (
+  available: string[],
+  uiLocale: string,
+  versionsById: VersionsById,
+): string | null => {
+  if (available.length === 0) return null;
+
+  const isLanguage = (id: string, language: string) =>
+    versionsById.get(id)?.language === language;
+
+  if (uiLocale === "he") {
+    const hebrew = available.find((id) => isLanguage(id, "he"));
+    if (hebrew) return hebrew;
+  }
+
+  for (const preferred of ENGLISH_PRIORITY_ORDER) {
+    if (available.includes(preferred)) return preferred;
+  }
+
+  const anyEnglish = available.find((id) => isLanguage(id, "en"));
+  if (anyEnglish) return anyEnglish;
+
+  const anyHebrew = available.find((id) => isLanguage(id, "he"));
+  if (anyHebrew) return anyHebrew;
+
+  return available[0] ?? null;
+};

--- a/app/utils/sanitizeHtml.ts
+++ b/app/utils/sanitizeHtml.ts
@@ -70,6 +70,20 @@ const escapeAttr = (value: string): string =>
 const isSafeHref = (href: string): boolean => !/^\s*javascript:/i.test(href);
 
 /**
+ * Sefaria's own site-relative cross-reference links — e.g. a "List of
+ * Questions" item linking to its answer:
+ * `href="/Talmud_Eser_HaSefirot,_Section_I,_List_of_Answers_on_Topics_55"`.
+ * That path doesn't exist on this site (only `#op-N`/`#seif-N` in-page
+ * fragments do) — Nitro's prerender crawler would otherwise follow it as an
+ * internal route and 404. Rewritten to an absolute sefaria.org link instead
+ * of stripped, since it's a genuinely useful cross-reference for the
+ * reader, just not one this site can serve itself.
+ */
+const SEFARIA_ORIGIN = "https://www.sefaria.org";
+const isSiteRelativeHref = (href: string): boolean =>
+  href.startsWith("/") && !href.startsWith("//");
+
+/**
  * Converts each Sefaria footnote-marker/footnote pair into an opaque
  * placeholder token, stashing the (unescaped) footnote text in `footnotes`
  * by index:
@@ -115,15 +129,31 @@ const sanitizeTag = (
 
   const allowedForTag = ALLOWED_ATTRS[tagName] ?? [];
   const attrs: string[] = [];
+  let rewroteSiteRelativeHref = false;
 
   for (const match of attrString.matchAll(ATTR_PAIR_RE)) {
     const name = (match[1] as string).toLowerCase();
     if (!allowedForTag.includes(name)) continue;
 
-    const value = match[3] ?? match[4] ?? match[5] ?? "";
-    if (name === "href" && !isSafeHref(value)) continue;
+    let value = match[3] ?? match[4] ?? match[5] ?? "";
+    if (name === "href") {
+      if (!isSafeHref(value)) continue;
+      if (isSiteRelativeHref(value)) {
+        value = `${SEFARIA_ORIGIN}${value}`;
+        rewroteSiteRelativeHref = true;
+      }
+    }
 
     attrs.push(`${name}="${escapeAttr(value)}"`);
+  }
+
+  // A rewritten Sefaria link now points off-site — open it in a new tab
+  // rather than navigating the reader away mid-chapter. `target`/`rel`
+  // aren't part of `ALLOWED_ATTRS.a` (nothing in the source content should
+  // control them), these are synthesized only for links this function
+  // itself just rewrote.
+  if (rewroteSiteRelativeHref) {
+    attrs.push('target="_blank"', 'rel="noopener noreferrer"');
   }
 
   const attrsStr = attrs.length > 0 ? ` ${attrs.join(" ")}` : "";
@@ -143,3 +173,25 @@ export const sanitizeHtml = (html: string): string => {
 
   return output;
 };
+
+const LEGACY_SITE_RELATIVE_HREF_RE = /href="(\/[^"#][^"]*)"/g;
+
+/**
+ * Rewrites a *already-sanitized* segment's remaining Sefaria site-relative
+ * hrefs (see `isSiteRelativeHref` above) to absolute sefaria.org links, with
+ * `target="_blank" rel="noopener noreferrer"`.
+ *
+ * `sanitizeHtml` does this itself for anything imported from here on — this
+ * narrow, standalone pass is only for content committed before this fix
+ * existed (Part 1's Questions/Answers source segments, which do this
+ * cross-referencing). It does a single attribute-level string replace, not
+ * a full re-parse of the html — the reader renders import-sanitized html
+ * as-is (see `SourcePane`), this is a one-off patch for pre-existing
+ * content, not a general render-time re-sanitization pass.
+ */
+export const rewriteLegacySefariaRelativeHrefs = (html: string): string =>
+  html.replace(LEGACY_SITE_RELATIVE_HREF_RE, (full, path: string) =>
+    path.startsWith("//")
+      ? full
+      : `href="${SEFARIA_ORIGIN}${path}" target="_blank" rel="noopener noreferrer"`,
+  );

--- a/app/utils/sourceSegments.ts
+++ b/app/utils/sourceSegments.ts
@@ -1,0 +1,50 @@
+/**
+ * Pure helpers over `SourceSegment[]` for the reader's source pane and the
+ * summary pane's heading-mini-toc fallback.
+ */
+import type { SourceSegment } from "~~/shared/types/content";
+
+/** DOM id a source segment renders with — the mini-toc's jump target (`activateAnchor`). */
+export const sourceSegmentAnchorId = (n: number): string => `seif-${n}`;
+
+const LEADING_SEIF_NUMBER_RE = /^(\d+)\.\s*/;
+
+/**
+ * English source segments imported from Sefaria carry a leading `"N. "`
+ * prefix that duplicates the segment's own `n` (e.g. `"1. Explaining the
+ * concept…"` for segment `n: 1`) — the Hebrew edition has no such prefix.
+ * Strips it for display when (and only when) the number matches `n`, so an
+ * incidental leading number that isn't the seif number is left alone. Pure
+ * and render-only — never mutates the content files themselves.
+ */
+export const stripLeadingSeifNumber = (html: string, n: number): string => {
+  const match = html.match(LEADING_SEIF_NUMBER_RE);
+  if (!match) return html;
+
+  const matchedNumber = Number.parseInt(match[1] as string, 10);
+  if (matchedNumber !== n) return html;
+
+  return html.slice(match[0].length);
+};
+
+export interface MiniTocEntry {
+  anchorId: string;
+  label: string;
+}
+
+/**
+ * Builds the summary pane's fallback mini-table-of-contents from a source
+ * version's segments: one entry per segment, labelled by its `heading` where
+ * the version has one (only chapters 1-2's Hebrew edition do, currently),
+ * falling back to a generic "Seif N" label otherwise — so the entry list is
+ * never shorter than the chapter's own seif count, and the summary pane is
+ * never an empty box even for a chapter with no `heading` data at all.
+ */
+export const sourceMiniTocEntries = (
+  segments: SourceSegment[],
+  seifLabel: (n: number) => string,
+): MiniTocEntry[] =>
+  segments.map((segment) => ({
+    anchorId: sourceSegmentAnchorId(segment.n),
+    label: segment.heading?.trim() || seifLabel(segment.n),
+  }));

--- a/app/utils/toc.ts
+++ b/app/utils/toc.ts
@@ -8,6 +8,7 @@ import type {
   TocPart,
   TocVolume,
 } from "~~/shared/types/content";
+import { KIND_ORDER } from "./chapterGrouping";
 
 export interface FlattenedChapter {
   chapter: TocChapter;
@@ -21,6 +22,21 @@ export interface Breadcrumb {
   chapter: TocChapter;
 }
 
+/**
+ * A part's chapters in true reading order: kind first (`KIND_ORDER` —
+ * chapter, then inner-observation, then questions, then answers), `number`
+ * within a kind second. `TocChapter.number` alone is only unique per kind
+ * (e.g. `chapter` chapters 1-2 and `inner-observation` chapters 1-10 both
+ * start at 1), so sorting by `number` alone would interleave kinds instead
+ * of reading through one before the next.
+ */
+const orderedChapters = (chapters: TocChapter[]): TocChapter[] =>
+  [...chapters].sort(
+    (a, b) =>
+      KIND_ORDER.indexOf(a.kind) - KIND_ORDER.indexOf(b.kind) ||
+      a.number - b.number,
+  );
+
 /** Flattens a `Toc` into every chapter, in volume -> part -> chapter reading order. */
 export const flattenChapters = (toc: Toc): FlattenedChapter[] => {
   const volumes = [...toc.volumes].sort((a, b) => a.number - b.number);
@@ -30,9 +46,7 @@ export const flattenChapters = (toc: Toc): FlattenedChapter[] => {
     const parts = [...volume.parts].sort((a, b) => a.number - b.number);
 
     for (const part of parts) {
-      const chapters = [...part.chapters].sort((a, b) => a.number - b.number);
-
-      for (const chapter of chapters) {
+      for (const chapter of orderedChapters(part.chapters)) {
         flattened.push({ chapter, part, volume });
       }
     }

--- a/i18n/locales/en.json
+++ b/i18n/locales/en.json
@@ -25,7 +25,29 @@
   },
   "reader": {
     "aiTranslated": "AI translated",
-    "hebrewOnly": "Hebrew only"
+    "hebrewOnly": "Hebrew only",
+    "pane": {
+      "summary": "Summary",
+      "source": "Source",
+      "commentary": "Commentary"
+    },
+    "versionLabel": "Edition",
+    "commentarySection": {
+      "ohr-pnimi": "Inner Light",
+      "histaklut-pnimit": "Inner Observation"
+    },
+    "commentaryEmpty": "No commentary available for this chapter yet.",
+    "sourceEmpty": "No source text available for this chapter yet.",
+    "summaryEmpty": "No summary available for this chapter yet.",
+    "miniTocTitle": "In this chapter",
+    "seifLabel": "Seif {n}",
+    "missingAnchor": {
+      "message": "Not available in this edition.",
+      "switchToHebrew": "Switch to Hebrew"
+    },
+    "prevChapter": "Previous chapter",
+    "nextChapter": "Next chapter",
+    "chapterNav": "Chapter navigation"
   },
   "home": {
     "description": "Talmud Eser Sefirot, read as aligned summary, source, and commentary — in English and Hebrew.",

--- a/i18n/locales/he.json
+++ b/i18n/locales/he.json
@@ -25,7 +25,29 @@
   },
   "reader": {
     "aiTranslated": "תרגום בינה מלאכותית",
-    "hebrewOnly": "בעברית בלבד"
+    "hebrewOnly": "בעברית בלבד",
+    "pane": {
+      "summary": "תקציר",
+      "source": "מקור",
+      "commentary": "פירוש"
+    },
+    "versionLabel": "מהדורה",
+    "commentarySection": {
+      "ohr-pnimi": "אור פנימי",
+      "histaklut-pnimit": "הסתכלות פנימית"
+    },
+    "commentaryEmpty": "אין עדיין פירוש זמין לפרק זה.",
+    "sourceEmpty": "אין עדיין טקסט מקור זמין לפרק זה.",
+    "summaryEmpty": "אין עדיין תקציר זמין לפרק זה.",
+    "miniTocTitle": "בפרק זה",
+    "seifLabel": "סעיף {n}",
+    "missingAnchor": {
+      "message": "לא זמין במהדורה זו.",
+      "switchToHebrew": "עבור לעברית"
+    },
+    "prevChapter": "הפרק הקודם",
+    "nextChapter": "הפרק הבא",
+    "chapterNav": "ניווט בין פרקים"
   },
   "home": {
     "description": "תלמוד עשר הספירות, לקריאה כשכבות מיושרות של תקציר, מקור ופירוש — באנגלית ובעברית.",

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -3,6 +3,21 @@ import { readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import type { Toc } from "./shared/types/content";
 
+// Mirrors `KIND_ORDER` in `app/utils/chapterGrouping.ts` — duplicated
+// (rather than imported) on purpose: this file is type-checked as part of
+// the project *root* (not through the Nuxt app's own tsconfig/path-alias
+// setup), so pulling in an `app/` module here drags its `~~/shared/types/content`
+// import along with it and breaks under the root tsconfig's path mapping.
+// Keep in sync if the reading-order rule ever changes.
+const CHAPTER_KIND_ORDER = [
+  "chapter",
+  "inner-observation",
+  "questions-terminology",
+  "questions-topics",
+  "answers-terminology",
+  "answers-topics",
+] as const;
+
 // `nitro.prerender.routes` needs each volume's contents page listed
 // explicitly (see the comment below) — read straight from the committed
 // ToC, the same way `scripts/validate-content.ts` reads content JSON, so
@@ -22,6 +37,26 @@ const volumePrerenderRoutes = toc.volumes.flatMap((volume) => [
   `/volumes/volume-${volume.number}`,
   `/he/volumes/volume-${volume.number}`,
 ]);
+
+// `/read/<chapterId>` for every chapter that exists, in both locales.
+// Listed explicitly rather than left to the crawler: a volume's contents
+// page collapses the 54/51-chapter answers-terminology/answers-topics
+// clusters into a single link to their first chapter (see
+// `~/utils/chapterGrouping`), so the crawler alone would never discover
+// chapters 2+ of a cluster. Same kind-then-number reading order as
+// `~/utils/toc`'s `flattenChapters` — irrelevant to prerendering itself,
+// just keeps this list's order legible.
+const readerPrerenderRoutes = toc.volumes.flatMap((volume) =>
+  volume.parts.flatMap((part) =>
+    [...part.chapters]
+      .sort(
+        (a, b) =>
+          CHAPTER_KIND_ORDER.indexOf(a.kind) -
+            CHAPTER_KIND_ORDER.indexOf(b.kind) || a.number - b.number,
+      )
+      .flatMap((chapter) => [`/read/${chapter.id}`, `/he/read/${chapter.id}`]),
+  ),
+);
 
 // https://nuxt.com/docs/api/configuration/nuxt-config
 export default defineNuxtConfig({
@@ -57,14 +92,9 @@ export default defineNuxtConfig({
   // scaffolding task; never ship it (or its localized variants — @nuxtjs/i18n
   // seeds every locale's copy of every static page into the prerender crawl,
   // so each locale prefix needs its own rule) in the generated static site.
-  // /read/** doesn't exist yet — volume contents pages and the homepage CTA
-  // link chapters ahead of time; excluding the routes keeps the crawler from
-  // failing the build on them. The reader task removes these.
   routeRules: {
     "/design-tokens": { prerender: false },
     "/he/design-tokens": { prerender: false },
-    "/read/**": { prerender: false }, // route lands in T7 — remove exclusion then
-    "/he/read/**": { prerender: false }, // route lands in T7 — remove exclusion then
   },
   nitro: {
     prerender: {
@@ -72,8 +102,11 @@ export default defineNuxtConfig({
       // it, but each `/volumes/[volume]` page's own link only exists for
       // Volume 1 (the rest render disabled/"coming soon", with no <a> for
       // the crawler to follow) — list every volume explicitly so all six
-      // contents pages still ship in the generated static site.
-      routes: volumePrerenderRoutes,
+      // contents pages still ship in the generated static site. Reader
+      // routes are listed explicitly for the same reason (see
+      // `readerPrerenderRoutes` above) — the crawler alone would miss most
+      // of the answers-terminology/answers-topics clusters.
+      routes: [...volumePrerenderRoutes, ...readerPrerenderRoutes],
     },
   },
   // Non-standard ports so `pnpm dev` never fights other local dev servers

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
   },
   "dependencies": {
     "@nuxtjs/i18n": "^10.4.1",
+    "@vueuse/core": "^14.3.0",
     "nuxt": "^4.5.0",
     "vue": "^3.5.40",
     "vue-router": "^5.2.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,9 @@ importers:
       '@nuxtjs/i18n':
         specifier: ^10.4.1
         version: 10.4.1(@vue/compiler-dom@3.5.40)(db0@0.3.4)(esbuild@0.28.1)(eslint@10.7.0(jiti@2.7.0)(supports-color@10.2.2))(ioredis@5.11.1(supports-color@10.2.2))(magicast@0.5.3)(rolldown@1.2.0)(rollup@4.62.2)(supports-color@10.2.2)(typescript@5.9.3)(vite@8.1.5(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0))(vue@3.5.40(typescript@5.9.3))
+      '@vueuse/core':
+        specifier: ^14.3.0
+        version: 14.3.0(vue@3.5.40(typescript@5.9.3))
       nuxt:
         specifier: ^4.5.0
         version: 4.5.0(@babel/plugin-syntax-jsx@7.29.7(@babel/core@7.29.7(supports-color@10.2.2)))(@babel/plugin-syntax-typescript@7.29.7(@babel/core@7.29.7(supports-color@10.2.2)))(@types/node@26.1.1)(@vue/compiler-sfc@3.5.40)(crossws@0.4.10(srvx@0.11.22))(db0@0.3.4)(esbuild@0.28.1)(eslint@10.7.0(jiti@2.7.0)(supports-color@10.2.2))(ioredis@5.11.1(supports-color@10.2.2))(lightningcss@1.33.0)(magicast@0.5.3)(optionator@0.9.4)(oxc-parser@0.140.0)(rollup-plugin-visualizer@7.0.1(rolldown@1.2.0)(rollup@4.62.2))(rollup@4.62.2)(srvx@0.11.22)(supports-color@10.2.2)(terser@5.49.0)(tsx@4.23.1)(typescript@5.9.3)(vite@8.1.5(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0))(vue-tsc@3.3.7(typescript@5.9.3))(yaml@2.9.0)
@@ -2292,6 +2295,9 @@ packages:
   '@types/resolve@1.20.2':
     resolution: {integrity: sha512-60BCwRFOZCQhDncwQdxxeOEEkbc5dIMccYLwbxsS4TUNeVECQ/pBJ0j09mrHOl/JJvpRPGwO9SvE4nR2Nb/a4Q==}
 
+  '@types/web-bluetooth@0.0.21':
+    resolution: {integrity: sha512-oIQLCGWtcFZy2JW77j9k8nHzAOpqMHLQejDA48XXMWH6tjCQHz5RCFz1bzsmROyL6PUm+LLnUiI4BCn221inxA==}
+
   '@types/whatwg-mimetype@3.0.2':
     resolution: {integrity: sha512-c2AKvDT8ToxLIOUlN51gTiHXflsfIFisS4pO7pDPoKouJCESkhZnEy623gwP9laCy5lnLDAw1vAzu2vM2YLOrA==}
 
@@ -2661,6 +2667,19 @@ packages:
     peerDependenciesMeta:
       '@vue/server-renderer':
         optional: true
+
+  '@vueuse/core@14.3.0':
+    resolution: {integrity: sha512-aHfz47g0ZhMtTVHmIzMVpJy8ePhhOy68GY5bv110+5DVtZ+W7BsOx+m61UNQqfrWyPztIHIanWa3E2tib3NFIw==}
+    peerDependencies:
+      vue: ^3.5.0
+
+  '@vueuse/metadata@14.3.0':
+    resolution: {integrity: sha512-BwxmbAzwAVF50+MW57GXOUEV61nFBGnlBvrTqj49PqWJu3uw7hdu72ztXeZ33RdZtDY6kO+bfCAE1PCn88Tktw==}
+
+  '@vueuse/shared@14.3.0':
+    resolution: {integrity: sha512-bZpge9eSXwa4ToSiqJ7j6KRwhAsneMFoSz3LMWKQDkqimm3D/tbFlrklrs/IOqC8tEcYmXQZJ6N0UrjhBirVCg==}
+    peerDependencies:
+      vue: ^3.5.0
 
   abbrev@2.0.0:
     resolution: {integrity: sha512-6/mh1E2u2YgEsCHdY0Yx5oW+61gZU+1vXaoiHHrpKeuRNNgFvS+/jrwHiQhB5apAf5oB7UB7E19ol2R2LKH8hQ==}
@@ -7805,6 +7824,8 @@ snapshots:
 
   '@types/resolve@1.20.2': {}
 
+  '@types/web-bluetooth@0.0.21': {}
+
   '@types/whatwg-mimetype@3.0.2': {}
 
   '@types/ws@8.18.1':
@@ -8275,6 +8296,19 @@ snapshots:
       vue-component-type-helpers: 3.3.7
     optionalDependencies:
       '@vue/server-renderer': 3.5.40
+
+  '@vueuse/core@14.3.0(vue@3.5.40(typescript@5.9.3))':
+    dependencies:
+      '@types/web-bluetooth': 0.0.21
+      '@vueuse/metadata': 14.3.0
+      '@vueuse/shared': 14.3.0(vue@3.5.40(typescript@5.9.3))
+      vue: 3.5.40(typescript@5.9.3)
+
+  '@vueuse/metadata@14.3.0': {}
+
+  '@vueuse/shared@14.3.0(vue@3.5.40(typescript@5.9.3))':
+    dependencies:
+      vue: 3.5.40(typescript@5.9.3)
 
   abbrev@2.0.0: {}
 

--- a/tests/unit/commentary-grouping.spec.ts
+++ b/tests/unit/commentary-grouping.spec.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from "vitest";
+import type { CommentaryItem } from "~~/shared/types/content";
+
+const item = (
+  anchorId: string,
+  order: number,
+  section: CommentaryItem["section"],
+): CommentaryItem => ({
+  anchorId,
+  order,
+  label: { en: String(order), he: String(order) },
+  sefariaRef: `x ${order}`,
+  targetSeif: 1,
+  section,
+  html: `item ${anchorId}`,
+});
+
+describe("groupCommentaryBySection", () => {
+  it("groups Ohr Pnimi items under 'ohr-pnimi', sorted by order", () => {
+    const items = [item("op-2", 2, "ohr-pnimi"), item("op-1", 1, "ohr-pnimi")];
+
+    expect(groupCommentaryBySection(items)).toEqual([
+      {
+        section: "ohr-pnimi",
+        items: [item("op-1", 1, "ohr-pnimi"), item("op-2", 2, "ohr-pnimi")],
+      },
+    ]);
+  });
+
+  it("only renders groups that actually have items", () => {
+    const items = [item("op-1", 1, "ohr-pnimi")];
+    const groups = groupCommentaryBySection(items);
+
+    expect(groups).toHaveLength(1);
+    expect(groups[0]?.section).toBe("ohr-pnimi");
+  });
+
+  it("puts Ohr Pnimi before Histaklut Pnimit when both are present", () => {
+    const items = [
+      item("hp-1", 1, "histaklut-pnimit"),
+      item("op-1", 1, "ohr-pnimi"),
+    ];
+
+    expect(groupCommentaryBySection(items).map((g) => g.section)).toEqual([
+      "ohr-pnimi",
+      "histaklut-pnimit",
+    ]);
+  });
+
+  it("returns an empty array for no items", () => {
+    expect(groupCommentaryBySection([])).toEqual([]);
+  });
+});

--- a/tests/unit/commentary-notice.spec.ts
+++ b/tests/unit/commentary-notice.spec.ts
@@ -1,0 +1,107 @@
+import { describe, expect, it } from "vitest";
+import type { CommentaryItem } from "~~/shared/types/content";
+
+const HEBREW = "he-jerusalem-1956";
+
+const commentaryItem = (anchorId: string): CommentaryItem => ({
+  anchorId,
+  order: 1,
+  label: { en: "1", he: "א" },
+  sefariaRef: "x",
+  targetSeif: 1,
+  section: "ohr-pnimi",
+  html: "…",
+});
+
+describe("resolveMissingAnchorNotice", () => {
+  it("is null when no anchor is active", () => {
+    expect(
+      resolveMissingAnchorNotice({
+        activeAnchor: null,
+        anchorOrigin: null,
+        displayedItems: [],
+        selectedVersionId: "en-sefaria-community",
+        hebrewItems: null,
+        hebrewVersionId: HEBREW,
+      }),
+    ).toBeNull();
+  });
+
+  it("is null when the anchor didn't originate from the source pane", () => {
+    expect(
+      resolveMissingAnchorNotice({
+        activeAnchor: "op-1",
+        anchorOrigin: "commentary",
+        displayedItems: [],
+        selectedVersionId: "en-sefaria-community",
+        hebrewItems: null,
+        hebrewVersionId: HEBREW,
+      }),
+    ).toBeNull();
+  });
+
+  it("is null for a summary-origin seif-N jump (not a commentary anchor)", () => {
+    expect(
+      resolveMissingAnchorNotice({
+        activeAnchor: "seif-3",
+        anchorOrigin: "summary",
+        displayedItems: [],
+        selectedVersionId: "en-sefaria-community",
+        hebrewItems: null,
+        hebrewVersionId: HEBREW,
+      }),
+    ).toBeNull();
+  });
+
+  it("is null when the currently-displayed version already has the anchor", () => {
+    expect(
+      resolveMissingAnchorNotice({
+        activeAnchor: "op-1",
+        anchorOrigin: "source",
+        displayedItems: [commentaryItem("op-1")],
+        selectedVersionId: "en-sefaria-community",
+        hebrewItems: null,
+        hebrewVersionId: HEBREW,
+      }),
+    ).toBeNull();
+  });
+
+  it("offers a switch to Hebrew when the anchor is missing but Hebrew has it", () => {
+    expect(
+      resolveMissingAnchorNotice({
+        activeAnchor: "op-9",
+        anchorOrigin: "source",
+        displayedItems: [commentaryItem("op-1")],
+        selectedVersionId: "en-sefaria-community",
+        hebrewItems: [commentaryItem("op-9")],
+        hebrewVersionId: HEBREW,
+      }),
+    ).toEqual({ anchorId: "op-9", canSwitchToHebrew: true });
+  });
+
+  it("doesn't offer a switch when Hebrew doesn't have the anchor either", () => {
+    expect(
+      resolveMissingAnchorNotice({
+        activeAnchor: "op-9",
+        anchorOrigin: "source",
+        displayedItems: [],
+        selectedVersionId: "en-sefaria-community",
+        hebrewItems: null,
+        hebrewVersionId: HEBREW,
+      }),
+    ).toEqual({ anchorId: "op-9", canSwitchToHebrew: false });
+  });
+
+  it("doesn't offer a switch when Hebrew is already the version being shown", () => {
+    expect(
+      resolveMissingAnchorNotice({
+        activeAnchor: "op-9",
+        anchorOrigin: "source",
+        displayedItems: [],
+        selectedVersionId: HEBREW,
+        hebrewItems: [],
+        hebrewVersionId: HEBREW,
+      }),
+    ).toEqual({ anchorId: "op-9", canSwitchToHebrew: false });
+  });
+});

--- a/tests/unit/commentary-pane.spec.ts
+++ b/tests/unit/commentary-pane.spec.ts
@@ -1,0 +1,75 @@
+import { mountSuspended } from "@nuxt/test-utils/runtime";
+import { describe, expect, it } from "vitest";
+import { defineComponent, h } from "vue";
+import CommentaryPane from "~/components/reader/CommentaryPane.vue";
+import type { CommentaryItem } from "~~/shared/types/content";
+
+// `CommentaryPane` reads its scroll container via `useReaderPaneContainer()`,
+// which throws without a `ReaderPane` ancestor — this stub provides just
+// that (not the rest of `ReaderPane`'s header chrome), so the test stays
+// focused on `CommentaryPane` itself.
+const PaneContainerStub = defineComponent({
+  setup(_, { slots }) {
+    const containerRef = provideReaderPaneContainer();
+    return () => h("div", { ref: containerRef }, slots.default?.());
+  },
+});
+
+const items: CommentaryItem[] = [
+  {
+    anchorId: "op-1",
+    order: 1,
+    label: { en: "1", he: "א" },
+    sefariaRef: "x 1",
+    targetSeif: 1,
+    section: "ohr-pnimi",
+    html: "First commentary item",
+  },
+  {
+    anchorId: "op-2",
+    order: 2,
+    label: { en: "2", he: "ב" },
+    sefariaRef: "x 2",
+    targetSeif: 1,
+    section: "ohr-pnimi",
+    html: "Second commentary item",
+  },
+];
+
+describe("CommentaryPane", () => {
+  it("renders items under their section heading", async () => {
+    const wrapper = await mountSuspended(PaneContainerStub, {
+      slots: { default: () => h(CommentaryPane, { items }) },
+    });
+
+    expect(wrapper.text()).toContain("Inner Light");
+    expect(wrapper.text()).toContain("First commentary item");
+    expect(wrapper.text()).toContain("Second commentary item");
+  });
+
+  it("shows an empty-state message when the chapter has no commentary", async () => {
+    const wrapper = await mountSuspended(PaneContainerStub, {
+      slots: { default: () => h(CommentaryPane, { items: [] }) },
+    });
+
+    expect(wrapper.text().toLowerCase()).toContain("no commentary available");
+  });
+
+  it("gives each item an id matching its anchorId, for highlight targeting", async () => {
+    const wrapper = await mountSuspended(PaneContainerStub, {
+      slots: { default: () => h(CommentaryPane, { items }) },
+    });
+
+    expect(wrapper.find("#op-1").exists()).toBe(true);
+    expect(wrapper.find("#op-2").exists()).toBe(true);
+  });
+
+  it("does not throw when a label chip is clicked", async () => {
+    const wrapper = await mountSuspended(PaneContainerStub, {
+      slots: { default: () => h(CommentaryPane, { items }) },
+    });
+
+    const chip = wrapper.findAll("button.tes-anchor")[0];
+    await chip?.trigger("click");
+  });
+});

--- a/tests/unit/reader-anchor-state.spec.ts
+++ b/tests/unit/reader-anchor-state.spec.ts
@@ -6,6 +6,7 @@ describe("initialReaderAnchorState", () => {
       activeAnchor: null,
       anchorOrigin: null,
       activePane: "source",
+      activationSeq: 0,
     });
   });
 });
@@ -22,6 +23,7 @@ describe("activateAnchorState", () => {
       activeAnchor: "op-12",
       anchorOrigin: "source",
       activePane: "source",
+      activationSeq: 1,
     });
   });
 
@@ -37,6 +39,7 @@ describe("activateAnchorState", () => {
       activeAnchor: "op-1",
       anchorOrigin: "commentary",
       activePane: "commentary",
+      activationSeq: 2,
     });
   });
 
@@ -50,6 +53,35 @@ describe("activateAnchorState", () => {
     expect(next.activeAnchor).toBe("seif-3");
     expect(next.anchorOrigin).toBe("summary");
     expect(next.activePane).toBe("summary");
+  });
+
+  it("bumps activationSeq even when re-activating the same id/origin", () => {
+    const first = activateAnchorState(
+      initialReaderAnchorState(),
+      "op-1",
+      "source",
+    );
+    const second = activateAnchorState(first, "op-1", "source");
+
+    expect(second.activeAnchor).toBe("op-1");
+    expect(second.anchorOrigin).toBe("source");
+    expect(second.activationSeq).toBe(first.activationSeq + 1);
+  });
+});
+
+describe("reactivateAnchorState", () => {
+  it("bumps activationSeq without touching the active anchor/origin/pane", () => {
+    const active = activateAnchorState(
+      initialReaderAnchorState(),
+      "op-1",
+      "commentary",
+    );
+    const next = reactivateAnchorState(active);
+
+    expect(next).toEqual({
+      ...active,
+      activationSeq: active.activationSeq + 1,
+    });
   });
 });
 
@@ -66,6 +98,7 @@ describe("clearAnchorState", () => {
       activeAnchor: null,
       anchorOrigin: null,
       activePane: "commentary",
+      activationSeq: active.activationSeq,
     });
   });
 });

--- a/tests/unit/reader-anchor-state.spec.ts
+++ b/tests/unit/reader-anchor-state.spec.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from "vitest";
+
+describe("initialReaderAnchorState", () => {
+  it("starts with no active anchor and the source pane active", () => {
+    expect(initialReaderAnchorState()).toEqual({
+      activeAnchor: null,
+      anchorOrigin: null,
+      activePane: "source",
+    });
+  });
+});
+
+describe("activateAnchorState", () => {
+  it("sets the active anchor, its origin, and makes the origin pane active", () => {
+    const next = activateAnchorState(
+      initialReaderAnchorState(),
+      "op-12",
+      "source",
+    );
+
+    expect(next).toEqual({
+      activeAnchor: "op-12",
+      anchorOrigin: "source",
+      activePane: "source",
+    });
+  });
+
+  it("overwrites a previously-active anchor from a different pane", () => {
+    const first = activateAnchorState(
+      initialReaderAnchorState(),
+      "op-1",
+      "source",
+    );
+    const next = activateAnchorState(first, "op-1", "commentary");
+
+    expect(next).toEqual({
+      activeAnchor: "op-1",
+      anchorOrigin: "commentary",
+      activePane: "commentary",
+    });
+  });
+
+  it("handles a summary-origin seif jump", () => {
+    const next = activateAnchorState(
+      initialReaderAnchorState(),
+      "seif-3",
+      "summary",
+    );
+
+    expect(next.activeAnchor).toBe("seif-3");
+    expect(next.anchorOrigin).toBe("summary");
+    expect(next.activePane).toBe("summary");
+  });
+});
+
+describe("clearAnchorState", () => {
+  it("clears the active anchor and its origin, but keeps the active pane", () => {
+    const active = activateAnchorState(
+      initialReaderAnchorState(),
+      "op-1",
+      "commentary",
+    );
+    const cleared = clearAnchorState(active);
+
+    expect(cleared).toEqual({
+      activeAnchor: null,
+      anchorOrigin: null,
+      activePane: "commentary",
+    });
+  });
+});

--- a/tests/unit/reader-anchor-sync.spec.ts
+++ b/tests/unit/reader-anchor-sync.spec.ts
@@ -1,0 +1,107 @@
+// Integration coverage for the reader's two-way anchor sync: a small tree
+// composing the real `ReaderShell` (provides `useReaderState`), two
+// `ReaderPane`-style containers (via `provideReaderPaneContainer`), and the
+// real `SourcePane`/`CommentaryPane` — the shape production actually uses,
+// minus `ReaderToolbar`/the version-select chrome, which aren't relevant
+// here. Covers the acceptance scenario directly: clicking a source anchor
+// highlights + scrolls the matching commentary item, and vice versa.
+import { mountSuspended } from "@nuxt/test-utils/runtime";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { defineComponent, h, nextTick } from "vue";
+import CommentaryPane from "~/components/reader/CommentaryPane.vue";
+import SourcePane from "~/components/reader/SourcePane.vue";
+import type { CommentaryItem, SourceSegment } from "~~/shared/types/content";
+
+const PaneContainerStub = defineComponent({
+  setup(_, { slots }) {
+    const containerRef = provideReaderPaneContainer();
+    return () => h("div", { ref: containerRef }, slots.default?.());
+  },
+});
+
+const ReaderTree = defineComponent({
+  props: {
+    segments: { type: Array as () => SourceSegment[], required: true },
+    items: { type: Array as () => CommentaryItem[], required: true },
+  },
+  setup(props) {
+    useReaderState();
+    return () =>
+      h("div", [
+        h(PaneContainerStub, null, () =>
+          h(SourcePane, { segments: props.segments }),
+        ),
+        h(PaneContainerStub, null, () =>
+          h(CommentaryPane, { items: props.items }),
+        ),
+      ]);
+  },
+});
+
+const segments: SourceSegment[] = [
+  {
+    n: 1,
+    sefariaRef: "x 1",
+    html: 'Text with <a class="tes-anchor" href="#op-1" data-anchor="op-1">א</a> an anchor.',
+    anchors: ["op-1"],
+  },
+];
+
+const items: CommentaryItem[] = [
+  {
+    anchorId: "op-1",
+    order: 1,
+    label: { en: "1", he: "א" },
+    sefariaRef: "y 1",
+    targetSeif: 1,
+    section: "ohr-pnimi",
+    html: "Inner Light on the first anchor.",
+  },
+];
+
+describe("reader anchor sync", () => {
+  beforeEach(() => {
+    Element.prototype.scrollIntoView = vi.fn();
+  });
+
+  it("highlights and scrolls the commentary item when its source anchor is clicked", async () => {
+    const wrapper = await mountSuspended(ReaderTree, {
+      props: { segments, items },
+    });
+
+    const anchor = wrapper.find('a.tes-anchor[data-anchor="op-1"]');
+    expect(anchor.exists()).toBe(true);
+
+    await anchor.trigger("click");
+    await nextTick();
+
+    const commentaryTarget = wrapper.find("#op-1");
+    expect(commentaryTarget.exists()).toBe(true);
+    expect(
+      (commentaryTarget.element as HTMLElement).classList.contains(
+        "is-highlighted",
+      ),
+    ).toBe(true);
+    expect(Element.prototype.scrollIntoView).toHaveBeenCalled();
+  });
+
+  it("highlights the source seif's anchor chip when the commentary item is clicked", async () => {
+    const wrapper = await mountSuspended(ReaderTree, {
+      props: { segments, items },
+    });
+
+    const chip = wrapper.find("#op-1 button.tes-anchor");
+    expect(chip.exists()).toBe(true);
+
+    await chip.trigger("click");
+    await nextTick();
+
+    const sourceAnchor = wrapper.find('a.tes-anchor[data-anchor="op-1"]');
+    expect(sourceAnchor.exists()).toBe(true);
+    expect(
+      (sourceAnchor.element as HTMLElement).classList.contains(
+        "is-highlighted",
+      ),
+    ).toBe(true);
+  });
+});

--- a/tests/unit/reader-anchor-sync.spec.ts
+++ b/tests/unit/reader-anchor-sync.spec.ts
@@ -10,6 +10,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { defineComponent, h, nextTick } from "vue";
 import CommentaryPane from "~/components/reader/CommentaryPane.vue";
 import SourcePane from "~/components/reader/SourcePane.vue";
+import type { ReaderState } from "~/composables/useReaderState";
 import type { CommentaryItem, SourceSegment } from "~~/shared/types/content";
 
 const PaneContainerStub = defineComponent({
@@ -19,22 +20,26 @@ const PaneContainerStub = defineComponent({
   },
 });
 
+// Setup returns the shared reader state (rather than only a render
+// function) so tests can drive `reactivateAnchor` directly, the same way
+// the reader page does after a version switch.
 const ReaderTree = defineComponent({
   props: {
     segments: { type: Array as () => SourceSegment[], required: true },
     items: { type: Array as () => CommentaryItem[], required: true },
   },
-  setup(props) {
-    useReaderState();
-    return () =>
-      h("div", [
-        h(PaneContainerStub, null, () =>
-          h(SourcePane, { segments: props.segments }),
-        ),
-        h(PaneContainerStub, null, () =>
-          h(CommentaryPane, { items: props.items }),
-        ),
-      ]);
+  setup() {
+    return useReaderState();
+  },
+  render() {
+    return h("div", [
+      h(PaneContainerStub, null, () =>
+        h(SourcePane, { segments: this.segments }),
+      ),
+      h(PaneContainerStub, null, () =>
+        h(CommentaryPane, { items: this.items }),
+      ),
+    ]);
   },
 });
 
@@ -103,5 +108,83 @@ describe("reader anchor sync", () => {
         "is-highlighted",
       ),
     ).toBe(true);
+  });
+
+  it("re-fires the highlight/scroll when the same anchor is activated again", async () => {
+    const wrapper = await mountSuspended(ReaderTree, {
+      props: { segments, items },
+    });
+
+    const anchor = wrapper.find('a.tes-anchor[data-anchor="op-1"]');
+
+    await anchor.trigger("click");
+    await nextTick();
+    expect(Element.prototype.scrollIntoView).toHaveBeenCalledTimes(1);
+
+    // Re-clicking the same anchor doesn't change `activeAnchor`/
+    // `anchorOrigin`, but should still re-fire the (possibly already-faded)
+    // highlight rather than being a no-op.
+    await anchor.trigger("click");
+    await nextTick();
+    expect(Element.prototype.scrollIntoView).toHaveBeenCalledTimes(2);
+  });
+
+  it("re-fires the highlight once a version switch renders the previously-missing item", async () => {
+    const wrapper = await mountSuspended(ReaderTree, {
+      props: { segments, items: [] },
+    });
+
+    const anchor = wrapper.find('a.tes-anchor[data-anchor="op-1"]');
+    await anchor.trigger("click");
+    await nextTick();
+
+    // The commentary version currently shown has nothing for this anchor
+    // (e.g. its English commentary is missing) - nothing to highlight yet.
+    expect(wrapper.find("#op-1").exists()).toBe(false);
+    expect(Element.prototype.scrollIntoView).not.toHaveBeenCalled();
+
+    // Simulate the "Switch to Hebrew" reconciliation path: the commentary
+    // pane now renders an item for the same anchor, and the page calls
+    // `reactivateAnchor()` since `activeAnchor`/`anchorOrigin` themselves
+    // didn't change.
+    await wrapper.setProps({ items });
+    (wrapper.vm as unknown as ReaderState).reactivateAnchor();
+    await nextTick();
+
+    const commentaryTarget = wrapper.find("#op-1");
+    expect(commentaryTarget.exists()).toBe(true);
+    expect(
+      (commentaryTarget.element as HTMLElement).classList.contains(
+        "is-highlighted",
+      ),
+    ).toBe(true);
+    expect(Element.prototype.scrollIntoView).toHaveBeenCalled();
+  });
+
+  it("doesn't double-activate when Enter fires both the container keydown and the anchor's native click", async () => {
+    const wrapper = await mountSuspended(ReaderTree, {
+      props: { segments, items },
+    });
+
+    const anchor = wrapper.find('a.tes-anchor[data-anchor="op-1"]')
+      .element as HTMLElement;
+
+    // A focused anchor's native Enter activation dispatches both a
+    // `keydown` and a synthesized `click`, synchronously, in the same task
+    // - dispatch both directly (no `await`/`trigger` in between, which
+    // would insert a microtask tick) to reproduce that exactly.
+    anchor.dispatchEvent(
+      new KeyboardEvent("keydown", {
+        key: "Enter",
+        bubbles: true,
+        cancelable: true,
+      }),
+    );
+    anchor.dispatchEvent(
+      new MouseEvent("click", { bubbles: true, cancelable: true }),
+    );
+    await nextTick();
+
+    expect(Element.prototype.scrollIntoView).toHaveBeenCalledTimes(1);
   });
 });

--- a/tests/unit/reader-pane.spec.ts
+++ b/tests/unit/reader-pane.spec.ts
@@ -1,0 +1,108 @@
+import { mountSuspended } from "@nuxt/test-utils/runtime";
+import { describe, expect, it } from "vitest";
+import ReaderPane from "~/components/reader/ReaderPane.vue";
+import type { ContentVersion } from "~~/shared/types/content";
+
+const hebrewMeta: ContentVersion = {
+  id: "he-jerusalem-1956",
+  language: "he",
+  direction: "rtl",
+  title: "ירושלים",
+  license: "Public Domain",
+  source: "sefaria",
+};
+
+const aiMeta: ContentVersion = {
+  id: "en-ai",
+  language: "en",
+  direction: "ltr",
+  title: "English (AI translation)",
+  license: "CC0",
+  source: "ai",
+  translatedFrom: "he-jerusalem-1956",
+};
+
+describe("ReaderPane", () => {
+  it("sets dir/lang on the scroll container from the version metadata", async () => {
+    const wrapper = await mountSuspended(ReaderPane, {
+      props: {
+        title: "Source",
+        versionOptions: [],
+        modelValue: "he-jerusalem-1956",
+        meta: hebrewMeta,
+      },
+    });
+
+    const container = wrapper.find('[lang="he"]');
+    expect(container.exists()).toBe(true);
+    expect(container.attributes("dir")).toBe("rtl");
+  });
+
+  it("shows the AI-translated badge only for an AI-sourced version", async () => {
+    const wrapper = await mountSuspended(ReaderPane, {
+      props: {
+        title: "Source",
+        versionOptions: [],
+        modelValue: "en-ai",
+        meta: aiMeta,
+      },
+    });
+
+    expect(wrapper.text()).toContain("AI translated");
+  });
+
+  it("hides the AI badge for a non-AI version", async () => {
+    const wrapper = await mountSuspended(ReaderPane, {
+      props: {
+        title: "Source",
+        versionOptions: [],
+        modelValue: "he-jerusalem-1956",
+        meta: hebrewMeta,
+      },
+    });
+
+    expect(wrapper.text()).not.toContain("AI translated");
+  });
+
+  it("only renders the version <select> when there's more than one version", async () => {
+    const single = await mountSuspended(ReaderPane, {
+      props: {
+        title: "Source",
+        versionOptions: [{ id: "he-jerusalem-1956", label: "Hebrew" }],
+        modelValue: "he-jerusalem-1956",
+        meta: hebrewMeta,
+      },
+    });
+    expect(single.find("select").exists()).toBe(false);
+
+    const multiple = await mountSuspended(ReaderPane, {
+      props: {
+        title: "Source",
+        versionOptions: [
+          { id: "he-jerusalem-1956", label: "Hebrew" },
+          { id: "en-ai", label: "English (AI)" },
+        ],
+        modelValue: "he-jerusalem-1956",
+        meta: hebrewMeta,
+      },
+    });
+    expect(multiple.find("select").exists()).toBe(true);
+  });
+
+  it("emits update:modelValue when the version <select> changes", async () => {
+    const wrapper = await mountSuspended(ReaderPane, {
+      props: {
+        title: "Source",
+        versionOptions: [
+          { id: "he-jerusalem-1956", label: "Hebrew" },
+          { id: "en-ai", label: "English (AI)" },
+        ],
+        modelValue: "he-jerusalem-1956",
+        meta: hebrewMeta,
+      },
+    });
+
+    await wrapper.find("select").setValue("en-ai");
+    expect(wrapper.emitted("update:modelValue")).toEqual([["en-ai"]]);
+  });
+});

--- a/tests/unit/reader-toolbar.spec.ts
+++ b/tests/unit/reader-toolbar.spec.ts
@@ -1,0 +1,87 @@
+import { mountSuspended } from "@nuxt/test-utils/runtime";
+import { describe, expect, it } from "vitest";
+import ReaderToolbar from "~/components/reader/ReaderToolbar.vue";
+import type { FlattenedChapter } from "~/utils/toc";
+
+const chapterEntry = (id: string, title: string): FlattenedChapter => ({
+  chapter: {
+    id,
+    kind: "chapter",
+    number: 1,
+    title: { en: title, he: title },
+    availableLayers: ["source"],
+    availableVersions: {
+      summary: [],
+      source: ["he-jerusalem-1956"],
+      commentary: [],
+    },
+  },
+  part: {
+    id: "part-01",
+    number: 1,
+    sefariaNode: "x",
+    title: { en: "Part 1", he: "חלק 1" },
+    chapters: [],
+  },
+  volume: {
+    id: "volume-01",
+    number: 1,
+    title: { en: "Volume 1", he: "כרך 1" },
+    parts: [],
+  },
+});
+
+const breadcrumbItems = [
+  { label: "Six volumes", to: "/volumes" },
+  { label: "Volume 1", to: "/volumes/volume-1" },
+  { label: "Part 1 · Chapter 1" },
+];
+
+describe("ReaderToolbar", () => {
+  it("renders the breadcrumb chain", async () => {
+    const wrapper = await mountSuspended(ReaderToolbar, {
+      props: { breadcrumbItems, prev: null, next: null },
+    });
+
+    expect(wrapper.text()).toContain("Six volumes");
+    expect(wrapper.text()).toContain("Volume 1");
+    expect(wrapper.text()).toContain("Part 1 · Chapter 1");
+  });
+
+  it("links to the previous and next chapters when they exist", async () => {
+    const prev = chapterEntry("part-01/chapter-01", "Chapter 1");
+    const next = chapterEntry("part-01/chapter-02", "Chapter 2");
+
+    const wrapper = await mountSuspended(ReaderToolbar, {
+      props: { breadcrumbItems, prev, next },
+    });
+
+    const links = wrapper.findAll("a");
+    expect(
+      links.some((link) =>
+        link.attributes("href")?.includes("/read/part-01/chapter-01"),
+      ),
+    ).toBe(true);
+    expect(
+      links.some((link) =>
+        link.attributes("href")?.includes("/read/part-01/chapter-02"),
+      ),
+    ).toBe(true);
+    expect(wrapper.text()).toContain("Chapter 1");
+    expect(wrapper.text()).toContain("Chapter 2");
+  });
+
+  it("disables prev/next at the corpus edges without rendering a link", async () => {
+    const wrapper = await mountSuspended(ReaderToolbar, {
+      props: { breadcrumbItems, prev: null, next: null },
+    });
+
+    const readLinks = wrapper
+      .findAll("a")
+      .filter((link) => link.attributes("href")?.includes("/read/"));
+    expect(readLinks).toHaveLength(0);
+
+    const disabled = wrapper.findAll("[aria-disabled='true']");
+    expect(disabled.length).toBe(2);
+  });
+});

--- a/tests/unit/reader-versions.spec.ts
+++ b/tests/unit/reader-versions.spec.ts
@@ -1,0 +1,97 @@
+import { describe, expect, it } from "vitest";
+import type { ContentVersion } from "~~/shared/types/content";
+
+const versions: ContentVersion[] = [
+  {
+    id: "he-jerusalem-1956",
+    language: "he",
+    direction: "rtl",
+    title: "ירושלים",
+    license: "Public Domain",
+    source: "sefaria",
+  },
+  {
+    id: "en-sefaria-community",
+    language: "en",
+    direction: "ltr",
+    title: "Sefaria Community Translation",
+    license: "CC0",
+    source: "sefaria",
+  },
+  {
+    id: "en-ai",
+    language: "en",
+    direction: "ltr",
+    title: "English (AI translation)",
+    license: "CC0",
+    source: "ai",
+    translatedFrom: "he-jerusalem-1956",
+  },
+  {
+    id: "en-curated",
+    language: "en",
+    direction: "ltr",
+    title: "Read TES Curated Summary",
+    license: "CC-BY",
+    source: "curated",
+  },
+];
+
+const versionsById = buildVersionsById(versions);
+
+describe("resolveDefaultVersion", () => {
+  it("picks Hebrew for a Hebrew UI locale when a Hebrew version is available", () => {
+    expect(
+      resolveDefaultVersion(
+        ["en-sefaria-community", "he-jerusalem-1956"],
+        "he",
+        versionsById,
+      ),
+    ).toBe("he-jerusalem-1956");
+  });
+
+  it("picks en-sefaria-community over en-ai for an English UI locale", () => {
+    expect(
+      resolveDefaultVersion(
+        ["he-jerusalem-1956", "en-sefaria-community", "en-ai"],
+        "en",
+        versionsById,
+      ),
+    ).toBe("en-sefaria-community");
+  });
+
+  it("falls back to en-ai when en-sefaria-community isn't available", () => {
+    expect(
+      resolveDefaultVersion(["he-jerusalem-1956", "en-ai"], "en", versionsById),
+    ).toBe("en-ai");
+  });
+
+  it("falls back to Hebrew for an English UI locale with no English version at all", () => {
+    expect(
+      resolveDefaultVersion(["he-jerusalem-1956"], "en", versionsById),
+    ).toBe("he-jerusalem-1956");
+  });
+
+  it("falls back to the best English version for a Hebrew UI locale with no Hebrew version", () => {
+    expect(
+      resolveDefaultVersion(
+        ["en-ai", "en-sefaria-community"],
+        "he",
+        versionsById,
+      ),
+    ).toBe("en-sefaria-community");
+  });
+
+  it("falls back to any other English version (en-curated) when neither priority id is present", () => {
+    expect(resolveDefaultVersion(["en-curated"], "en", versionsById)).toBe(
+      "en-curated",
+    );
+    expect(resolveDefaultVersion(["en-curated"], "he", versionsById)).toBe(
+      "en-curated",
+    );
+  });
+
+  it("returns null for an empty list", () => {
+    expect(resolveDefaultVersion([], "en", versionsById)).toBeNull();
+  });
+});

--- a/tests/unit/reader-versions.spec.ts
+++ b/tests/unit/reader-versions.spec.ts
@@ -1,5 +1,7 @@
-import { describe, expect, it } from "vitest";
-import type { ContentVersion } from "~~/shared/types/content";
+import { mountSuspended } from "@nuxt/test-utils/runtime";
+import { beforeEach, describe, expect, it } from "vitest";
+import { defineComponent, nextTick } from "vue";
+import type { ContentVersion, TocChapter } from "~~/shared/types/content";
 
 const versions: ContentVersion[] = [
   {
@@ -93,5 +95,89 @@ describe("resolveDefaultVersion", () => {
 
   it("returns null for an empty list", () => {
     expect(resolveDefaultVersion([], "en", versionsById)).toBeNull();
+  });
+});
+
+describe("useReaderVersions (hydration)", () => {
+  const STORAGE_KEY = "readtes:reader-versions";
+
+  const chapter: TocChapter = {
+    id: "part-01/chapter-01",
+    kind: "chapter",
+    number: 1,
+    title: { en: "Chapter 1", he: "פרק 1" },
+    availableLayers: ["source"],
+    availableVersions: {
+      summary: [],
+      source: ["he-jerusalem-1956", "en-sefaria-community"],
+      commentary: [],
+    },
+  };
+
+  // Default UI locale in tests is "en" (see nuxt.config.ts), so the
+  // default-rule resolution for this chapter's source layer is the English
+  // version — distinct from the Hebrew override persisted below.
+  const SSR_DEFAULT = "en-sefaria-community";
+  const PERSISTED_OVERRIDE = "he-jerusalem-1956";
+
+  const Host = defineComponent({
+    setup() {
+      const readerVersions = useReaderVersions(chapter, versions);
+      // Captured synchronously in `setup`, i.e. before this component's
+      // `onMounted` runs — this is the value the very first render (and,
+      // for a real page load, the prerendered SSR markup) resolves to.
+      const preMountSource = readerVersions.source.value;
+      return { readerVersions, preMountSource };
+    },
+    render: () => null,
+  });
+
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it("resolves to the SSR default before mount, then reconciles to the persisted override after mount", async () => {
+    localStorage.setItem(
+      STORAGE_KEY,
+      JSON.stringify({
+        source: PERSISTED_OVERRIDE,
+        commentary: null,
+        summary: null,
+      }),
+    );
+
+    const wrapper = await mountSuspended(Host);
+
+    // The pre-mount value (captured in `setup`, matching what SSR would
+    // have rendered) must equal the default-rule resolution, not the
+    // persisted override — this is the hydration-mismatch guard.
+    expect(wrapper.vm.preMountSource).toBe(SSR_DEFAULT);
+
+    await nextTick();
+
+    // Post-mount, the persisted override reconciles in.
+    expect(wrapper.vm.readerVersions.source.value).toBe(PERSISTED_OVERRIDE);
+  });
+
+  it("still resolves to the default rule post-mount when nothing is persisted", async () => {
+    const wrapper = await mountSuspended(Host);
+    await nextTick();
+
+    expect(wrapper.vm.readerVersions.source.value).toBe(SSR_DEFAULT);
+  });
+
+  it("keeps persisting a version choice via setVersion", async () => {
+    const wrapper = await mountSuspended(Host);
+    await nextTick();
+
+    wrapper.vm.readerVersions.setVersion("source", PERSISTED_OVERRIDE);
+    await nextTick();
+
+    expect(wrapper.vm.readerVersions.source.value).toBe(PERSISTED_OVERRIDE);
+    expect(JSON.parse(localStorage.getItem(STORAGE_KEY) ?? "{}")).toEqual({
+      source: PERSISTED_OVERRIDE,
+      commentary: null,
+      summary: null,
+    });
   });
 });

--- a/tests/unit/sanitize.spec.ts
+++ b/tests/unit/sanitize.spec.ts
@@ -54,6 +54,29 @@ describe("sanitizeHtml — attribute stripping", () => {
     expect(sanitizeHtml(html)).toBe('<a class="ok">click</a>');
   });
 
+  it("rewrites a Sefaria site-relative href to an absolute sefaria.org link, opened in a new tab", () => {
+    const html =
+      '<a href="/Talmud_Eser_HaSefirot,_Section_I,_List_of_Answers_on_Topics_55">לתשובה</a>';
+
+    expect(sanitizeHtml(html)).toBe(
+      '<a href="https://www.sefaria.org/Talmud_Eser_HaSefirot,_Section_I,_List_of_Answers_on_Topics_55" target="_blank" rel="noopener noreferrer">לתשובה</a>',
+    );
+  });
+
+  it("leaves an in-page fragment href (#op-N) alone", () => {
+    const html = '<a href="#op-1" class="tes-anchor" data-anchor="op-1">א</a>';
+
+    expect(sanitizeHtml(html)).toBe(
+      '<a href="#op-1" class="tes-anchor" data-anchor="op-1">א</a>',
+    );
+  });
+
+  it("leaves a protocol-relative href (//example.com) alone", () => {
+    const html = '<a href="//example.com/x">link</a>';
+
+    expect(sanitizeHtml(html)).toBe('<a href="//example.com/x">link</a>');
+  });
+
   it("strips all attributes from tags with no allowlisted attributes", () => {
     expect(sanitizeHtml('<b class="x" style="color:red">bold</b>')).toBe(
       "<b>bold</b>",
@@ -144,6 +167,29 @@ describe("sanitizeHtml — nested/malformed tags", () => {
   it("handles a disallowed tag nested inside an allowed one", () => {
     expect(sanitizeHtml('<span class="x"><div>inner</div></span>')).toBe(
       '<span class="x">inner</span>',
+    );
+  });
+});
+
+describe("rewriteLegacySefariaRelativeHrefs", () => {
+  it("rewrites a Sefaria site-relative href already baked into committed content", () => {
+    const html =
+      'מה המה המושגים המושללים. <small>(<a href="/Talmud_Eser_HaSefirot,_Section_I,_List_of_Answers_on_Topics_55">לתשובה</a>)</small>';
+
+    expect(rewriteLegacySefariaRelativeHrefs(html)).toBe(
+      'מה המה המושגים המושללים. <small>(<a href="https://www.sefaria.org/Talmud_Eser_HaSefirot,_Section_I,_List_of_Answers_on_Topics_55" target="_blank" rel="noopener noreferrer">לתשובה</a>)</small>',
+    );
+  });
+
+  it("leaves an in-page #op-N fragment href alone", () => {
+    const html = '<a class="tes-anchor" href="#op-1" data-anchor="op-1">א</a>';
+
+    expect(rewriteLegacySefariaRelativeHrefs(html)).toBe(html);
+  });
+
+  it("leaves html with no hrefs at all unchanged", () => {
+    expect(rewriteLegacySefariaRelativeHrefs("<b>plain text</b>")).toBe(
+      "<b>plain text</b>",
     );
   });
 });

--- a/tests/unit/source-pane.spec.ts
+++ b/tests/unit/source-pane.spec.ts
@@ -1,0 +1,81 @@
+import { mountSuspended } from "@nuxt/test-utils/runtime";
+import { describe, expect, it } from "vitest";
+import { defineComponent, h } from "vue";
+import SourcePane from "~/components/reader/SourcePane.vue";
+import type { SourceSegment } from "~~/shared/types/content";
+
+// `SourcePane` reads its scroll container via `useReaderPaneContainer()`,
+// which throws without a `ReaderPane` ancestor.
+const PaneContainerStub = defineComponent({
+  setup(_, { slots }) {
+    const containerRef = provideReaderPaneContainer();
+    return () => h("div", { ref: containerRef }, slots.default?.());
+  },
+});
+
+describe("SourcePane", () => {
+  it("strips the leading Sefaria seif-number prefix from the displayed html", async () => {
+    const segments: SourceSegment[] = [
+      {
+        n: 1,
+        sefariaRef: "x 1",
+        html: "1. <b>Explaining the concept of the initial contraction</b>",
+        anchors: [],
+      },
+    ];
+
+    const wrapper = await mountSuspended(PaneContainerStub, {
+      slots: { default: () => h(SourcePane, { segments }) },
+    });
+
+    expect(wrapper.text()).toContain(
+      "Explaining the concept of the initial contraction",
+    );
+    // The numeral chip (rendered separately) still shows "1" once, but the
+    // stripped prefix's literal "1. " text must be gone from the body.
+    expect(wrapper.html()).not.toContain("1. <b>Explaining");
+  });
+
+  it("gives each segment an id matching the seif-N scheme, for mini-toc jump targets", async () => {
+    const segments: SourceSegment[] = [
+      { n: 1, sefariaRef: "x 1", html: "First.", anchors: [] },
+      { n: 2, sefariaRef: "x 2", html: "Second.", anchors: [] },
+    ];
+
+    const wrapper = await mountSuspended(PaneContainerStub, {
+      slots: { default: () => h(SourcePane, { segments }) },
+    });
+
+    expect(wrapper.find("#seif-1").exists()).toBe(true);
+    expect(wrapper.find("#seif-2").exists()).toBe(true);
+  });
+
+  it("shows an empty-state message when the chapter has no source segments", async () => {
+    const wrapper = await mountSuspended(PaneContainerStub, {
+      slots: { default: () => h(SourcePane, { segments: [] }) },
+    });
+
+    expect(wrapper.text().toLowerCase()).toContain("no source text available");
+  });
+
+  it("rewrites a legacy Sefaria site-relative href so the prerender crawler doesn't 404 on it", async () => {
+    const segments: SourceSegment[] = [
+      {
+        n: 1,
+        sefariaRef: "x 1",
+        html: '<a href="/Talmud_Eser_HaSefirot,_Section_I,_List_of_Answers_on_Topics_55">reply</a>',
+        anchors: [],
+      },
+    ];
+
+    const wrapper = await mountSuspended(PaneContainerStub, {
+      slots: { default: () => h(SourcePane, { segments }) },
+    });
+
+    const link = wrapper.find("a");
+    expect(link.attributes("href")).toBe(
+      "https://www.sefaria.org/Talmud_Eser_HaSefirot,_Section_I,_List_of_Answers_on_Topics_55",
+    );
+    expect(link.attributes("target")).toBe("_blank");
+  });
+});

--- a/tests/unit/source-segments.spec.ts
+++ b/tests/unit/source-segments.spec.ts
@@ -1,0 +1,105 @@
+import { describe, expect, it } from "vitest";
+
+describe("stripLeadingSeifNumber", () => {
+  it("strips a leading number that matches the segment's own n", () => {
+    expect(
+      stripLeadingSeifNumber(
+        "1. <b>Explaining the concept of the initial contraction</b>",
+        1,
+      ),
+    ).toBe("<b>Explaining the concept of the initial contraction</b>");
+  });
+
+  it("strips regardless of extra whitespace after the period", () => {
+    expect(stripLeadingSeifNumber("2.   The reason for creation", 2)).toBe(
+      "The reason for creation",
+    );
+  });
+
+  it("leaves the html alone when there's no leading number at all", () => {
+    expect(stripLeadingSeifNumber("<b>No leading number here</b>", 1)).toBe(
+      "<b>No leading number here</b>",
+    );
+  });
+
+  it("leaves the html alone when the leading number doesn't match n (Hebrew has no such prefix)", () => {
+    expect(stripLeadingSeifNumber("דע כי טרם שנאצלו", 1)).toBe(
+      "דע כי טרם שנאצלו",
+    );
+  });
+
+  it("leaves the html alone when a leading number happens not to equal this segment's n", () => {
+    expect(stripLeadingSeifNumber("42. An unrelated leading number", 1)).toBe(
+      "42. An unrelated leading number",
+    );
+  });
+});
+
+describe("sourceSegmentAnchorId", () => {
+  it("builds the seif-N id scheme", () => {
+    expect(sourceSegmentAnchorId(1)).toBe("seif-1");
+    expect(sourceSegmentAnchorId(42)).toBe("seif-42");
+  });
+});
+
+describe("sourceMiniTocEntries", () => {
+  const seifLabel = (n: number) => `Seif ${n}`;
+
+  it("uses each segment's heading when it has one", () => {
+    const entries = sourceMiniTocEntries(
+      [
+        {
+          n: 1,
+          sefariaRef: "x 1",
+          heading: "Before restriction",
+          html: "",
+          anchors: [],
+        },
+        {
+          n: 2,
+          sefariaRef: "x 2",
+          heading: "The central point",
+          html: "",
+          anchors: [],
+        },
+      ],
+      seifLabel,
+    );
+
+    expect(entries).toEqual([
+      { anchorId: "seif-1", label: "Before restriction" },
+      { anchorId: "seif-2", label: "The central point" },
+    ]);
+  });
+
+  it("falls back to a generic seif label when a segment has no heading", () => {
+    const entries = sourceMiniTocEntries(
+      [{ n: 1, sefariaRef: "x 1", html: "", anchors: [] }],
+      seifLabel,
+    );
+
+    expect(entries).toEqual([{ anchorId: "seif-1", label: "Seif 1" }]);
+  });
+
+  it("falls back for a blank/whitespace-only heading too", () => {
+    const entries = sourceMiniTocEntries(
+      [{ n: 1, sefariaRef: "x 1", heading: "   ", html: "", anchors: [] }],
+      seifLabel,
+    );
+
+    expect(entries).toEqual([{ anchorId: "seif-1", label: "Seif 1" }]);
+  });
+
+  it("never shorter than the segment count, even with zero headings", () => {
+    const entries = sourceMiniTocEntries(
+      [
+        { n: 1, sefariaRef: "x 1", html: "", anchors: [] },
+        { n: 2, sefariaRef: "x 2", html: "", anchors: [] },
+        { n: 3, sefariaRef: "x 3", html: "", anchors: [] },
+      ],
+      seifLabel,
+    );
+
+    expect(entries).toHaveLength(3);
+  });
+});

--- a/tests/unit/summary-pane.spec.ts
+++ b/tests/unit/summary-pane.spec.ts
@@ -1,0 +1,72 @@
+import { mountSuspended } from "@nuxt/test-utils/runtime";
+import { describe, expect, it } from "vitest";
+import SummaryPane from "~/components/reader/SummaryPane.vue";
+import type { SourceSegment, SummaryItem } from "~~/shared/types/content";
+
+const summaryItems: SummaryItem[] = [
+  {
+    id: "summary-1",
+    targetSeif: 1,
+    heading: "Before restriction: the simple light",
+    html: "<p>Before anything…</p>",
+  },
+];
+
+const sourceSegments: SourceSegment[] = [
+  {
+    n: 1,
+    sefariaRef: "x 1",
+    heading: "Before restriction",
+    html: "",
+    anchors: [],
+  },
+  { n: 2, sefariaRef: "x 2", html: "", anchors: [] },
+];
+
+describe("SummaryPane", () => {
+  it("renders the curated summary when the chapter has one", async () => {
+    const wrapper = await mountSuspended(SummaryPane, {
+      props: { summaryItems, sourceSegments },
+    });
+
+    expect(wrapper.text()).toContain("Before restriction: the simple light");
+    // The mini-toc must not also render alongside a real summary.
+    expect(wrapper.text()).not.toContain("In this chapter");
+  });
+
+  it("falls back to a heading mini-toc when there's no summary layer", async () => {
+    const wrapper = await mountSuspended(SummaryPane, {
+      props: { summaryItems: [], sourceSegments },
+    });
+
+    expect(wrapper.text()).toContain("In this chapter");
+    expect(wrapper.text()).toContain("Before restriction");
+    // Segment 2 has no `heading` — falls back to a generic seif label so the
+    // mini-toc entry count still matches the segment count.
+    expect(wrapper.text()).toContain("Seif 2");
+  });
+
+  it("is never an empty box, even with no summary and no source segments", async () => {
+    const wrapper = await mountSuspended(SummaryPane, {
+      props: { summaryItems: [], sourceSegments: [] },
+    });
+
+    expect(wrapper.text().trim().length).toBeGreaterThan(0);
+  });
+
+  it("activates a seif anchor from the summary pane on mini-toc entry click", async () => {
+    const wrapper = await mountSuspended(SummaryPane, {
+      props: { summaryItems: [], sourceSegments },
+    });
+
+    const button = wrapper
+      .findAll("button")
+      .find((b) => b.text() === "Before restriction");
+    expect(button).toBeTruthy();
+    await button?.trigger("click");
+    // No error thrown, and the button exists/responds — the actual
+    // cross-pane effect (SourcePane highlighting `seif-1`) is covered by
+    // `useReaderState`'s own unit tests plus the source pane's handling of
+    // `data-anchor`/`id` lookups.
+  });
+});

--- a/tests/unit/toc.spec.ts
+++ b/tests/unit/toc.spec.ts
@@ -1,14 +1,17 @@
 import { describe, expect, it } from "vitest";
-import type { Toc } from "~~/shared/types/content";
+import type { ChapterKind, Toc } from "~~/shared/types/content";
 
-const chapter = (id: string, number: number) => ({
+const chapterOf = (id: string, kind: ChapterKind, number: number) => ({
   id,
-  kind: "chapter" as const,
+  kind,
   number,
   title: { en: id, he: id },
   availableLayers: [],
   availableVersions: { summary: [], source: [], commentary: [] },
 });
+
+const chapter = (id: string, number: number) =>
+  chapterOf(id, "chapter", number);
 
 const fixtureToc: Toc = {
   volumes: [
@@ -65,6 +68,83 @@ describe("flattenChapters", () => {
       "part-02/chapter-01",
       "part-03/chapter-01",
     ]);
+  });
+});
+
+describe("flattenChapters — mixed chapter kinds", () => {
+  // Regression coverage: `TocChapter.number` restarts at 1 within each kind
+  // (a real part-01 shape — 2 `chapter`s, 10 `inner-observation`s, 1
+  // `questions-terminology`, 54 `answers-terminology`), so sorting a part's
+  // chapters by `number` alone (the pre-fix behaviour) interleaved kinds —
+  // e.g. `chapter` #1, `inner-observation` #1, and `answers-terminology` #1
+  // all tied at `number: 1` — instead of reading through one kind before
+  // the next. `flattenChapters` must sort by kind (`KIND_ORDER`) first.
+  const mixedKindToc: Toc = {
+    volumes: [
+      {
+        id: "volume-01",
+        number: 1,
+        title: { en: "Volume 1", he: "כרך 1" },
+        parts: [
+          {
+            id: "part-01",
+            number: 1,
+            sefariaNode: "Talmud Eser HaSefirot, Section I",
+            title: { en: "Part 1", he: "חלק 1" },
+            // Authored out of reading order on purpose, to prove the sort
+            // (not incidental array order) produces the right result.
+            chapters: [
+              chapterOf(
+                "part-01/answers-terminology-02",
+                "answers-terminology",
+                2,
+              ),
+              chapterOf("part-01/inner-observation-02", "inner-observation", 2),
+              chapterOf("part-01/chapter-02", "chapter", 2),
+              chapterOf(
+                "part-01/answers-terminology-01",
+                "answers-terminology",
+                1,
+              ),
+              chapterOf(
+                "part-01/questions-terminology-01",
+                "questions-terminology",
+                1,
+              ),
+              chapterOf("part-01/inner-observation-01", "inner-observation", 1),
+              chapterOf("part-01/chapter-01", "chapter", 1),
+            ],
+          },
+        ],
+      },
+    ],
+  };
+
+  it("orders chapters by kind first, then by number within the kind", () => {
+    expect(
+      flattenChapters(mixedKindToc).map((entry) => entry.chapter.id),
+    ).toEqual([
+      "part-01/chapter-01",
+      "part-01/chapter-02",
+      "part-01/inner-observation-01",
+      "part-01/inner-observation-02",
+      "part-01/questions-terminology-01",
+      "part-01/answers-terminology-01",
+      "part-01/answers-terminology-02",
+    ]);
+  });
+
+  it("prevNextChapter crosses from the last `chapter` into `inner-observation`, not into `answers-*`", () => {
+    const { next } = prevNextChapter(mixedKindToc, "part-01/chapter-02");
+    expect(next?.chapter.id).toBe("part-01/inner-observation-01");
+  });
+
+  it("prevNextChapter crosses from `inner-observation` into `questions-terminology`", () => {
+    const { next } = prevNextChapter(
+      mixedKindToc,
+      "part-01/inner-observation-02",
+    );
+    expect(next?.chapter.id).toBe("part-01/questions-terminology-01");
   });
 });
 


### PR DESCRIPTION
Closes #22. The core of the product: `/read/[part]/[chapter]`.

## What

- Three synced panes (summary/mini-toc · source · commentary) with two-way anchor navigation: clicking an anchor in the source scrolls and softly highlights its Ohr Pnimi item, and vice versa — implemented with per-pane containment (no event bus, no cross-pane DOM reach), `prefers-reduced-motion` respected
- Per-pane language and edition: version selectors driven by `versions.json` metadata, per-pane `dir`/`lang` (Hebrew source beside English commentary works), locale-aware default-version rules, "AI translated" badge whenever an en-ai edition is shown
- Missing-anchor notice with one-click switch to Hebrew (no silent no-ops); mini-toc fallback so the third pane is never empty on Inner Observation chapters; leading seif-number stripped at render only
- 238 reader routes prerendered (119 chapters × 2 locales); `/read` exclusions removed
- Two pre-existing bugs fixed en route, with regression tests: chapter ordering across kinds in prev/next, and legacy Sefaria site-relative hrefs (defended at import-time and render-time)
- Review round: hydration-safe version persistence (SSR-matching first render, post-mount reconciliation), re-triggerable anchor activation incl. post-switch highlight, Enter double-fire guard

## Verification

225 tests green; full chain (`task qa`, typecheck, generate 516 routes, validate:content) clean. Opus code review + focused re-review of the fix round (traced by construction, 22 covering tests re-run live). Interactive visual pass: anchor-click sync verified in the served build — including the fully mirrored RTL reader with an LTR English pane inside it.