### PR TITLE
Reader study mode: the lesson as an interface

### DIFF
--- a/app/components/reader/ChapterIntro.vue
+++ b/app/components/reader/ChapterIntro.vue
@@ -1,0 +1,44 @@
+<script setup lang="ts">
+// Study mode's chapter-intro card, at the top of `StudyStream`: the same
+// summary-or-mini-toc body as the panes-mode summary pane
+// (`ReaderSummaryBody`), inside a native `<details>` disclosure — a plain
+// `<details>` needs no extra ARIA to be a fully accessible collapsible;
+// collapsed by default (no `open` attribute) so a mobile reader lands on
+// the source stream itself, not a wall of summary text.
+import type { SourceSegment, SummaryItem } from "~~/shared/types/content";
+
+defineProps<{
+  summaryItems: SummaryItem[];
+  sourceSegments: SourceSegment[];
+}>();
+
+const { t } = useI18n();
+</script>
+
+<template>
+  <details
+    class="group mb-6 rounded-card border border-(--border) bg-(--surface-reading)"
+  >
+    <summary
+      class="flex cursor-pointer list-none items-center justify-between gap-2 px-4 py-3 [&::-webkit-details-marker]:hidden focus-visible:outline focus-visible:outline-2 focus-visible:outline-teal"
+    >
+      <span
+        class="font-display text-sm tracking-wide text-(--text-muted) uppercase"
+      >
+        {{ t("reader.chapterIntro.title") }}
+      </span>
+      <span
+        aria-hidden="true"
+        class="text-(--text-muted) transition-transform group-open:rotate-180"
+        >⌄</span
+      >
+    </summary>
+
+    <div class="px-4 pb-4">
+      <ReaderSummaryBody
+        :summary-items="summaryItems"
+        :source-segments="sourceSegments"
+      />
+    </div>
+  </details>
+</template>

--- a/app/components/reader/InlineCommentary.vue
+++ b/app/components/reader/InlineCommentary.vue
@@ -46,6 +46,7 @@ const fold = () => toggleInline(props.anchorId);
       <button
         type="button"
         class="rounded-button px-2 py-1 text-xs text-(--text-muted) hover:text-teal focus-visible:outline focus-visible:outline-2 focus-visible:outline-teal"
+        :aria-label="t('reader.studyMode.fold')"
         @click="fold"
       >
         {{ t("reader.studyMode.fold") }}

--- a/app/components/reader/InlineCommentary.vue
+++ b/app/components/reader/InlineCommentary.vue
@@ -1,0 +1,80 @@
+<script setup lang="ts">
+// Study mode's inline commentary disclosure: unfolds directly beneath the
+// source segment containing the tapped anchor (`StudyStream`), rather than
+// scrolling the reader across to a separate commentary pane. Reuses the T7
+// missing-anchor notice pattern (`resolveAnchorAvailability`,
+// `~/utils/commentaryNotice`) inline instead of as a toast, since several
+// of these can be open at once and each needs its own "not in this
+// edition" check independent of the others.
+import type { CommentaryItem, ContentVersion } from "~~/shared/types/content";
+
+const props = defineProps<{
+  anchorId: string;
+  /** This anchor's items in the currently-selected commentary version — empty means "missing". */
+  items: CommentaryItem[];
+  meta: ContentVersion | null;
+  canSwitchToHebrew: boolean;
+}>();
+
+const emit = defineEmits<{ "switch-to-hebrew": [] }>();
+
+const { locale, t } = useI18n();
+const { toggleInline } = useReaderState();
+
+const isMissing = computed(() => props.items.length === 0);
+const isAiTranslated = computed(() => props.meta?.source === "ai");
+
+const fold = () => toggleInline(props.anchorId);
+</script>
+
+<template>
+  <div
+    :id="anchorId"
+    class="reader-anchor-target scroll-mt-24 rounded-card border-s-4 border-teal bg-(--surface-reading) p-3"
+    :dir="meta?.direction ?? 'ltr'"
+    :lang="meta?.language"
+  >
+    <div class="mb-1.5 flex items-center justify-between gap-2">
+      <span
+        v-if="isAiTranslated"
+        class="rounded-button border border-orange-cta px-1.5 py-0.5 text-xs font-medium text-orange-cta"
+      >
+        {{ t("reader.aiTranslated") }}
+      </span>
+      <span v-else />
+
+      <button
+        type="button"
+        class="rounded-button px-2 py-1 text-xs text-(--text-muted) hover:text-teal focus-visible:outline focus-visible:outline-2 focus-visible:outline-teal"
+        @click="fold"
+      >
+        {{ t("reader.studyMode.fold") }}
+      </button>
+    </div>
+
+    <p v-if="isMissing" class="text-xs text-orange-cta">
+      {{ t("reader.missingAnchor.message") }}
+      <button
+        v-if="canSwitchToHebrew"
+        type="button"
+        class="ms-1 underline"
+        @click="emit('switch-to-hebrew')"
+      >
+        {{ t("reader.missingAnchor.switchToHebrew") }}
+      </button>
+    </p>
+
+    <ol v-else class="flex flex-col gap-3">
+      <li
+        v-for="item in items"
+        :key="item.anchorId"
+        class="leading-relaxed text-(--text-primary)"
+      >
+        <span class="me-1.5 text-xs font-semibold text-teal">{{
+          localizedText(item.label, locale)
+        }}</span>
+        <span v-html="item.html" />
+      </li>
+    </ol>
+  </div>
+</template>

--- a/app/components/reader/ProgressRail.vue
+++ b/app/components/reader/ProgressRail.vue
@@ -1,0 +1,59 @@
+<script setup lang="ts">
+// Study mode's thin reading-position rail: a fixed strip on the
+// inline-end edge (`end-0` — the logical property, so it lands on the
+// left in RTL rather than needing a `dir`-conditional class) that fills
+// top-down as the reader scrolls through the chapter. Passive scroll/resize
+// listeners, rAF-batched, and the fill itself only ever changes via a
+// `transform: scaleY(...)` on a fixed-size track — no layout-affecting
+// property is ever touched, so this can never cause layout thrash.
+const { t } = useI18n();
+
+const progress = ref(0);
+let rafHandle: number | null = null;
+
+const measure = () => {
+  rafHandle = null;
+  progress.value = computeReadingProgress({
+    scrollTop: window.scrollY,
+    viewportHeight: window.innerHeight,
+    contentHeight: document.documentElement.scrollHeight,
+  });
+};
+
+const onScrollOrResize = () => {
+  if (rafHandle !== null) return;
+  rafHandle = requestAnimationFrame(measure);
+};
+
+onMounted(() => {
+  measure();
+  window.addEventListener("scroll", onScrollOrResize, { passive: true });
+  window.addEventListener("resize", onScrollOrResize, { passive: true });
+});
+
+onUnmounted(() => {
+  window.removeEventListener("scroll", onScrollOrResize);
+  window.removeEventListener("resize", onScrollOrResize);
+  if (rafHandle !== null) cancelAnimationFrame(rafHandle);
+});
+
+const percent = computed(() => Math.round(progress.value * 100));
+</script>
+
+<template>
+  <div
+    class="pointer-events-none fixed inset-y-0 end-0 z-20 w-1"
+    role="progressbar"
+    aria-valuemin="0"
+    aria-valuemax="100"
+    :aria-valuenow="percent"
+    :aria-label="t('reader.progressLabel')"
+  >
+    <div class="h-full w-full bg-(--border)">
+      <div
+        class="h-full w-full origin-top bg-teal"
+        :style="{ transform: `scaleY(${progress})` }"
+      />
+    </div>
+  </div>
+</template>

--- a/app/components/reader/ReaderPane.vue
+++ b/app/components/reader/ReaderPane.vue
@@ -1,10 +1,10 @@
 <script setup lang="ts">
 // Generic pane chrome shared by the summary/source/commentary panes: a
-// header (layer title + version <select> when there's more than one + the
-// "AI translated" badge) above a scroll container that carries the
-// version's `dir`/`lang` — the actual pane content (SourcePane etc.) is
-// slotted in, and grabs this container via `useReaderPaneContainer()` for
-// its own `useHighlightedAnchor`.
+// header (`ReaderVersionHeader` — layer title + version <select> when
+// there's more than one + the "AI translated" badge) above a scroll
+// container that carries the version's `dir`/`lang` — the actual pane
+// content (SourcePane etc.) is slotted in, and grabs this container via
+// `useReaderPaneContainer()` for its own `useHighlightedAnchor`.
 import type { ContentVersion } from "~~/shared/types/content";
 
 export interface ReaderVersionOption {
@@ -12,7 +12,7 @@ export interface ReaderVersionOption {
   label: string;
 }
 
-const props = defineProps<{
+defineProps<{
   title: string;
   versionOptions: ReaderVersionOption[];
   modelValue: string | null;
@@ -20,16 +20,6 @@ const props = defineProps<{
 }>();
 
 const emit = defineEmits<{ "update:modelValue": [value: string] }>();
-
-const { t } = useI18n();
-
-const selectId = useId();
-const isAiTranslated = computed(() => props.meta?.source === "ai");
-
-const onVersionChange = (event: Event) => {
-  const value = (event.target as HTMLSelectElement).value;
-  emit("update:modelValue", value);
-};
 
 const containerRef = provideReaderPaneContainer();
 </script>
@@ -39,40 +29,14 @@ const containerRef = provideReaderPaneContainer();
     <header
       class="flex shrink-0 flex-wrap items-center justify-between gap-2 border-b border-(--border) px-4 py-2.5"
     >
-      <h2
-        class="font-display text-sm tracking-wide text-(--text-muted) uppercase"
-      >
-        {{ title }}
-      </h2>
-
-      <div class="flex items-center gap-2">
-        <span
-          v-if="isAiTranslated"
-          class="rounded-button border border-orange-cta px-1.5 py-0.5 text-xs font-medium text-orange-cta"
-        >
-          {{ t("reader.aiTranslated") }}
-        </span>
-
-        <template v-if="versionOptions.length > 1">
-          <label :for="selectId" class="sr-only">{{
-            t("reader.versionLabel")
-          }}</label>
-          <select
-            :id="selectId"
-            class="rounded-input border border-(--border) bg-(--surface) px-2 py-1 text-xs text-(--text-primary)"
-            :value="modelValue ?? ''"
-            @change="onVersionChange"
-          >
-            <option
-              v-for="option in versionOptions"
-              :key="option.id"
-              :value="option.id"
-            >
-              {{ option.label }}
-            </option>
-          </select>
-        </template>
-      </div>
+      <ReaderVersionHeader
+        :title="title"
+        :version-options="versionOptions"
+        :model-value="modelValue"
+        :meta="meta"
+        class="flex-1"
+        @update:model-value="(value) => emit('update:modelValue', value)"
+      />
 
       <slot name="toast" />
     </header>

--- a/app/components/reader/ReaderShell.vue
+++ b/app/components/reader/ReaderShell.vue
@@ -6,11 +6,11 @@
 // >=1024px: a fixed-viewport CSS grid (`[280px_1fr_1.1fr]`, summary | source
 // | commentary) — the toolbar stays put and each pane scrolls independently
 // within the viewport (see `layouts/reader.vue` for the outer `h-dvh`).
-// <1024px, for this task: the same three panes simply stacked in normal
-// document flow, no fixed height — a later task (T8) replaces this with a
-// real mobile study/panes mode; the state above already doesn't assume a
-// desktop-only shape (`activePane` exists precisely so that task can plug
-// into it).
+// <1024px: the same three panes simply stacked in normal document flow, no
+// fixed height — this is what panes mode falls back to on a narrow
+// viewport when the reader explicitly toggles out of study mode (T8's
+// default there); the state above already doesn't assume a desktop-only
+// shape (`activePane` exists precisely so that mode can plug into it).
 useReaderState();
 </script>
 
@@ -33,7 +33,10 @@ useReaderState();
       >
         <slot name="source" />
       </div>
-      <div class="lg:flex lg:h-full lg:min-h-0 lg:flex-col">
+      <div
+        id="reader-commentary-pane"
+        class="scroll-mt-4 lg:flex lg:h-full lg:min-h-0 lg:flex-col"
+      >
         <slot name="commentary" />
       </div>
     </div>

--- a/app/components/reader/ReaderShell.vue
+++ b/app/components/reader/ReaderShell.vue
@@ -1,16 +1,22 @@
 <script setup lang="ts">
-// Orchestrator for the three-pane reader. Provides the shared
-// `useReaderState()` (every pane beneath it, however deeply slotted,
-// injects the same instance — see the provide/inject notes there).
+// Orchestrator for the three-pane reader. Consumes the shared
+// `useReaderState()` — `layouts/reader.vue` is the real provider (its
+// unconditional `useAutoHidingChrome()` call reaches in and provides it
+// first, being an ancestor of every reader page), so this call and every
+// pane's beneath it, however deeply slotted, just inject that same
+// instance. See the provide/inject notes on `useReaderState` itself for
+// the fresh-instance fallback (and dev warning) if that provider is ever
+// missing.
 //
 // >=1024px: a fixed-viewport CSS grid (`[280px_1fr_1.1fr]`, summary | source
 // | commentary) — the toolbar stays put and each pane scrolls independently
 // within the viewport (see `layouts/reader.vue` for the outer `h-dvh`).
 // <1024px: the same three panes simply stacked in normal document flow, no
 // fixed height — this is what panes mode falls back to on a narrow
-// viewport when the reader explicitly toggles out of study mode (T8's
-// default there); the state above already doesn't assume a desktop-only
-// shape (`activePane` exists precisely so that mode can plug into it).
+// viewport when the reader explicitly toggles out of study mode. Nothing
+// here reads `activePane` yet — it's tracked in `useReaderState` for a
+// possible future single-pane mobile mode to plug into, not wired into
+// this shell today.
 useReaderState();
 </script>
 

--- a/app/components/reader/ReaderSourceSegment.vue
+++ b/app/components/reader/ReaderSourceSegment.vue
@@ -1,0 +1,30 @@
+<script setup lang="ts">
+// One source segment's rendering: the seif-number chip + its sanitized,
+// anchor-tappable html. Extracted from `SourcePane` (T7) so `StudyStream`
+// (T8) renders segments identically instead of duplicating this markup —
+// both wrap it in their own `id="seif-N"`/`.reader-anchor-target` list
+// item; this owns only the segment's own content.
+import type { SourceSegment } from "~~/shared/types/content";
+
+const props = defineProps<{ segment: SourceSegment }>();
+
+// `rewriteLegacySefariaRelativeHrefs` patches a data quirk in already-
+// committed content: some Questions/Answers chapters' Hebrew source has
+// Sefaria's own site-relative cross-reference links (`href="/Talmud_..."`),
+// which don't resolve on this site — see `app/utils/sanitizeHtml.ts`.
+const displayHtml = computed(() =>
+  rewriteLegacySefariaRelativeHrefs(
+    stripLeadingSeifNumber(props.segment.html, props.segment.n),
+  ),
+);
+</script>
+
+<template>
+  <span
+    class="me-2 inline-flex h-5 min-w-5 items-center justify-center rounded-full bg-(--surface-raised) px-1 align-middle text-xs tabular-nums text-(--text-muted)"
+    aria-hidden="true"
+  >
+    {{ segment.n }}
+  </span>
+  <span v-html="displayHtml" />
+</template>

--- a/app/components/reader/ReaderSummaryBody.vue
+++ b/app/components/reader/ReaderSummaryBody.vue
@@ -1,0 +1,71 @@
+<script setup lang="ts">
+// The chapter's curated summary when it has one — most chapters don't
+// (only chapter-01 does, so far): falls back to the chapter's `heading`s
+// extracted from its source segments as a mini table-of-contents, so this
+// is never an empty box. Each mini-toc entry jumps to that seif (`seif-N`,
+// `useHighlightedAnchor` on `SourcePane`/`StudyStream`).
+//
+// Extracted from `SummaryPane` (T7) so `ChapterIntro` (T8, study mode's
+// collapsible intro card) renders the exact same summary-or-mini-toc body
+// instead of duplicating it — `SummaryPane` and `ChapterIntro` differ only
+// in the chrome wrapped around this (a pane column vs a `<details>` card).
+import type { SourceSegment, SummaryItem } from "~~/shared/types/content";
+
+const props = defineProps<{
+  summaryItems: SummaryItem[];
+  sourceSegments: SourceSegment[];
+}>();
+
+const { t } = useI18n();
+const { activateAnchor } = useReaderState();
+
+const hasSummary = computed(() => props.summaryItems.length > 0);
+
+const miniToc = computed(() =>
+  sourceMiniTocEntries(props.sourceSegments, (n) =>
+    t("reader.seifLabel", { n }),
+  ),
+);
+
+const onMiniTocEntryClick = (anchorId: string) => {
+  activateAnchor(anchorId, "summary");
+};
+</script>
+
+<template>
+  <div v-if="hasSummary" class="flex flex-col gap-6">
+    <article
+      v-for="item in summaryItems"
+      :key="item.id"
+      class="leading-relaxed text-(--text-primary)"
+    >
+      <h3 class="font-display text-base text-(--text-primary)">
+        {{ item.heading }}
+      </h3>
+      <div class="mt-1 text-sm text-(--text-muted)" v-html="item.html" />
+    </article>
+  </div>
+
+  <nav v-else-if="miniToc.length > 0" :aria-label="t('reader.miniTocTitle')">
+    <h3
+      class="font-display text-sm tracking-wide text-(--text-muted) uppercase"
+    >
+      {{ t("reader.miniTocTitle") }}
+    </h3>
+    <ol class="mt-3 flex flex-col gap-1">
+      <li v-for="entry in miniToc" :key="entry.anchorId">
+        <button
+          type="button"
+          class="rounded-button px-2 py-1 text-start text-sm text-(--text-primary) hover:text-teal focus-visible:outline focus-visible:outline-2 focus-visible:outline-teal"
+          @click="onMiniTocEntryClick(entry.anchorId)"
+        >
+          {{ entry.label }}
+        </button>
+      </li>
+    </ol>
+  </nav>
+
+  <p v-else class="text-sm text-(--text-muted)">
+    {{ t("reader.summaryEmpty") }}
+  </p>
+</template>

--- a/app/components/reader/ReaderToolbar.vue
+++ b/app/components/reader/ReaderToolbar.vue
@@ -1,7 +1,11 @@
 <script setup lang="ts">
 // Breadcrumb ("Six volumes › Volume N › Part N · Chapter title") + prev/next
-// chapter links, disabled at the corpus edges. `prev`/`next` come straight
-// from `prevNextChapter` (`~/utils/toc`) — this component only renders.
+// chapter links, disabled at the corpus edges, plus the study/panes mode
+// toggle (T8). In study mode this whole bar becomes sticky and
+// auto-hides on scroll-down (`useAutoHidingChrome`, shared with
+// `layouts/reader.vue`'s navbar wrapper so both pieces of chrome move
+// together) — panes mode leaves it in normal flow, untouched, exactly as
+// T7 shipped it.
 import type { BreadcrumbItem } from "~/components/app/AppBreadcrumb.vue";
 import type { FlattenedChapter } from "~/utils/toc";
 
@@ -13,11 +17,57 @@ defineProps<{
 
 const { t, locale } = useI18n();
 const localePath = useLocalePath();
+
+const { mode, setMode } = useReaderMode();
+const { visible: chromeVisible } = useAutoHidingChrome();
+const isStudyMode = computed(() => mode.value === "study");
 </script>
 
 <template>
-  <div class="flex flex-col gap-3 border-b border-(--border) px-4 py-3 sm:px-6">
-    <AppBreadcrumb :items="breadcrumbItems" />
+  <div
+    class="flex flex-col gap-3 border-b border-(--border) bg-(--surface) px-4 py-3 sm:px-6"
+    :class="[
+      isStudyMode &&
+        'sticky top-0 z-30 transition-transform duration-200 ease-out motion-reduce:transition-none',
+      isStudyMode && !chromeVisible && '-translate-y-full',
+    ]"
+  >
+    <div class="flex items-center justify-between gap-3">
+      <AppBreadcrumb :items="breadcrumbItems" />
+
+      <div
+        role="group"
+        :aria-label="t('reader.mode.label')"
+        class="flex shrink-0 overflow-hidden rounded-button border border-(--border) text-xs"
+      >
+        <button
+          type="button"
+          :aria-pressed="mode === 'study'"
+          class="px-2.5 py-1 focus-visible:outline focus-visible:outline-2 focus-visible:outline-teal"
+          :class="
+            mode === 'study'
+              ? 'bg-teal text-surface-white'
+              : 'text-(--text-primary) hover:bg-(--surface-raised)'
+          "
+          @click="setMode('study')"
+        >
+          {{ t("reader.mode.study") }}
+        </button>
+        <button
+          type="button"
+          :aria-pressed="mode === 'panes'"
+          class="border-s border-(--border) px-2.5 py-1 focus-visible:outline focus-visible:outline-2 focus-visible:outline-teal"
+          :class="
+            mode === 'panes'
+              ? 'bg-teal text-surface-white'
+              : 'text-(--text-primary) hover:bg-(--surface-raised)'
+          "
+          @click="setMode('panes')"
+        >
+          {{ t("reader.mode.panes") }}
+        </button>
+      </div>
+    </div>
 
     <nav
       :aria-label="t('reader.chapterNav')"

--- a/app/components/reader/ReaderVersionHeader.vue
+++ b/app/components/reader/ReaderVersionHeader.vue
@@ -1,0 +1,66 @@
+<script setup lang="ts">
+// A layer's title + version <select> (when there's more than one) + the
+// "AI translated" badge — extracted from `ReaderPane` (T7) so `StudyStream`
+// (T8) can offer the same source/commentary edition switching inline in
+// the stream, without duplicating the select/badge markup. `ReaderPane`
+// wraps this with the rest of its pane chrome (border, scroll container).
+import type { ContentVersion } from "~~/shared/types/content";
+
+const props = defineProps<{
+  title: string;
+  versionOptions: { id: string; label: string }[];
+  modelValue: string | null;
+  meta: ContentVersion | null;
+}>();
+
+const emit = defineEmits<{ "update:modelValue": [value: string] }>();
+
+const { t } = useI18n();
+
+const selectId = useId();
+const isAiTranslated = computed(() => props.meta?.source === "ai");
+
+const onVersionChange = (event: Event) => {
+  const value = (event.target as HTMLSelectElement).value;
+  emit("update:modelValue", value);
+};
+</script>
+
+<template>
+  <div class="flex flex-wrap items-center justify-between gap-2">
+    <h2
+      class="font-display text-sm tracking-wide text-(--text-muted) uppercase"
+    >
+      {{ title }}
+    </h2>
+
+    <div class="flex items-center gap-2">
+      <span
+        v-if="isAiTranslated"
+        class="rounded-button border border-orange-cta px-1.5 py-0.5 text-xs font-medium text-orange-cta"
+      >
+        {{ t("reader.aiTranslated") }}
+      </span>
+
+      <template v-if="versionOptions.length > 1">
+        <label :for="selectId" class="sr-only">{{
+          t("reader.versionLabel")
+        }}</label>
+        <select
+          :id="selectId"
+          class="rounded-input border border-(--border) bg-(--surface) px-2 py-1 text-xs text-(--text-primary)"
+          :value="modelValue ?? ''"
+          @change="onVersionChange"
+        >
+          <option
+            v-for="option in versionOptions"
+            :key="option.id"
+            :value="option.id"
+          >
+            {{ option.label }}
+          </option>
+        </select>
+      </template>
+    </div>
+  </div>
+</template>

--- a/app/components/reader/SourcePane.vue
+++ b/app/components/reader/SourcePane.vue
@@ -1,13 +1,9 @@
 <script setup lang="ts">
 // Renders a chapter's source segments. Anchor clicks (`a.tes-anchor[data-anchor]`,
 // Sefaria's inline commentary markers, normalized at import time — see
-// `app/utils/anchors.ts`) are caught via a single delegated listener on the
-// scroll container, bound imperatively (not a template `@click`) so a
-// non-interactive container isn't flagged by
-// `vuejs-accessibility/no-static-element-interactions` — the actual
-// interactive elements are the `<a>` tags themselves, which already have a
-// working `href="#op-N"` no-JS fallback; this only intercepts to run the
-// reader's own highlight/scroll behaviour instead of a plain in-page jump.
+// `app/utils/anchors.ts`) are caught via `useAnchorActivation`'s single
+// delegated listener on the scroll container — see that composable for why
+// it's bound imperatively rather than a template `@click`.
 import type { SourceSegment } from "~~/shared/types/content";
 
 defineProps<{ segments: SourceSegment[] }>();
@@ -16,72 +12,7 @@ const { t } = useI18n();
 const { activateAnchor } = useReaderState();
 const containerRef = useReaderPaneContainer();
 useHighlightedAnchor("source", containerRef);
-
-// `rewriteLegacySefariaRelativeHrefs` patches a data quirk in already-
-// committed content: some Questions/Answers chapters' Hebrew source has
-// Sefaria's own site-relative cross-reference links (`href="/Talmud_..."`),
-// which don't resolve on this site — see `app/utils/sanitizeHtml.ts`.
-const displayHtml = (segment: SourceSegment): string =>
-  rewriteLegacySefariaRelativeHrefs(
-    stripLeadingSeifNumber(segment.html, segment.n),
-  );
-
-const anchorIdFromEvent = (event: Event): string | undefined => {
-  const target = event.target as HTMLElement | null;
-  const anchor = target?.closest<HTMLAnchorElement>(
-    "a.tes-anchor[data-anchor]",
-  );
-  return anchor?.dataset.anchor;
-};
-
-// A focused `<a href>`'s native Enter activation fires both this `keydown`
-// (which handles it, since Space also needs handling here and anchors don't
-// natively activate on Space) and a browser-synthesized `click` right after
-// — without a guard, that click re-runs `activateAnchor` for the same Enter
-// press. `suppressNextClickId` records the id an Enter keydown just
-// activated so the following synthetic click for that same id is a no-op;
-// it's cleared on a microtask so it can never suppress a later *real*
-// click if the browser's `click` doesn't materialize (e.g. `preventDefault`
-// already stopped it upstream).
-let suppressNextClickId: string | null = null;
-
-const onContainerClick = (event: MouseEvent) => {
-  const id = anchorIdFromEvent(event);
-  if (!id) return;
-  if (suppressNextClickId === id) {
-    suppressNextClickId = null;
-    return;
-  }
-  event.preventDefault();
-  activateAnchor(id, "source");
-};
-
-const onContainerKeydown = (event: KeyboardEvent) => {
-  if (event.key !== "Enter" && event.key !== " ") return;
-  const id = anchorIdFromEvent(event);
-  if (!id) return;
-  event.preventDefault();
-  activateAnchor(id, "source");
-
-  if (event.key === "Enter") {
-    suppressNextClickId = id;
-    queueMicrotask(() => {
-      if (suppressNextClickId === id) suppressNextClickId = null;
-    });
-  }
-};
-
-watchEffect((onCleanup) => {
-  const container = containerRef.value;
-  if (!container) return;
-
-  container.addEventListener("click", onContainerClick);
-  container.addEventListener("keydown", onContainerKeydown);
-  onCleanup(() => {
-    container.removeEventListener("click", onContainerClick);
-    container.removeEventListener("keydown", onContainerKeydown);
-  });
-});
+useAnchorActivation(containerRef, (id) => activateAnchor(id, "source"));
 </script>
 
 <template>
@@ -95,13 +26,7 @@ watchEffect((onCleanup) => {
       :key="segment.n"
       class="reader-anchor-target scroll-mt-4 text-lg leading-relaxed text-(--text-primary)"
     >
-      <span
-        class="me-2 inline-flex h-5 min-w-5 items-center justify-center rounded-full bg-(--surface-raised) px-1 align-middle text-xs tabular-nums text-(--text-muted)"
-        aria-hidden="true"
-      >
-        {{ segment.n }}
-      </span>
-      <span v-html="displayHtml(segment)" />
+      <ReaderSourceSegment :segment="segment" />
     </li>
   </ol>
   <p v-else class="text-sm text-(--text-muted)">

--- a/app/components/reader/StudyStream.vue
+++ b/app/components/reader/StudyStream.vue
@@ -1,0 +1,179 @@
+<script setup lang="ts">
+// The signature mobile reading experience (T8): source segments flow as a
+// single reading stream — commentary comes to the reader inline instead of
+// living in a separate pane the reader has to juggle. Default mode below
+// the `lg` breakpoint (`useReaderMode`); reuses the exact same version
+// selection (`ReaderVersionHeader`), seif rendering (`ReaderSourceSegment`)
+// and anchor-activation behaviour (`useAnchorActivation`) as panes mode's
+// `SourcePane`, rather than duplicating any of it.
+import type {
+  CommentaryItem,
+  ContentVersion,
+  SourceSegment,
+  SummaryItem,
+} from "~~/shared/types/content";
+
+const props = defineProps<{
+  sourceSegments: SourceSegment[];
+  commentaryItems: CommentaryItem[];
+  summaryItems: SummaryItem[];
+  sourceMeta: ContentVersion | null;
+  commentaryMeta: ContentVersion | null;
+  sourceVersionOptions: { id: string; label: string }[];
+  commentaryVersionOptions: { id: string; label: string }[];
+  sourceVersion: string | null;
+  commentaryVersion: string | null;
+  /** The chapter's `he-jerusalem-1956` commentary items, if it has that version — for the inline "switch to Hebrew" notice. */
+  hebrewItems: CommentaryItem[] | null;
+  hebrewVersionId: string;
+}>();
+
+const emit = defineEmits<{
+  "update:sourceVersion": [value: string];
+  "update:commentaryVersion": [value: string];
+}>();
+
+const { t } = useI18n();
+const { activateAnchor, toggleInline, expandedAnchors } = useReaderState();
+const { setMode } = useReaderMode();
+
+// Study mode has no separate scroll container of its own — the whole
+// document scrolls (see `useAutoHidingChrome`) — but `useHighlightedAnchor`
+// and `useAnchorActivation` both just need *an* ancestor element containing
+// every anchor target to query against; this stream's own root serves that
+// role the same way a `ReaderPane`'s container does in panes mode.
+const containerRef = ref<HTMLElement | null>(null);
+useHighlightedAnchor("source", containerRef);
+useAnchorActivation(containerRef, (id) => {
+  activateAnchor(id, "source");
+  toggleInline(id);
+});
+
+const isExpanded = (anchorId: string): boolean =>
+  expandedAnchors.value.has(anchorId);
+
+const commentaryItemsForAnchor = (anchorId: string): CommentaryItem[] =>
+  props.commentaryItems.filter((item) => item.anchorId === anchorId);
+
+const canSwitchToHebrewFor = (anchorId: string): boolean =>
+  resolveAnchorAvailability({
+    anchorId,
+    displayedItems: props.commentaryItems,
+    selectedVersionId: props.commentaryVersion,
+    hebrewItems: props.hebrewItems,
+    hebrewVersionId: props.hebrewVersionId,
+  }).canSwitchToHebrew;
+
+// Unlike panes mode's single global `missingAnchorNotice`, several inline
+// disclosures can be open at once — switching commentary edition just
+// updates the shared `commentaryItems` prop these all read from, so no
+// `reactivateAnchor()`-style re-trigger is needed here: every open
+// `InlineCommentary` re-renders off plain prop reactivity.
+const switchToHebrew = () => {
+  emit("update:commentaryVersion", props.hebrewVersionId);
+};
+
+const hasCommentaryLayer = computed(
+  () => props.commentaryVersionOptions.length > 0,
+);
+
+/** Switches to panes mode and scrolls straight to its commentary column — see `ReaderShell`'s `#reader-commentary-pane`. */
+const goToFullCommentary = async () => {
+  setMode("panes");
+  await nextTick();
+  document
+    .getElementById("reader-commentary-pane")
+    ?.scrollIntoView({ block: "start" });
+};
+</script>
+
+<template>
+  <div
+    ref="containerRef"
+    class="mx-auto flex max-w-[65ch] flex-col px-4 py-6 sm:px-6"
+  >
+    <div class="mb-4 flex flex-col gap-2">
+      <ReaderVersionHeader
+        v-if="sourceVersionOptions.length > 1"
+        :title="t('reader.pane.source')"
+        :version-options="sourceVersionOptions"
+        :model-value="sourceVersion"
+        :meta="sourceMeta"
+        @update:model-value="(value) => emit('update:sourceVersion', value)"
+      />
+      <ReaderVersionHeader
+        v-if="commentaryVersionOptions.length > 1"
+        :title="t('reader.pane.commentary')"
+        :version-options="commentaryVersionOptions"
+        :model-value="commentaryVersion"
+        :meta="commentaryMeta"
+        @update:model-value="(value) => emit('update:commentaryVersion', value)"
+      />
+    </div>
+
+    <ReaderChapterIntro
+      :summary-items="summaryItems"
+      :source-segments="sourceSegments"
+    />
+
+    <ol
+      v-if="sourceSegments.length > 0"
+      class="flex flex-col gap-6"
+      :dir="sourceMeta?.direction ?? 'ltr'"
+      :lang="sourceMeta?.language"
+    >
+      <li
+        v-for="segment in sourceSegments"
+        :id="`seif-${segment.n}`"
+        :key="segment.n"
+        class="reader-anchor-target scroll-mt-24 text-lg leading-relaxed text-(--text-primary)"
+      >
+        <ReaderSourceSegment :segment="segment" />
+
+        <div v-for="anchorId in segment.anchors" :key="anchorId" class="mt-3">
+          <Transition
+            enter-active-class="grid transition-[grid-template-rows] duration-200 ease-out motion-reduce:transition-none"
+            leave-active-class="grid transition-[grid-template-rows] duration-200 ease-out motion-reduce:transition-none"
+            enter-from-class="grid-rows-[0fr]"
+            enter-to-class="grid-rows-[1fr]"
+            leave-from-class="grid-rows-[1fr]"
+            leave-to-class="grid-rows-[0fr]"
+          >
+            <div v-if="isExpanded(anchorId)" class="grid overflow-hidden">
+              <div class="overflow-hidden">
+                <ReaderInlineCommentary
+                  :anchor-id="anchorId"
+                  :items="commentaryItemsForAnchor(anchorId)"
+                  :meta="commentaryMeta"
+                  :can-switch-to-hebrew="canSwitchToHebrewFor(anchorId)"
+                  @switch-to-hebrew="switchToHebrew"
+                />
+              </div>
+            </div>
+          </Transition>
+        </div>
+      </li>
+    </ol>
+    <p v-else class="text-sm text-(--text-muted)">
+      {{ t("reader.sourceEmpty") }}
+    </p>
+
+    <section
+      v-if="hasCommentaryLayer"
+      class="mt-10 rounded-card border border-(--border) p-4 text-center"
+    >
+      <p class="text-sm text-(--text-muted)">
+        {{ t("reader.studyMode.readFullCommentaryHint") }}
+      </p>
+      <button
+        type="button"
+        class="mt-2 rounded-button border border-teal px-3 py-1.5 text-sm font-medium text-teal hover:bg-teal hover:text-surface-white focus-visible:outline focus-visible:outline-2 focus-visible:outline-teal"
+        @click="goToFullCommentary"
+      >
+        {{ t("reader.studyMode.readFullCommentary") }}
+      </button>
+    </section>
+
+    <ReaderProgressRail />
+  </div>
+</template>

--- a/app/components/reader/StudyStream.vue
+++ b/app/components/reader/StudyStream.vue
@@ -65,6 +65,12 @@ watchEffect(
     if (!container) return;
 
     const expanded = expandedAnchors.value;
+    // Read (without using) `sourceSegments` so this effect also re-runs
+    // after a source-version switch replaces the `v-html` anchor nodes —
+    // otherwise the freshly patched anchors would sit un-synced until the
+    // next `expandedAnchors` change, contradicting the whole point of
+    // this effect.
+    void props.sourceSegments;
     container
       .querySelectorAll<HTMLAnchorElement>("a.tes-anchor[data-anchor]")
       .forEach((anchor) => {

--- a/app/components/reader/StudyStream.vue
+++ b/app/components/reader/StudyStream.vue
@@ -49,6 +49,38 @@ useAnchorActivation(containerRef, (id) => {
   toggleInline(id);
 });
 
+// The anchor markers themselves live in sanitized `v-html` (see
+// `ReaderSourceSegment`), outside Vue's own attribute bindings, so their
+// `aria-expanded`/`aria-controls` can't just be template-bound like a
+// normal disclosure trigger — this small effect is what keeps them in
+// sync with `expandedAnchors` instead. Scoped to this stream's own
+// container only (no cross-pane DOM reach), and `flush: "post"` so it
+// always runs after Vue has (re)patched the `v-html` markup it targets —
+// e.g. on a source-version switch, which replaces those anchor nodes
+// outright. `aria-controls` points at the matching `InlineCommentary`'s
+// own root, which is already given `:id="anchorId"` there.
+watchEffect(
+  () => {
+    const container = containerRef.value;
+    if (!container) return;
+
+    const expanded = expandedAnchors.value;
+    container
+      .querySelectorAll<HTMLAnchorElement>("a.tes-anchor[data-anchor]")
+      .forEach((anchor) => {
+        const anchorId = anchor.dataset.anchor;
+        if (!anchorId) return;
+
+        anchor.setAttribute("aria-controls", anchorId);
+        anchor.setAttribute(
+          "aria-expanded",
+          expanded.has(anchorId) ? "true" : "false",
+        );
+      });
+  },
+  { flush: "post" },
+);
+
 const isExpanded = (anchorId: string): boolean =>
   expandedAnchors.value.has(anchorId);
 

--- a/app/components/reader/SummaryPane.vue
+++ b/app/components/reader/SummaryPane.vue
@@ -1,68 +1,20 @@
 <script setup lang="ts">
-// Renders the chapter's curated summary when it has one — most chapters
-// don't (only chapter-01 does, so far): the pane instead shows the
-// chapter's `heading`s extracted from its source segments as a mini
-// table-of-contents, so the third pane is never an empty box. Each mini-toc
-// entry jumps the source pane to that seif (`seif-N`, `useHighlightedAnchor`
-// on `SourcePane`) — the summary pane itself is never a highlight target,
-// only an anchor *origin*.
+// Thin wrapper around `ReaderSummaryBody` — see that component for the
+// summary-or-mini-toc rendering rule. Kept as its own component (rather
+// than inlining `ReaderSummaryBody` directly in the reader page) so the
+// panes-mode summary pane and study mode's `ChapterIntro` can each wrap it
+// in their own chrome without either depending on the other's markup.
 import type { SourceSegment, SummaryItem } from "~~/shared/types/content";
 
-const props = defineProps<{
+defineProps<{
   summaryItems: SummaryItem[];
   sourceSegments: SourceSegment[];
 }>();
-
-const { t } = useI18n();
-const { activateAnchor } = useReaderState();
-
-const hasSummary = computed(() => props.summaryItems.length > 0);
-
-const miniToc = computed(() =>
-  sourceMiniTocEntries(props.sourceSegments, (n) =>
-    t("reader.seifLabel", { n }),
-  ),
-);
-
-const onMiniTocEntryClick = (anchorId: string) => {
-  activateAnchor(anchorId, "summary");
-};
 </script>
 
 <template>
-  <div v-if="hasSummary" class="flex flex-col gap-6">
-    <article
-      v-for="item in summaryItems"
-      :key="item.id"
-      class="leading-relaxed text-(--text-primary)"
-    >
-      <h3 class="font-display text-base text-(--text-primary)">
-        {{ item.heading }}
-      </h3>
-      <div class="mt-1 text-sm text-(--text-muted)" v-html="item.html" />
-    </article>
-  </div>
-
-  <nav v-else-if="miniToc.length > 0" :aria-label="t('reader.miniTocTitle')">
-    <h3
-      class="font-display text-sm tracking-wide text-(--text-muted) uppercase"
-    >
-      {{ t("reader.miniTocTitle") }}
-    </h3>
-    <ol class="mt-3 flex flex-col gap-1">
-      <li v-for="entry in miniToc" :key="entry.anchorId">
-        <button
-          type="button"
-          class="rounded-button px-2 py-1 text-start text-sm text-(--text-primary) hover:text-teal focus-visible:outline focus-visible:outline-2 focus-visible:outline-teal"
-          @click="onMiniTocEntryClick(entry.anchorId)"
-        >
-          {{ entry.label }}
-        </button>
-      </li>
-    </ol>
-  </nav>
-
-  <p v-else class="text-sm text-(--text-muted)">
-    {{ t("reader.summaryEmpty") }}
-  </p>
+  <ReaderSummaryBody
+    :summary-items="summaryItems"
+    :source-segments="sourceSegments"
+  />
 </template>

--- a/app/composables/useAnchorActivation.ts
+++ b/app/composables/useAnchorActivation.ts
@@ -1,0 +1,77 @@
+/**
+ * Delegated click/keyboard activation for a container's `a.tes-anchor[data-anchor]`
+ * markers (Sefaria's inline commentary anchors, normalized at import time —
+ * see `app/utils/anchors.ts`). Bound imperatively via `addEventListener`
+ * (not a template `@click`) so the container itself — not an interactive
+ * element — isn't flagged by `vuejs-accessibility/no-static-element-interactions`;
+ * the actual interactive elements are the `<a>` tags, which already have a
+ * working `href="#op-N"` no-JS fallback.
+ *
+ * Extracted from `SourcePane` (T7) so `StudyStream` (T8) gets the exact
+ * same activation behaviour — including the Enter-key double-fire guard
+ * below — without duplicating it: only what happens on activation (`onActivate`)
+ * differs between panes mode (`activateAnchor`) and study mode
+ * (`activateAnchor` + `toggleInline`).
+ */
+import type { Ref } from "vue";
+
+const anchorIdFromEvent = (event: Event): string | undefined => {
+  const target = event.target as HTMLElement | null;
+  const anchor = target?.closest<HTMLAnchorElement>(
+    "a.tes-anchor[data-anchor]",
+  );
+  return anchor?.dataset.anchor;
+};
+
+export const useAnchorActivation = (
+  containerRef: Ref<HTMLElement | null | undefined>,
+  onActivate: (anchorId: string) => void,
+): void => {
+  // A focused `<a href>`'s native Enter activation fires both a `keydown`
+  // (handled here, since Space also needs handling and anchors don't
+  // natively activate on Space) and a browser-synthesized `click` right
+  // after — without a guard, that click would re-run `onActivate` for the
+  // same Enter press. `suppressNextClickId` records the id an Enter keydown
+  // just activated so the following synthetic click for that same id is a
+  // no-op; cleared on a microtask so it can never suppress a later *real*
+  // click.
+  let suppressNextClickId: string | null = null;
+
+  const onContainerClick = (event: MouseEvent) => {
+    const id = anchorIdFromEvent(event);
+    if (!id) return;
+    if (suppressNextClickId === id) {
+      suppressNextClickId = null;
+      return;
+    }
+    event.preventDefault();
+    onActivate(id);
+  };
+
+  const onContainerKeydown = (event: KeyboardEvent) => {
+    if (event.key !== "Enter" && event.key !== " ") return;
+    const id = anchorIdFromEvent(event);
+    if (!id) return;
+    event.preventDefault();
+    onActivate(id);
+
+    if (event.key === "Enter") {
+      suppressNextClickId = id;
+      queueMicrotask(() => {
+        if (suppressNextClickId === id) suppressNextClickId = null;
+      });
+    }
+  };
+
+  watchEffect((onCleanup) => {
+    const container = containerRef.value;
+    if (!container) return;
+
+    container.addEventListener("click", onContainerClick);
+    container.addEventListener("keydown", onContainerKeydown);
+    onCleanup(() => {
+      container.removeEventListener("click", onContainerClick);
+      container.removeEventListener("keydown", onContainerKeydown);
+    });
+  });
+};

--- a/app/composables/useAutoHidingChrome.ts
+++ b/app/composables/useAutoHidingChrome.ts
@@ -1,0 +1,78 @@
+/**
+ * Study mode's auto-hiding chrome: the reader toolbar (`ReaderToolbar`) and,
+ * on mobile, the site navbar (`layouts/reader.vue`) both read the same
+ * `visible` flag and translate away together on scroll-down, returning on
+ * scroll-up or near the top — see `~/utils/autoHidingChrome` for the pure
+ * transition rules this only measures scroll for.
+ *
+ * Provide/inject singleton, same shape as `useReaderState`/`useReaderMode`:
+ * `layouts/reader.vue` calls this first (with `scrollRef: null`, i.e. track
+ * `window` — study mode scrolls the whole document, there's no inner pane
+ * container), so it becomes the provider; `ReaderToolbar`'s later call (and
+ * any other consumer) just injects that same instance, regardless of what
+ * they pass for `scrollRef` — only the creating call's argument is ever
+ * used, since the whole point is one shared scroll-visibility state for
+ * every piece of chrome on the page.
+ *
+ * Reads `useReaderState().expandedAnchors` directly (rather than taking it
+ * as a parameter) so the public signature stays the single `scrollRef` arg
+ * named in the design brief, while still applying the "never hide while a
+ * disclosure is open near the top" rule baked into
+ * `nextChromeVisibilityState`.
+ */
+import type { ComputedRef, InjectionKey, Ref } from "vue";
+import {
+  initialChromeVisibilityState,
+  nextChromeVisibilityState,
+} from "~/utils/autoHidingChrome";
+
+export interface AutoHidingChrome {
+  visible: ComputedRef<boolean>;
+}
+
+const AUTO_HIDING_CHROME_KEY: InjectionKey<AutoHidingChrome> =
+  Symbol("auto-hiding-chrome");
+
+const createAutoHidingChrome = (
+  scrollRef: Ref<HTMLElement | null> | null,
+): AutoHidingChrome => {
+  const { expandedAnchors } = useReaderState();
+  const state = ref(initialChromeVisibilityState());
+
+  const readScrollTop = (): number => {
+    if (scrollRef) return scrollRef.value?.scrollTop ?? 0;
+    return typeof window === "undefined" ? 0 : window.scrollY;
+  };
+
+  const handleScroll = () => {
+    state.value = nextChromeVisibilityState(state.value, {
+      scrollTop: readScrollTop(),
+      hasOpenDisclosure: expandedAnchors.value.size > 0,
+    });
+  };
+
+  onMounted(() => {
+    const target: EventTarget | null | undefined = scrollRef
+      ? scrollRef.value
+      : typeof window === "undefined"
+        ? null
+        : window;
+    if (!target) return;
+
+    target.addEventListener("scroll", handleScroll, { passive: true });
+    onUnmounted(() => target.removeEventListener("scroll", handleScroll));
+  });
+
+  return { visible: computed(() => state.value.visible) };
+};
+
+export const useAutoHidingChrome = (
+  scrollRef: Ref<HTMLElement | null> | null = null,
+): AutoHidingChrome => {
+  const existing = inject(AUTO_HIDING_CHROME_KEY, null);
+  if (existing) return existing;
+
+  const state = createAutoHidingChrome(scrollRef);
+  provide(AUTO_HIDING_CHROME_KEY, state);
+  return state;
+};

--- a/app/composables/useAutoHidingChrome.ts
+++ b/app/composables/useAutoHidingChrome.ts
@@ -19,6 +19,13 @@
  * named in the design brief, while still applying the "never hide while a
  * disclosure is open near the top" rule baked into
  * `nextChromeVisibilityState`.
+ *
+ * The scroll listener itself is gated to study mode (`useReaderMode`):
+ * panes mode never shows any auto-hiding chrome, so it should cost zero
+ * scroll work — the listener attaches when `mode` becomes `"study"` and
+ * detaches the moment it isn't, rather than running for the lifetime of
+ * the page regardless of mode. Handler work is also rAF-throttled, same
+ * pattern as `ProgressRail`'s scroll/resize handling.
  */
 import type { ComputedRef, InjectionKey, Ref } from "vue";
 import {
@@ -37,6 +44,7 @@ const createAutoHidingChrome = (
   scrollRef: Ref<HTMLElement | null> | null,
 ): AutoHidingChrome => {
   const { expandedAnchors } = useReaderState();
+  const { mode } = useReaderMode();
   const state = ref(initialChromeVisibilityState());
 
   const readScrollTop = (): number => {
@@ -44,11 +52,25 @@ const createAutoHidingChrome = (
     return typeof window === "undefined" ? 0 : window.scrollY;
   };
 
-  const handleScroll = () => {
+  let rafHandle: number | null = null;
+
+  const measure = () => {
+    rafHandle = null;
     state.value = nextChromeVisibilityState(state.value, {
       scrollTop: readScrollTop(),
       hasOpenDisclosure: expandedAnchors.value.size > 0,
     });
+  };
+
+  const handleScroll = () => {
+    if (rafHandle !== null) return;
+    rafHandle = requestAnimationFrame(measure);
+  };
+
+  const cancelPendingMeasure = () => {
+    if (rafHandle === null) return;
+    cancelAnimationFrame(rafHandle);
+    rafHandle = null;
   };
 
   onMounted(() => {
@@ -59,8 +81,19 @@ const createAutoHidingChrome = (
         : window;
     if (!target) return;
 
-    target.addEventListener("scroll", handleScroll, { passive: true });
-    onUnmounted(() => target.removeEventListener("scroll", handleScroll));
+    watch(
+      mode,
+      (current, _previous, onCleanup) => {
+        if (current !== "study") return;
+
+        target.addEventListener("scroll", handleScroll, { passive: true });
+        onCleanup(() => {
+          target.removeEventListener("scroll", handleScroll);
+          cancelPendingMeasure();
+        });
+      },
+      { immediate: true },
+    );
   });
 
   return { visible: computed(() => state.value.visible) };

--- a/app/composables/useReaderMode.ts
+++ b/app/composables/useReaderMode.ts
@@ -1,0 +1,85 @@
+/**
+ * The reader's study/panes mode toggle — same provide/inject singleton
+ * shape as `useReaderState`: whichever component calls this first in a
+ * given reader page's tree (the `[chapter]` page itself, ahead of
+ * `ReaderShell`/`ReaderToolbar`/`StudyStream`) creates and provides the
+ * state; every later call in that tree injects the same instance.
+ *
+ * Hydration note (mirrors `useReaderVersions`): viewport is unknowable
+ * during prerendering, so consulting it (or the persisted override) for
+ * the very first client render would make that render diverge from the
+ * prerendered HTML it's hydrating — a mismatch. `resolveReaderMode`
+ * (`~/utils/readerMode`) always resolves to the fixed `FIXED_PREMOUNT_MODE`
+ * until `hydrated` flips true in `onMounted`; only then do the real
+ * viewport (`prefersStudyViewport`, tracked via a `matchMedia` listener)
+ * and the persisted `override` get consulted.
+ */
+import { useLocalStorage } from "@vueuse/core";
+import type { ComputedRef, InjectionKey } from "vue";
+import {
+  resolveReaderMode,
+  STUDY_MODE_MEDIA_QUERY,
+  type ReaderMode,
+} from "~/utils/readerMode";
+
+const STORAGE_KEY = "readtes:reader-mode";
+
+export interface ReaderModeState {
+  mode: ComputedRef<ReaderMode>;
+  /** Sets (and persists) an explicit user override — wins over the viewport default from then on. */
+  setMode: (mode: ReaderMode) => void;
+}
+
+const READER_MODE_KEY: InjectionKey<ReaderModeState> = Symbol("reader-mode");
+
+const createReaderModeState = (): ReaderModeState => {
+  const override = useLocalStorage<ReaderMode | null>(STORAGE_KEY, null);
+  const prefersStudyViewport = ref(false);
+
+  // Gates viewport/override reads until after mount — see the module doc.
+  const hydrated = ref(false);
+
+  onMounted(() => {
+    if (typeof window === "undefined" || !("matchMedia" in window)) {
+      hydrated.value = true;
+      return;
+    }
+
+    const mql = window.matchMedia(STUDY_MODE_MEDIA_QUERY);
+    prefersStudyViewport.value = mql.matches;
+
+    const onChange = (event: MediaQueryListEvent) => {
+      prefersStudyViewport.value = event.matches;
+    };
+    mql.addEventListener("change", onChange);
+    onUnmounted(() => mql.removeEventListener("change", onChange));
+
+    // Set only after `prefersStudyViewport` already reflects the real
+    // viewport, so `mode`'s first hydrated-reactive pass resolves correctly
+    // in one step rather than flashing the fixed default an extra tick.
+    hydrated.value = true;
+  });
+
+  const mode = computed(() =>
+    resolveReaderMode({
+      hydrated: hydrated.value,
+      override: override.value,
+      prefersStudyViewport: prefersStudyViewport.value,
+    }),
+  );
+
+  const setMode = (next: ReaderMode) => {
+    override.value = next;
+  };
+
+  return { mode, setMode };
+};
+
+export const useReaderMode = (): ReaderModeState => {
+  const existing = inject(READER_MODE_KEY, null);
+  if (existing) return existing;
+
+  const state = createReaderModeState();
+  provide(READER_MODE_KEY, state);
+  return state;
+};

--- a/app/composables/useReaderState.ts
+++ b/app/composables/useReaderState.ts
@@ -15,6 +15,7 @@ import {
   clearAnchorState,
   initialReaderAnchorState,
   reactivateAnchorState,
+  toggleInlineAnchorSet,
   type PaneId,
 } from "~/utils/readerAnchorState";
 
@@ -34,6 +35,15 @@ export interface ReaderState {
   /** Re-fires the highlight/scroll for the *current* anchor without changing it. */
   reactivateAnchor: () => void;
   clearAnchor: () => void;
+  /**
+   * Study mode's set of anchor ids whose commentary is currently unfolded
+   * inline (`InlineCommentary`/`StudyStream`) — panes mode never reads
+   * this. Several anchors can be open at once, so this is a set, not a
+   * scalar like `activeAnchor`.
+   */
+  expandedAnchors: Ref<ReadonlySet<string>>;
+  /** Opens `anchorId`'s inline disclosure if closed, closes it if open. */
+  toggleInline: (anchorId: string) => void;
 }
 
 const READER_STATE_KEY: InjectionKey<ReaderState> = Symbol("reader-state");
@@ -44,6 +54,7 @@ const createReaderState = (): ReaderState => {
   const anchorOrigin = ref<PaneId | null>(initial.anchorOrigin);
   const activePane = ref<PaneId>(initial.activePane);
   const activationSeq = ref<number>(initial.activationSeq);
+  const expandedAnchors = ref<ReadonlySet<string>>(new Set());
 
   const activateAnchor = (id: string, origin: PaneId) => {
     const next = activateAnchorState(
@@ -83,6 +94,13 @@ const createReaderState = (): ReaderState => {
     anchorOrigin.value = next.anchorOrigin;
   };
 
+  const toggleInline = (anchorId: string) => {
+    expandedAnchors.value = toggleInlineAnchorSet(
+      expandedAnchors.value,
+      anchorId,
+    );
+  };
+
   return {
     activeAnchor,
     anchorOrigin,
@@ -91,6 +109,8 @@ const createReaderState = (): ReaderState => {
     activateAnchor,
     reactivateAnchor,
     clearAnchor,
+    expandedAnchors,
+    toggleInline,
   };
 };
 

--- a/app/composables/useReaderState.ts
+++ b/app/composables/useReaderState.ts
@@ -1,9 +1,13 @@
 /**
- * The reader's cross-pane anchor sync state, shared by `ReaderShell` and
- * every pane beneath it via provide/inject — no event bus, no cross-pane
- * DOM reach. Each pane's own `useHighlightedAnchor(paneId, containerRef)`
- * watches `activeAnchor`/`anchorOrigin` and only reacts when it isn't the
- * origin pane.
+ * The reader's cross-pane anchor sync state. The actual provider is
+ * `layouts/reader.vue`: its unconditional `useAutoHidingChrome()` call
+ * reaches in and calls `useReaderState()` first, and since that layout
+ * renders as an ancestor of every reader page, that's the instance
+ * `ReaderShell` and every pane beneath it (however deeply slotted) end up
+ * injecting via provide/inject — no event bus, no cross-pane DOM reach.
+ * Each pane's own `useHighlightedAnchor(paneId, containerRef)` watches
+ * `activeAnchor`/`anchorOrigin` and only reacts when it isn't the origin
+ * pane.
  *
  * `activePane` exists (even though this task is desktop-first, all three
  * panes always visible) so a later single-pane mobile mode (T8) can plug
@@ -115,13 +119,25 @@ const createReaderState = (): ReaderState => {
 };
 
 /**
- * Called by `ReaderShell` (provides a fresh state) and by every pane beneath
- * it (injects the same instance) — whichever component calls this first in
- * a given reader page's tree creates and provides the state.
+ * The real provider is `layouts/reader.vue` (see the module doc above);
+ * `ReaderShell` and every pane beneath it just inject that same instance.
+ * The fresh-instance fallback below only exists for a caller mounted
+ * without that layout as an ancestor (an isolated test, a future misuse)
+ * — since that means the expected provider never ran, it warns in dev so
+ * the mistake doesn't go silent.
  */
 export const useReaderState = (): ReaderState => {
   const existing = inject(READER_STATE_KEY, null);
   if (existing) return existing;
+
+  if (import.meta.dev) {
+    console.warn(
+      "[useReaderState] no provided reader state found in the component " +
+        "tree — creating a fresh instance instead. Expected " +
+        "`layouts/reader.vue` (via its useAutoHidingChrome() call) to have " +
+        "provided one higher up.",
+    );
+  }
 
   const state = createReaderState();
   provide(READER_STATE_KEY, state);

--- a/app/layouts/reader.vue
+++ b/app/layouts/reader.vue
@@ -1,5 +1,20 @@
 <script setup lang="ts">
+// This layout is only ever used by the `/read/[part]/[chapter]` page, so
+// it's safe (and the only place it makes sense) to establish the reader's
+// shared mode/auto-hide-chrome state here: `useReaderMode()` and
+// `useAutoHidingChrome()` are provide/inject singletons (see those
+// composables) — whichever component calls each first in the tree becomes
+// its provider, and since this layout renders *around* the page (an
+// ancestor in the component tree, not a sibling), calling them here first
+// means `ReaderToolbar`'s later calls just inject the same instances. That
+// lets the navbar (only this layout's concern) and the toolbar (the page's)
+// hide/show as one unit on mobile scroll, without the layout needing to
+// know anything about the page beneath it beyond that.
 const { t } = useI18n();
+
+const { mode } = useReaderMode();
+const { visible: chromeVisible } = useAutoHidingChrome();
+const isStudyMode = computed(() => mode.value === "study");
 </script>
 
 <template>
@@ -12,7 +27,15 @@ const { t } = useI18n();
     >
       {{ t("common.skipToContent") }}
     </a>
-    <AppNavBar />
+    <div
+      :class="[
+        isStudyMode &&
+          'sticky top-0 z-40 transition-transform duration-200 ease-out motion-reduce:transition-none',
+        isStudyMode && !chromeVisible && '-translate-y-full',
+      ]"
+    >
+      <AppNavBar />
+    </div>
     <main id="main-content" class="flex-1">
       <slot />
     </main>

--- a/app/pages/read/[part]/[chapter].vue
+++ b/app/pages/read/[part]/[chapter].vue
@@ -46,6 +46,11 @@ const {
 );
 
 const readerVersions = useReaderVersions(entry.chapter, versions.value);
+// Study mode below `lg`, panes at/above it by default — user overrides
+// persist across chapters (`useReaderMode`). Decides which of the two
+// component trees below actually mounts; `ReaderToolbar` (rendered either
+// way) reads the same shared state for its mode-toggle control.
+const { mode } = useReaderMode();
 const versionsById = computed(() => buildVersionsById(versions.value));
 
 const versionOptions = (ids: string[]) =>
@@ -139,67 +144,96 @@ useSeoMeta({
 </script>
 
 <template>
-  <ReaderShell>
-    <template #toolbar>
+  <div class="contents">
+    <ReaderShell v-if="mode === 'panes'">
+      <template #toolbar>
+        <ReaderToolbar
+          :breadcrumb-items="breadcrumbItems"
+          :prev="prev"
+          :next="next"
+        />
+      </template>
+
+      <template #summary>
+        <ReaderPane
+          :title="t('reader.pane.summary')"
+          :version-options="summaryVersionOptions"
+          :model-value="readerVersions.summary.value"
+          :meta="summaryMeta"
+          @update:model-value="(id) => readerVersions.setVersion('summary', id)"
+        >
+          <ReaderSummaryPane
+            :summary-items="summaryItems"
+            :source-segments="sourceSegments"
+          />
+        </ReaderPane>
+      </template>
+
+      <template #source>
+        <ReaderPane
+          :title="t('reader.pane.source')"
+          :version-options="sourceVersionOptions"
+          :model-value="readerVersions.source.value"
+          :meta="sourceMeta"
+          @update:model-value="(id) => readerVersions.setVersion('source', id)"
+        >
+          <ReaderSourcePane :segments="sourceSegments" />
+        </ReaderPane>
+      </template>
+
+      <template #commentary>
+        <ReaderPane
+          :title="t('reader.pane.commentary')"
+          :version-options="commentaryVersionOptions"
+          :model-value="readerVersions.commentary.value"
+          :meta="commentaryMeta"
+          @update:model-value="
+            (id) => readerVersions.setVersion('commentary', id)
+          "
+        >
+          <template v-if="missingAnchorNotice" #toast>
+            <p class="basis-full text-xs text-orange-cta">
+              {{ t("reader.missingAnchor.message") }}
+              <button
+                v-if="missingAnchorNotice.canSwitchToHebrew"
+                type="button"
+                class="ms-1 underline"
+                @click="switchCommentaryToHebrew"
+              >
+                {{ t("reader.missingAnchor.switchToHebrew") }}
+              </button>
+            </p>
+          </template>
+          <ReaderCommentaryPane :items="commentaryItems" />
+        </ReaderPane>
+      </template>
+    </ReaderShell>
+
+    <template v-else>
       <ReaderToolbar
         :breadcrumb-items="breadcrumbItems"
         :prev="prev"
         :next="next"
       />
-    </template>
-
-    <template #summary>
-      <ReaderPane
-        :title="t('reader.pane.summary')"
-        :version-options="summaryVersionOptions"
-        :model-value="readerVersions.summary.value"
-        :meta="summaryMeta"
-        @update:model-value="(id) => readerVersions.setVersion('summary', id)"
-      >
-        <ReaderSummaryPane
-          :summary-items="summaryItems"
-          :source-segments="sourceSegments"
-        />
-      </ReaderPane>
-    </template>
-
-    <template #source>
-      <ReaderPane
-        :title="t('reader.pane.source')"
-        :version-options="sourceVersionOptions"
-        :model-value="readerVersions.source.value"
-        :meta="sourceMeta"
-        @update:model-value="(id) => readerVersions.setVersion('source', id)"
-      >
-        <ReaderSourcePane :segments="sourceSegments" />
-      </ReaderPane>
-    </template>
-
-    <template #commentary>
-      <ReaderPane
-        :title="t('reader.pane.commentary')"
-        :version-options="commentaryVersionOptions"
-        :model-value="readerVersions.commentary.value"
-        :meta="commentaryMeta"
-        @update:model-value="
-          (id) => readerVersions.setVersion('commentary', id)
+      <ReaderStudyStream
+        :source-segments="sourceSegments"
+        :commentary-items="commentaryItems"
+        :summary-items="summaryItems"
+        :source-meta="sourceMeta"
+        :commentary-meta="commentaryMeta"
+        :source-version-options="sourceVersionOptions"
+        :commentary-version-options="commentaryVersionOptions"
+        :source-version="readerVersions.source.value"
+        :commentary-version="readerVersions.commentary.value"
+        :hebrew-items="commentaryByVersion[HEBREW_VERSION_ID]?.items ?? null"
+        :hebrew-version-id="HEBREW_VERSION_ID"
+        @update:source-version="
+          (id: string) => readerVersions.setVersion('source', id)
         "
-      >
-        <template v-if="missingAnchorNotice" #toast>
-          <p class="basis-full text-xs text-orange-cta">
-            {{ t("reader.missingAnchor.message") }}
-            <button
-              v-if="missingAnchorNotice.canSwitchToHebrew"
-              type="button"
-              class="ms-1 underline"
-              @click="switchCommentaryToHebrew"
-            >
-              {{ t("reader.missingAnchor.switchToHebrew") }}
-            </button>
-          </p>
-        </template>
-        <ReaderCommentaryPane :items="commentaryItems" />
-      </ReaderPane>
+        @update:commentary-version="
+          (id: string) => readerVersions.setVersion('commentary', id)
+        "
+      />
     </template>
-  </ReaderShell>
+  </div>
 </template>

--- a/app/utils/autoHidingChrome.ts
+++ b/app/utils/autoHidingChrome.ts
@@ -1,0 +1,56 @@
+/**
+ * Pure state machine for the study mode's auto-hiding chrome
+ * (`useAutoHidingChrome`): the reader toolbar (and, on mobile, the site
+ * navbar) translates away on scroll-down and returns on scroll-up, so the
+ * reading stream gets the full viewport without chrome ever being
+ * unreachable. Kept free of the DOM so the transition rules are
+ * unit-testable without mounting anything — the composable only measures
+ * `scrollTop` and forwards it here.
+ */
+export interface ChromeVisibilityState {
+  visible: boolean;
+  lastScrollTop: number;
+}
+
+export const initialChromeVisibilityState = (): ChromeVisibilityState => ({
+  visible: true,
+  lastScrollTop: 0,
+});
+
+/** Sub-pixel/momentum-scroll jitter smaller than this never toggles visibility. */
+const HIDE_THRESHOLD_PX = 8;
+
+/** Always visible within this many px of the very top of the stream. */
+const NEAR_TOP_PX = 48;
+
+/**
+ * A wider "always visible" band used only while a disclosure is open —
+ * hiding the chrome out from under an inline commentary card the reader
+ * just opened near the top of the stream would read as content jumping
+ * under them; the plain `NEAR_TOP_PX` band alone isn't generous enough to
+ * cover that case.
+ */
+const NEAR_TOP_WITH_DISCLOSURE_PX = 240;
+
+export const nextChromeVisibilityState = (
+  state: ChromeVisibilityState,
+  params: { scrollTop: number; hasOpenDisclosure: boolean },
+): ChromeVisibilityState => {
+  const { scrollTop, hasOpenDisclosure } = params;
+
+  if (scrollTop <= NEAR_TOP_PX) {
+    return { visible: true, lastScrollTop: scrollTop };
+  }
+
+  if (hasOpenDisclosure && scrollTop <= NEAR_TOP_WITH_DISCLOSURE_PX) {
+    return { visible: true, lastScrollTop: scrollTop };
+  }
+
+  const delta = scrollTop - state.lastScrollTop;
+  if (Math.abs(delta) < HIDE_THRESHOLD_PX) {
+    return { ...state, lastScrollTop: scrollTop };
+  }
+
+  // Scrolling down (positive delta) hides; scrolling up shows.
+  return { visible: delta < 0, lastScrollTop: scrollTop };
+};

--- a/app/utils/commentaryNotice.ts
+++ b/app/utils/commentaryNotice.ts
@@ -18,6 +18,46 @@ export interface MissingAnchorNotice {
   canSwitchToHebrew: boolean;
 }
 
+export interface AnchorAvailability {
+  /** `true` when `anchorId` has no item in the currently-displayed version. */
+  missing: boolean;
+  /** Whether the chapter's Hebrew commentary version does have this anchor. */
+  canSwitchToHebrew: boolean;
+}
+
+/**
+ * Core "is this anchor missing from the commentary version currently
+ * shown, and can the reader one-click over to Hebrew instead" rule, keyed
+ * by a single `anchorId` — shared by `resolveMissingAnchorNotice` (panes
+ * mode's single global toast, gated to the one `activeAnchor`) and study
+ * mode's `StudyStream`, which runs this once per anchor in
+ * `expandedAnchors` (several can be open at once, unlike panes mode's
+ * single active anchor).
+ */
+export const resolveAnchorAvailability = (params: {
+  anchorId: string;
+  /** Items of the commentary version currently displayed (empty if none loaded). */
+  displayedItems: CommentaryItem[];
+  /** The chapter's currently-selected commentary version id, if any. */
+  selectedVersionId: string | null;
+  /** Items of the chapter's `he-jerusalem-1956` commentary version, if it exists. */
+  hebrewItems: CommentaryItem[] | null;
+  hebrewVersionId: string;
+}): AnchorAvailability => {
+  const alreadyShown = params.displayedItems.some(
+    (item) => item.anchorId === params.anchorId,
+  );
+  if (alreadyShown) return { missing: false, canSwitchToHebrew: false };
+
+  const isHebrewSelected = params.selectedVersionId === params.hebrewVersionId;
+  const hebrewHasAnchor =
+    !isHebrewSelected &&
+    (params.hebrewItems?.some((item) => item.anchorId === params.anchorId) ??
+      false);
+
+  return { missing: true, canSwitchToHebrew: hebrewHasAnchor };
+};
+
 export const resolveMissingAnchorNotice = (params: {
   activeAnchor: string | null;
   anchorOrigin: PaneId | null;
@@ -38,16 +78,17 @@ export const resolveMissingAnchorNotice = (params: {
   if (anchorOrigin !== "source") return null;
   if (!activeAnchor || !isCommentaryAnchor(activeAnchor)) return null;
 
-  const alreadyShown = params.displayedItems.some(
-    (item) => item.anchorId === activeAnchor,
-  );
-  if (alreadyShown) return null;
+  const availability = resolveAnchorAvailability({
+    anchorId: activeAnchor,
+    displayedItems: params.displayedItems,
+    selectedVersionId: params.selectedVersionId,
+    hebrewItems: params.hebrewItems,
+    hebrewVersionId: params.hebrewVersionId,
+  });
+  if (!availability.missing) return null;
 
-  const isHebrewSelected = params.selectedVersionId === params.hebrewVersionId;
-  const hebrewHasAnchor =
-    !isHebrewSelected &&
-    (params.hebrewItems?.some((item) => item.anchorId === activeAnchor) ??
-      false);
-
-  return { anchorId: activeAnchor, canSwitchToHebrew: hebrewHasAnchor };
+  return {
+    anchorId: activeAnchor,
+    canSwitchToHebrew: availability.canSwitchToHebrew,
+  };
 };

--- a/app/utils/readerAnchorState.ts
+++ b/app/utils/readerAnchorState.ts
@@ -69,3 +69,25 @@ export const reactivateAnchorState = (
   ...state,
   activationSeq: state.activationSeq + 1,
 });
+
+/**
+ * Toggles one anchor id in study mode's set of inline-expanded commentary
+ * disclosures (`useReaderState().expandedAnchors`) — unlike `activeAnchor`
+ * (a single value), several anchors can be unfolded inline at once, so
+ * this is a set, not a scalar. Always returns a new `Set` instance (never
+ * mutates `expanded` in place) so a plain `ref<Set<string>>` re-render
+ * correctly off a wholesale reassignment, the same immutable-update
+ * approach as the rest of this module.
+ */
+export const toggleInlineAnchorSet = (
+  expanded: ReadonlySet<string>,
+  anchorId: string,
+): Set<string> => {
+  const next = new Set(expanded);
+  if (next.has(anchorId)) {
+    next.delete(anchorId);
+  } else {
+    next.add(anchorId);
+  }
+  return next;
+};

--- a/app/utils/readerMode.ts
+++ b/app/utils/readerMode.ts
@@ -1,0 +1,41 @@
+/**
+ * Pure default-resolution rule for the reader's mode toggle
+ * (`useReaderMode`): study (single scrolling stream, commentary folds in
+ * inline) vs panes (the T7 three-aligned-panes layout).
+ *
+ * Viewport is unknowable during prerendering/SSR (there is no `window`),
+ * and re-checking it in the very first client render (used for hydration)
+ * would diverge from that prerendered markup — the same hydration hazard
+ * `useReaderVersions` documents for persisted version prefs. The fix here
+ * is the same shape: `resolveReaderMode` always returns the fixed,
+ * viewport-independent `FIXED_PREMOUNT_MODE` until `hydrated` is true, so
+ * SSR output and the client's pre-mount render are always identical byte
+ * for byte. Only after `onMounted` does the real viewport (and any
+ * persisted user override) get consulted — see `useReaderMode`.
+ *
+ * `FIXED_PREMOUNT_MODE` is "panes" specifically because that's what every
+ * one of this repo's 238 prerendered `/read/**` routes already ships
+ * (T7 — the three-pane layout with no viewport branching at all): keeping
+ * it as the fixed pre-mount default means this task changes zero bytes of
+ * existing prerendered HTML, and mobile visitors see that same markup for
+ * one frame before JS swaps them into study mode, instead of any route's
+ * static output changing shape.
+ */
+export type ReaderMode = "study" | "panes";
+
+/** Matches Tailwind's `lg` breakpoint (1024px) — study mode below it, panes at/above. */
+export const STUDY_MODE_MEDIA_QUERY = "(max-width: 1023.98px)";
+
+export const FIXED_PREMOUNT_MODE: ReaderMode = "panes";
+
+export const resolveReaderMode = (params: {
+  hydrated: boolean;
+  /** The user's persisted explicit choice, if any — always wins once hydrated. */
+  override: ReaderMode | null;
+  /** `true` when `STUDY_MODE_MEDIA_QUERY` currently matches. */
+  prefersStudyViewport: boolean;
+}): ReaderMode => {
+  if (!params.hydrated) return FIXED_PREMOUNT_MODE;
+  if (params.override) return params.override;
+  return params.prefersStudyViewport ? "study" : "panes";
+};

--- a/app/utils/readingProgress.ts
+++ b/app/utils/readingProgress.ts
@@ -1,0 +1,20 @@
+/**
+ * Pure computation for `ProgressRail`: how far through the chapter's
+ * scrollable content the reader has scrolled, as a 0..1 fraction. Kept
+ * separate from the DOM measurements (`scrollTop`/`innerHeight`/
+ * `scrollHeight`) so the arithmetic — including the "nothing to scroll"
+ * edge case — is unit-testable without a real layout.
+ */
+export const computeReadingProgress = (params: {
+  scrollTop: number;
+  viewportHeight: number;
+  contentHeight: number;
+}): number => {
+  const scrollable = params.contentHeight - params.viewportHeight;
+
+  // A chapter shorter than the viewport has nothing to scroll — it's
+  // entirely on screen already, i.e. fully "read" through.
+  if (scrollable <= 0) return 1;
+
+  return Math.min(Math.max(params.scrollTop / scrollable, 0), 1);
+};

--- a/i18n/locales/en.json
+++ b/i18n/locales/en.json
@@ -47,7 +47,21 @@
     },
     "prevChapter": "Previous chapter",
     "nextChapter": "Next chapter",
-    "chapterNav": "Chapter navigation"
+    "chapterNav": "Chapter navigation",
+    "mode": {
+      "label": "Reading mode",
+      "study": "Study",
+      "panes": "Panes"
+    },
+    "chapterIntro": {
+      "title": "In this chapter"
+    },
+    "studyMode": {
+      "fold": "Fold",
+      "readFullCommentary": "Read the full commentary",
+      "readFullCommentaryHint": "Only commentary you've opened shows here — browse every item for this chapter in the full three-pane view."
+    },
+    "progressLabel": "Reading progress"
   },
   "home": {
     "description": "Talmud Eser Sefirot, read as aligned summary, source, and commentary — in English and Hebrew.",

--- a/i18n/locales/he.json
+++ b/i18n/locales/he.json
@@ -47,7 +47,21 @@
     },
     "prevChapter": "הפרק הקודם",
     "nextChapter": "הפרק הבא",
-    "chapterNav": "ניווט בין פרקים"
+    "chapterNav": "ניווט בין פרקים",
+    "mode": {
+      "label": "מצב קריאה",
+      "study": "לימוד",
+      "panes": "עמודות"
+    },
+    "chapterIntro": {
+      "title": "בפרק זה"
+    },
+    "studyMode": {
+      "fold": "קפל",
+      "readFullCommentary": "קרא את הפירוש המלא",
+      "readFullCommentaryHint": "רק פירוש שפתחת מוצג כאן — עיין בכל הפריטים לפרק זה בתצוגת שלוש העמודות המלאה."
+    },
+    "progressLabel": "התקדמות בקריאה"
   },
   "home": {
     "description": "תלמוד עשר הספירות, לקריאה כשכבות מיושרות של תקציר, מקור ופירוש — באנגלית ובעברית.",

--- a/tests/unit/auto-hiding-chrome.spec.ts
+++ b/tests/unit/auto-hiding-chrome.spec.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from "vitest";
+
+describe("initialChromeVisibilityState", () => {
+  it("starts visible, at the top", () => {
+    expect(initialChromeVisibilityState()).toEqual({
+      visible: true,
+      lastScrollTop: 0,
+    });
+  });
+});
+
+describe("nextChromeVisibilityState", () => {
+  it("hides on a clear scroll-down past the near-top band", () => {
+    const state = { visible: true, lastScrollTop: 100 };
+    const next = nextChromeVisibilityState(state, {
+      scrollTop: 200,
+      hasOpenDisclosure: false,
+    });
+
+    expect(next.visible).toBe(false);
+    expect(next.lastScrollTop).toBe(200);
+  });
+
+  it("shows again on a clear scroll-up", () => {
+    const state = { visible: false, lastScrollTop: 400 };
+    const next = nextChromeVisibilityState(state, {
+      scrollTop: 300,
+      hasOpenDisclosure: false,
+    });
+
+    expect(next.visible).toBe(true);
+  });
+
+  it("stays visible within the near-top band regardless of direction", () => {
+    const state = { visible: true, lastScrollTop: 0 };
+    const next = nextChromeVisibilityState(state, {
+      scrollTop: 20,
+      hasOpenDisclosure: false,
+    });
+
+    expect(next.visible).toBe(true);
+  });
+
+  it("ignores sub-threshold jitter without toggling visibility", () => {
+    const state = { visible: false, lastScrollTop: 500 };
+    const next = nextChromeVisibilityState(state, {
+      scrollTop: 503,
+      hasOpenDisclosure: false,
+    });
+
+    expect(next.visible).toBe(false);
+    expect(next.lastScrollTop).toBe(503);
+  });
+
+  it("never hides while a disclosure is open near the top, even past the plain near-top band", () => {
+    const state = { visible: true, lastScrollTop: 60 };
+    const next = nextChromeVisibilityState(state, {
+      scrollTop: 200,
+      hasOpenDisclosure: true,
+    });
+
+    expect(next.visible).toBe(true);
+  });
+
+  it("still hides on scroll-down once far enough past the disclosure-open band", () => {
+    const state = { visible: true, lastScrollTop: 250 };
+    const next = nextChromeVisibilityState(state, {
+      scrollTop: 400,
+      hasOpenDisclosure: true,
+    });
+
+    expect(next.visible).toBe(false);
+  });
+
+  it("hides normally on scroll-down once the disclosure closes", () => {
+    const state = { visible: true, lastScrollTop: 100 };
+    const next = nextChromeVisibilityState(state, {
+      scrollTop: 200,
+      hasOpenDisclosure: false,
+    });
+
+    expect(next.visible).toBe(false);
+  });
+});

--- a/tests/unit/commentary-notice.spec.ts
+++ b/tests/unit/commentary-notice.spec.ts
@@ -105,3 +105,82 @@ describe("resolveMissingAnchorNotice", () => {
     ).toEqual({ anchorId: "op-9", canSwitchToHebrew: false });
   });
 });
+
+// `resolveAnchorAvailability` is the per-anchor rule `resolveMissingAnchorNotice`
+// itself delegates to — study mode (`StudyStream`) runs this once per
+// anchor in `expandedAnchors` instead of gating on a single global
+// `activeAnchor`/`anchorOrigin`, since several inline disclosures can be
+// open at once, each independently "missing" or not.
+describe("resolveAnchorAvailability", () => {
+  it("is not missing when the currently-displayed version already has the anchor", () => {
+    expect(
+      resolveAnchorAvailability({
+        anchorId: "op-1",
+        displayedItems: [commentaryItem("op-1")],
+        selectedVersionId: "en-sefaria-community",
+        hebrewItems: null,
+        hebrewVersionId: HEBREW,
+      }),
+    ).toEqual({ missing: false, canSwitchToHebrew: false });
+  });
+
+  it("is missing, and offers a switch to Hebrew, when Hebrew has the anchor", () => {
+    expect(
+      resolveAnchorAvailability({
+        anchorId: "op-9",
+        displayedItems: [commentaryItem("op-1")],
+        selectedVersionId: "en-sefaria-community",
+        hebrewItems: [commentaryItem("op-9")],
+        hebrewVersionId: HEBREW,
+      }),
+    ).toEqual({ missing: true, canSwitchToHebrew: true });
+  });
+
+  it("is missing with no Hebrew switch offered when Hebrew doesn't have it either", () => {
+    expect(
+      resolveAnchorAvailability({
+        anchorId: "op-9",
+        displayedItems: [],
+        selectedVersionId: "en-sefaria-community",
+        hebrewItems: null,
+        hebrewVersionId: HEBREW,
+      }),
+    ).toEqual({ missing: true, canSwitchToHebrew: false });
+  });
+
+  it("doesn't offer a switch when Hebrew is already the version being shown", () => {
+    expect(
+      resolveAnchorAvailability({
+        anchorId: "op-9",
+        displayedItems: [],
+        selectedVersionId: HEBREW,
+        hebrewItems: [],
+        hebrewVersionId: HEBREW,
+      }),
+    ).toEqual({ missing: true, canSwitchToHebrew: false });
+  });
+
+  it("checks each anchor independently — several can be open in study mode at once", () => {
+    const displayedItems = [commentaryItem("op-1")];
+
+    expect(
+      resolveAnchorAvailability({
+        anchorId: "op-1",
+        displayedItems,
+        selectedVersionId: "en-sefaria-community",
+        hebrewItems: null,
+        hebrewVersionId: HEBREW,
+      }).missing,
+    ).toBe(false);
+
+    expect(
+      resolveAnchorAvailability({
+        anchorId: "op-2",
+        displayedItems,
+        selectedVersionId: "en-sefaria-community",
+        hebrewItems: null,
+        hebrewVersionId: HEBREW,
+      }).missing,
+    ).toBe(true);
+  });
+});

--- a/tests/unit/reader-anchor-state.spec.ts
+++ b/tests/unit/reader-anchor-state.spec.ts
@@ -102,3 +102,29 @@ describe("clearAnchorState", () => {
     });
   });
 });
+
+describe("toggleInlineAnchorSet", () => {
+  it("adds an anchor id that isn't yet expanded", () => {
+    const next = toggleInlineAnchorSet(new Set(), "op-1");
+    expect(next).toEqual(new Set(["op-1"]));
+  });
+
+  it("removes an anchor id that's already expanded (fold)", () => {
+    const next = toggleInlineAnchorSet(new Set(["op-1"]), "op-1");
+    expect(next).toEqual(new Set());
+  });
+
+  it("leaves other expanded anchors untouched — several can be open at once", () => {
+    const next = toggleInlineAnchorSet(new Set(["op-1", "op-2"]), "op-3");
+    expect(next).toEqual(new Set(["op-1", "op-2", "op-3"]));
+
+    const folded = toggleInlineAnchorSet(next, "op-2");
+    expect(folded).toEqual(new Set(["op-1", "op-3"]));
+  });
+
+  it("never mutates the set it was given", () => {
+    const original = new Set(["op-1"]);
+    toggleInlineAnchorSet(original, "op-2");
+    expect(original).toEqual(new Set(["op-1"]));
+  });
+});

--- a/tests/unit/reader-mode.spec.ts
+++ b/tests/unit/reader-mode.spec.ts
@@ -1,0 +1,155 @@
+import { mountSuspended } from "@nuxt/test-utils/runtime";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { defineComponent, nextTick } from "vue";
+
+describe("resolveReaderMode", () => {
+  it("always resolves to the fixed premount mode before hydration, regardless of viewport", () => {
+    expect(
+      resolveReaderMode({
+        hydrated: false,
+        override: null,
+        prefersStudyViewport: true,
+      }),
+    ).toBe(FIXED_PREMOUNT_MODE);
+
+    expect(
+      resolveReaderMode({
+        hydrated: false,
+        override: "study",
+        prefersStudyViewport: true,
+      }),
+    ).toBe(FIXED_PREMOUNT_MODE);
+  });
+
+  it("resolves to study on a narrow viewport once hydrated, with no override", () => {
+    expect(
+      resolveReaderMode({
+        hydrated: true,
+        override: null,
+        prefersStudyViewport: true,
+      }),
+    ).toBe("study");
+  });
+
+  it("resolves to panes on a wide viewport once hydrated, with no override", () => {
+    expect(
+      resolveReaderMode({
+        hydrated: true,
+        override: null,
+        prefersStudyViewport: false,
+      }),
+    ).toBe("panes");
+  });
+
+  it("lets a persisted override win over the viewport default once hydrated", () => {
+    expect(
+      resolveReaderMode({
+        hydrated: true,
+        override: "panes",
+        prefersStudyViewport: true,
+      }),
+    ).toBe("panes");
+
+    expect(
+      resolveReaderMode({
+        hydrated: true,
+        override: "study",
+        prefersStudyViewport: false,
+      }),
+    ).toBe("study");
+  });
+});
+
+describe("useReaderMode (hydration)", () => {
+  const stubMatchMedia = (matches: boolean) => {
+    const listeners = new Set<(event: MediaQueryListEvent) => void>();
+    vi.stubGlobal(
+      "matchMedia",
+      vi.fn().mockImplementation((query: string) => ({
+        matches,
+        media: query,
+        addEventListener: (
+          _type: string,
+          listener: (event: MediaQueryListEvent) => void,
+        ) => listeners.add(listener),
+        removeEventListener: (
+          _type: string,
+          listener: (event: MediaQueryListEvent) => void,
+        ) => listeners.delete(listener),
+      })),
+    );
+  };
+
+  const Host = defineComponent({
+    setup() {
+      const readerMode = useReaderMode();
+      // Captured synchronously in `setup` — this is what SSR (and the
+      // client's pre-mount render) would have resolved to.
+      const preMountMode = readerMode.mode.value;
+      return { readerMode, preMountMode };
+    },
+    render: () => null,
+  });
+
+  beforeEach(() => {
+    localStorage.clear();
+    vi.unstubAllGlobals();
+  });
+
+  it("resolves to the fixed premount mode before mount, then the narrow-viewport default after", async () => {
+    stubMatchMedia(true);
+
+    const wrapper = await mountSuspended(Host);
+
+    expect(wrapper.vm.preMountMode).toBe(FIXED_PREMOUNT_MODE);
+
+    await nextTick();
+
+    expect(wrapper.vm.readerMode.mode.value).toBe("study");
+  });
+
+  it("resolves to panes after mount on a wide viewport", async () => {
+    stubMatchMedia(false);
+
+    const wrapper = await mountSuspended(Host);
+    await nextTick();
+
+    expect(wrapper.vm.readerMode.mode.value).toBe("panes");
+  });
+
+  it("reconciles a persisted override in after mount, winning over the viewport default", async () => {
+    stubMatchMedia(true);
+
+    // Establish the persisted override the same way the composable itself
+    // writes it (via `setMode`), rather than assuming a storage encoding.
+    const setup = await mountSuspended(Host);
+    await nextTick();
+    setup.vm.readerMode.setMode("panes");
+    await nextTick();
+
+    // A fresh mount (a "new page load") still starts from the fixed default...
+    const wrapper = await mountSuspended(Host);
+    expect(wrapper.vm.preMountMode).toBe(FIXED_PREMOUNT_MODE);
+
+    // ...then reconciles to the persisted override once hydrated, even
+    // though the viewport default here would be "study".
+    await nextTick();
+    expect(wrapper.vm.readerMode.mode.value).toBe("panes");
+  });
+
+  it("persists an explicit setMode call across a fresh mount", async () => {
+    stubMatchMedia(true);
+
+    const wrapper = await mountSuspended(Host);
+    await nextTick();
+    expect(wrapper.vm.readerMode.mode.value).toBe("study");
+
+    wrapper.vm.readerMode.setMode("panes");
+    await nextTick();
+    expect(wrapper.vm.readerMode.mode.value).toBe("panes");
+
+    const returning = await mountSuspended(Host);
+    await nextTick();
+    expect(returning.vm.readerMode.mode.value).toBe("panes");
+  });
+});

--- a/tests/unit/reader-toolbar.spec.ts
+++ b/tests/unit/reader-toolbar.spec.ts
@@ -84,4 +84,40 @@ describe("ReaderToolbar", () => {
     const disabled = wrapper.findAll("[aria-disabled='true']");
     expect(disabled.length).toBe(2);
   });
+
+  it("renders a study/panes mode toggle, reflecting the current mode via aria-pressed", async () => {
+    const wrapper = await mountSuspended(ReaderToolbar, {
+      props: { breadcrumbItems, prev: null, next: null },
+    });
+
+    const studyButton = wrapper
+      .findAll("button")
+      .find((button) => button.text() === "Study");
+    const panesButton = wrapper
+      .findAll("button")
+      .find((button) => button.text() === "Panes");
+    expect(studyButton).toBeTruthy();
+    expect(panesButton).toBeTruthy();
+  });
+
+  it("switches the toggle's pressed state when clicked", async () => {
+    const wrapper = await mountSuspended(ReaderToolbar, {
+      props: { breadcrumbItems, prev: null, next: null },
+    });
+
+    const studyButton = wrapper
+      .findAll("button")
+      .find((button) => button.text() === "Study");
+    const panesButton = wrapper
+      .findAll("button")
+      .find((button) => button.text() === "Panes");
+
+    await studyButton?.trigger("click");
+    expect(studyButton?.attributes("aria-pressed")).toBe("true");
+    expect(panesButton?.attributes("aria-pressed")).toBe("false");
+
+    await panesButton?.trigger("click");
+    expect(panesButton?.attributes("aria-pressed")).toBe("true");
+    expect(studyButton?.attributes("aria-pressed")).toBe("false");
+  });
 });

--- a/tests/unit/reading-progress.spec.ts
+++ b/tests/unit/reading-progress.spec.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from "vitest";
+
+describe("computeReadingProgress", () => {
+  it("is 0 at the very top of a scrollable chapter", () => {
+    expect(
+      computeReadingProgress({
+        scrollTop: 0,
+        viewportHeight: 800,
+        contentHeight: 3000,
+      }),
+    ).toBe(0);
+  });
+
+  it("is 1 at the very bottom of a scrollable chapter", () => {
+    expect(
+      computeReadingProgress({
+        scrollTop: 2200,
+        viewportHeight: 800,
+        contentHeight: 3000,
+      }),
+    ).toBe(1);
+  });
+
+  it("is proportional partway through", () => {
+    expect(
+      computeReadingProgress({
+        scrollTop: 1100,
+        viewportHeight: 800,
+        contentHeight: 3000,
+      }),
+    ).toBe(0.5);
+  });
+
+  it("is 1 (fully read) when the chapter is shorter than the viewport", () => {
+    expect(
+      computeReadingProgress({
+        scrollTop: 0,
+        viewportHeight: 800,
+        contentHeight: 400,
+      }),
+    ).toBe(1);
+  });
+
+  it("clamps to 1 even if scrollTop overshoots (e.g. elastic/bounce scrolling)", () => {
+    expect(
+      computeReadingProgress({
+        scrollTop: 5000,
+        viewportHeight: 800,
+        contentHeight: 3000,
+      }),
+    ).toBe(1);
+  });
+
+  it("clamps to 0 for a negative scrollTop (elastic overscroll at the top)", () => {
+    expect(
+      computeReadingProgress({
+        scrollTop: -50,
+        viewportHeight: 800,
+        contentHeight: 3000,
+      }),
+    ).toBe(0);
+  });
+});

--- a/tests/unit/study-stream.spec.ts
+++ b/tests/unit/study-stream.spec.ts
@@ -1,0 +1,156 @@
+// Integration coverage for study mode's inline commentary disclosure
+// (T8): a small, close-to-production mount of the real `StudyStream` —
+// covers tapping an anchor to unfold/fold its commentary inline, several
+// anchors open at once, and the inline missing-anchor notice with its
+// one-click Hebrew switch. `reader-anchor-sync.spec.ts` covers the
+// equivalent panes-mode cross-pane behaviour this reuses
+// (`useAnchorActivation`/`useHighlightedAnchor`).
+import { mountSuspended } from "@nuxt/test-utils/runtime";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import StudyStream from "~/components/reader/StudyStream.vue";
+import type { CommentaryItem, SourceSegment } from "~~/shared/types/content";
+
+const HEBREW = "he-jerusalem-1956";
+
+const segments: SourceSegment[] = [
+  {
+    n: 1,
+    sefariaRef: "x 1",
+    html: 'First segment with <a class="tes-anchor" href="#op-1" data-anchor="op-1">א</a> and <a class="tes-anchor" href="#op-2" data-anchor="op-2">ב</a> two anchors.',
+    anchors: ["op-1", "op-2"],
+  },
+  {
+    n: 2,
+    sefariaRef: "x 2",
+    html: "Second segment, no anchors.",
+    anchors: [],
+  },
+];
+
+const commentaryItem = (anchorId: string): CommentaryItem => ({
+  anchorId,
+  order: 1,
+  label: { en: anchorId, he: anchorId },
+  sefariaRef: "y",
+  targetSeif: 1,
+  section: "ohr-pnimi",
+  html: `Commentary for ${anchorId}.`,
+});
+
+// Only op-1 has an item in the currently-selected (English) commentary
+// version — op-2 is "missing in this edition" but present in Hebrew.
+const commentaryItems: CommentaryItem[] = [commentaryItem("op-1")];
+const hebrewItems: CommentaryItem[] = [
+  commentaryItem("op-1"),
+  commentaryItem("op-2"),
+];
+
+const baseProps = {
+  sourceSegments: segments,
+  commentaryItems,
+  summaryItems: [],
+  sourceMeta: null,
+  commentaryMeta: null,
+  sourceVersionOptions: [],
+  commentaryVersionOptions: [
+    { id: "en-sefaria-community", label: "English" },
+    { id: HEBREW, label: "Hebrew" },
+  ],
+  sourceVersion: null,
+  commentaryVersion: "en-sefaria-community",
+  hebrewItems,
+  hebrewVersionId: HEBREW,
+};
+
+describe("StudyStream", () => {
+  beforeEach(() => {
+    Element.prototype.scrollIntoView = vi.fn();
+  });
+
+  it("unfolds an anchor's commentary inline on tap, and folds it back on a second tap", async () => {
+    const wrapper = await mountSuspended(StudyStream, { props: baseProps });
+
+    expect(wrapper.text()).not.toContain("Commentary for op-1");
+
+    const anchor = wrapper.find('a.tes-anchor[data-anchor="op-1"]');
+    await anchor.trigger("click");
+
+    expect(wrapper.text()).toContain("Commentary for op-1");
+
+    await anchor.trigger("click");
+
+    expect(wrapper.text()).not.toContain("Commentary for op-1");
+  });
+
+  it("keeps multiple anchors open at once — opening a second doesn't fold the first", async () => {
+    const wrapper = await mountSuspended(StudyStream, { props: baseProps });
+
+    await wrapper.find('a.tes-anchor[data-anchor="op-1"]').trigger("click");
+    // op-2 is "missing" in the currently-selected version, but tapping it
+    // should still open its (missing-notice) disclosure alongside op-1's.
+    await wrapper.find('a.tes-anchor[data-anchor="op-2"]').trigger("click");
+
+    expect(wrapper.text()).toContain("Commentary for op-1");
+    expect(wrapper.text()).toContain("Not available in this edition");
+  });
+
+  it("shows the inline missing-anchor notice with a one-click Hebrew switch, and emits the version change", async () => {
+    const wrapper = await mountSuspended(StudyStream, { props: baseProps });
+
+    await wrapper.find('a.tes-anchor[data-anchor="op-2"]').trigger("click");
+
+    expect(wrapper.text()).toContain("Not available in this edition");
+    const switchButton = wrapper
+      .findAll("button")
+      .find((button) => button.text() === "Switch to Hebrew");
+    expect(switchButton).toBeTruthy();
+
+    await switchButton?.trigger("click");
+
+    expect(wrapper.emitted("update:commentaryVersion")).toEqual([[HEBREW]]);
+  });
+
+  it("doesn't offer a Hebrew switch once Hebrew is already selected", async () => {
+    const wrapper = await mountSuspended(StudyStream, {
+      props: {
+        ...baseProps,
+        commentaryItems: [],
+        commentaryVersion: HEBREW,
+        hebrewItems: [],
+      },
+    });
+
+    await wrapper.find('a.tes-anchor[data-anchor="op-1"]').trigger("click");
+
+    expect(wrapper.text()).toContain("Not available in this edition");
+    expect(
+      wrapper.findAll("button").some((b) => b.text() === "Switch to Hebrew"),
+    ).toBe(false);
+  });
+
+  it("renders every commentary item for an anchor when more than one applies", async () => {
+    const wrapper = await mountSuspended(StudyStream, {
+      props: {
+        ...baseProps,
+        commentaryItems: [commentaryItem("op-1"), commentaryItem("op-1")],
+      },
+    });
+
+    await wrapper.find('a.tes-anchor[data-anchor="op-1"]').trigger("click");
+
+    const matches = wrapper.text().match(/Commentary for op-1/g) ?? [];
+    expect(matches).toHaveLength(2);
+  });
+
+  it("offers the 'read the full commentary' link when the chapter has a commentary layer", async () => {
+    const wrapper = await mountSuspended(StudyStream, { props: baseProps });
+    expect(wrapper.text()).toContain("Read the full commentary");
+  });
+
+  it("hides the 'read the full commentary' link when the chapter has no commentary layer", async () => {
+    const wrapper = await mountSuspended(StudyStream, {
+      props: { ...baseProps, commentaryVersionOptions: [] },
+    });
+    expect(wrapper.text()).not.toContain("Read the full commentary");
+  });
+});

--- a/tests/unit/study-stream.spec.ts
+++ b/tests/unit/study-stream.spec.ts
@@ -97,6 +97,35 @@ describe("StudyStream", () => {
     expect(anchor.attributes("aria-expanded")).toBe("false");
   });
 
+  it("re-syncs aria-expanded/aria-controls onto the fresh anchor node after a source-version switch", async () => {
+    const wrapper = await mountSuspended(StudyStream, { props: baseProps });
+
+    await wrapper.find('a.tes-anchor[data-anchor="op-1"]').trigger("click");
+    expect(
+      wrapper
+        .find('a.tes-anchor[data-anchor="op-1"]')
+        .attributes("aria-expanded"),
+    ).toBe("true");
+
+    // A source-version switch replaces the `v-html` markup outright — same
+    // anchor id, but a brand-new DOM node with none of the attributes the
+    // previous node had synced onto it.
+    const switchedSegments: SourceSegment[] = [
+      {
+        n: 1,
+        sefariaRef: "x 1",
+        html: 'Different wording with <a class="tes-anchor" href="#op-1" data-anchor="op-1">א</a> the same anchor.',
+        anchors: ["op-1", "op-2"],
+      },
+      segments[1]!,
+    ];
+    await wrapper.setProps({ sourceSegments: switchedSegments });
+
+    const freshAnchor = wrapper.find('a.tes-anchor[data-anchor="op-1"]');
+    expect(freshAnchor.attributes("aria-expanded")).toBe("true");
+    expect(freshAnchor.attributes("aria-controls")).toBe("op-1");
+  });
+
   it("keeps multiple anchors open at once — opening a second doesn't fold the first", async () => {
     const wrapper = await mountSuspended(StudyStream, { props: baseProps });
 

--- a/tests/unit/study-stream.spec.ts
+++ b/tests/unit/study-stream.spec.ts
@@ -82,6 +82,21 @@ describe("StudyStream", () => {
     expect(wrapper.text()).not.toContain("Commentary for op-1");
   });
 
+  it("flips aria-expanded (and sets aria-controls) on the tapped anchor as its inline disclosure toggles", async () => {
+    const wrapper = await mountSuspended(StudyStream, { props: baseProps });
+
+    const anchor = wrapper.find('a.tes-anchor[data-anchor="op-1"]');
+    expect(anchor.attributes("aria-expanded")).toBe("false");
+    expect(anchor.attributes("aria-controls")).toBe("op-1");
+
+    await anchor.trigger("click");
+    expect(anchor.attributes("aria-expanded")).toBe("true");
+    expect(anchor.attributes("aria-controls")).toBe("op-1");
+
+    await anchor.trigger("click");
+    expect(anchor.attributes("aria-expanded")).toBe("false");
+  });
+
   it("keeps multiple anchors open at once — opening a second doesn't fold the first", async () => {
     const wrapper = await mountSuspended(StudyStream, { props: baseProps });
 


### PR DESCRIPTION
Closes #25. The signature mobile reading experience, modeled on how the morning TES lessons move through the book.

## What

- **Study mode** (mobile default, desktop-available via persisted toggle): a single reading stream where tapping an anchor unfolds its Ohr Pnimi commentary inline beneath the sentence — multiple disclosures open at once, fold affordances, AI-translated badges, and the missing-item notice with one-click Hebrew switch reused inline
- Collapsible chapter-intro card (summary layer or mini-toc fallback), reading-progress rail (rAF-batched, transform-only, `role="progressbar"`), auto-hiding chrome (rAF-throttled, attaches only in study mode, wider stay-visible band while a disclosure is open near the top)
- Built by extending the merged reader's state model (`expandedAnchors`/`toggleInline` alongside `activationSeq`), with shared pieces genuinely extracted (`ReaderVersionHeader`, `ReaderSourceSegment`, `ReaderSummaryBody`, `useAnchorActivation`) — pre-existing panes-mode specs pass unmodified, prerendered markup unchanged
- Hydration-safe mode persistence (SSR-matching first render, post-mount reconciliation), reduced-motion via pure CSS
- Review rounds: state-ownership docs corrected + dev-mode inject warning; full `aria-expanded`/`aria-controls` disclosure semantics on the anchor triggers, including re-sync after a source-version switch replaces the v-html nodes (empirically caught by re-review, fixed with a reproduction test)

## Verification

267 tests green; full chain (`task qa`, typecheck, generate 516 routes, validate:content) clean across three review rounds. Interactive visual pass on the served build: Hebrew mobile tap→unfold→fold cycle with zero page errors, RTL-correct (rail, borders, לימוד/עמודות toggle), English AI-translated chapter in dark mode with badge and version dropdown.