### PR TITLE
Exclude .claude agent worktrees from Prettier checks

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -2,3 +2,4 @@ pnpm-lock.yaml
 .nuxt
 .output
 content/
+.claude/


### PR DESCRIPTION
Completes the worktree-isolation tooling fix from #28: `format:check` no longer crawls into in-progress agent worktrees under `.claude/`. `task qa` verified green with an active worktree present.