### PR TITLE
chore: agent context architecture, convention enforcement, and Docker dev env

### DIFF
--- a/.agents/skills/tes-content-model/SKILL.md
+++ b/.agents/skills/tes-content-model/SKILL.md
@@ -1,0 +1,140 @@
+---
+name: tes-content-model
+description: The committed-JSON content model under content/ — file layout, Zod schemas, chapter/anchor id grammar, validate:content integrity checks, and the split-ToC scheme (toc.volumes.json + toc.parts/*.json) that keeps app payloads small. Use when touching anything in content/, shared/types/content.ts, app/utils/toc.ts, the ToC composables, or when a content validation check fails.
+---
+
+# Content model
+
+Content is committed JSON under `content/`, validated by Zod schemas in
+`shared/types/content.ts` (schemas + `z.infer` types; the app must only
+`import type` from this file — `zod` is a scripts/tests-only dependency and
+must never end up in the client bundle).
+
+```
+content/
+  versions.json                              ContentVersion[] — the version registry
+  toc.json                                    the canonical Toc (volumes -> parts -> chapters) — BUILD-TIME ONLY, see below
+  toc.volumes.json                            TocVolumesFile — volumes -> parts skeleton, no chapter lists (~17KB)
+  toc.parts/part-<NN>.json                    TocPartFile — one part's full TocChapter[] + its own/parent-volume identity
+  parts/part-<NN>/chapters/<chapterSlug>/
+    <layer>.<versionId>.json                  one ChapterLayerFile per (chapter, layer, version)
+```
+
+- **One file = one (chapter, layer, version).** `layer` is `summary` |
+  `source` | `commentary`. Filenames follow `<layer>.<versionId>.json`,
+  e.g. `source.he-jerusalem-1956.json`, `summary.en-curated.json`. The
+  file's own `chapterId`/`layer`/`versionId` fields must match its location
+  and filename — `validate-content` enforces this.
+- **Chapter ids** are `<partId>/<chapterSlug>`, e.g. `part-01/chapter-01`,
+  `part-01/inner-observation-01`, `part-01/questions-terminology-01`.
+- **Anchor id grammar: `op-<order>`.** Sefaria's inline commentary markers
+  (`<i data-commentator="Ohr Penimi" data-label="…" data-order="N">`) become
+  anchor id `op-N`, where `N` is `data-order` (continuous per chapter). See
+  `app/utils/anchors.ts` (`extractAnchors`, `normalizeAnchors`) and
+  `app/utils/sanitizeHtml.ts` for the HTML transforms involved.
+- **`pnpm validate:content`** (`scripts/validate-content.ts`, run via
+  `tsx`) Zod-validates every JSON file under `content/`, then cross-checks
+  integrity: every source segment's `anchors[]` has a matching
+  `CommentaryItem.anchorId` in some commentary version of the same chapter;
+  every `CommentaryItem.targetSeif` exists as a source segment `n`; every
+  `toc.json` `availableVersions` entry has a corresponding file on disk, and
+  vice versa; and (see "Split ToC" below) `toc.volumes.json` +
+  `toc.parts/*.json` are exactly derivable from `toc.json`.
+  `tests/unit/content-integrity.spec.ts` runs the same check over the
+  committed tree as part of `pnpm test`.
+- `ContentVersion.source` includes `'ai'` for AI-generated translations
+  (the reader UI badges these); `ContentVersion.translatedFrom` optionally
+  names the source-language `versionId` an AI/human translation was made
+  from.
+
+## Split ToC (`toc.volumes.json` + `toc.parts/*.json`) — app-facing, `content/toc.json` is build-time only
+
+At full-corpus scale `content/toc.json` is 2.9MB+ (16 parts, 5,148+
+chapters). Loading it in `app/` code (the pre-T11 shape) meant Nuxt
+serialized the _entire_ ToC into every page's inlined payload — 391KB
+reader pages, 9-11s/route prerender times, hour-scale `pnpm generate` runs.
+**`app/` code must never import `content/toc.json` directly** — a unit test
+guardrail (`tests/unit/no-full-toc-import.spec.ts`) greps `app/**/*.{ts,vue}`
+for a quoted import of it and fails the suite if one appears. `toc.json`
+stays the single canonical file for everything build-time: the importers,
+`scripts/validate-content.ts`, `nuxt.config.ts`'s prerender route list, and
+`server/routes/sitemap.xml.ts` (a Nitro server route, not `app/` — prerendered
+once per build, not shipped as a client-facing payload) all still read it
+directly.
+
+Instead, `app/` loads two smaller, derived files:
+
+- **`content/toc.volumes.json`** (`TocVolumesFile`, ~17KB total) — every
+  volume's parts, _without_ chapter lists. Each part carries `chapterCount`,
+  `kindsPresent`, `firstChapterId`/`lastChapterId` +
+  `firstChapterTitle`/`lastChapterTitle` (in the same kind-then-number
+  reading order as `orderedPartChapters`, below), and a precomputed
+  `availableSummary: { he, en }` (`LanguageAvailability` — `"none" |
+"partial" | "full"`) for the volumes index's language chips. Loaded by
+  `useLocalizedVolumes()`.
+- **`content/toc.parts/part-<NN>.json`** (`TocPartFile`) — one part's full
+  `TocChapter[]` (exactly what `toc.json` holds for that part) plus the
+  part's own `{ id, number, title }` and its parent volume's — enough for
+  the reader page and a volume's contents page to render breadcrumbs/SEO
+  from this one file alone. Loaded by `useLocalizedParts(partIds)`, a lazy
+  `import.meta.glob` over `content/toc.parts/*.json` keyed by part id (same
+  style as `useChapterContent`'s glob over `content/parts/**`) — a reader
+  page loads only its own part; a volume's contents page loads only that
+  volume's 2-3 parts.
+
+Both composables do a direct `await import()` of the statically bundled
+JSON — **no `useAsyncData`** (same reasoning as `useChapterContent`: server
+and client resolve the identical module, there's no fetch to coordinate, and
+wrapping it would re-add the payload-serialization cost this split exists to
+avoid). `app/utils/toc.ts` holds the pure helpers over these two shapes
+(`orderedPartChapters`, `findChapterInPart`, `findVolumeBySlug`,
+`volumeHasContent`, `adjacentParts`, `prevNextChapterLinks` — the last
+crosses a part boundary using the _adjacent_ part's
+`firstChapterId`/`lastChapterId` + title from `toc.volumes.json`, never
+loading the neighbor part's full file just to label a nav link).
+
+**Who emits the split files**: `scripts/lib/toc-splits.ts`
+(`deriveTocVolumesFile`/`deriveTocPartFiles`, pure; `writeTocSplitFiles`,
+I/O — also removes any stale `toc.parts/*.json` for a part id no longer in
+`toc.json`). Both importers (`import-sefaria.ts`, `import-kabbalahmedia.ts`)
+call `writeTocSplitFiles` immediately after they rewrite `toc.json`, so the
+split files are always regenerated in the same run. `pnpm emit:toc-splits`
+(`scripts/emit-toc-splits.ts`) runs the same derivation standalone, for
+after a manual edit to `toc.json`. `scripts/validate-content.ts`'s
+equivalence check re-derives both files from the committed `toc.json` and
+structurally compares them against what's on disk — any drift (stale,
+missing, or mismatched file) is a validation error, so these files can never
+silently go stale.
+
+## Content-chunk prefetch-link stripping
+
+`nuxt.config.ts`'s `build:manifest` hook.
+`useChapterContent`'s `import.meta.glob("../../content/parts/**/*.json")`
+(and `useLocalizedParts`'s equivalent over `content/toc.parts/*.json`) gives
+every reader page's _built_ (`pnpm generate`/`pnpm build`) output a
+`<link rel="prefetch">` for nearly every chapter's content chunk,
+regardless of which chapter it is — Rollup's client manifest records every
+file a glob matches as a "dynamic import" of the module containing the
+glob, and Nitro's renderer (`vue-bundle-renderer`) turns every dynamic
+import of an always-touched module into a prefetch link, with no
+manifest-side or Nuxt-config opt-out (`experimental.prefetchPreloadTags`
+looks related but gates a different, unrelated opt-in feature). Measured
+before the fix, on a generated `read/part-05/chapter-01` page: 5,212
+prefetch links, 373KB of a 391KB page (95.4%) — the real rendered content
+is ~18KB, matching dev mode (unaffected — Vite dev doesn't build this
+manifest) almost exactly. This predates the split-ToC change above (the
+glob itself is unchanged, only its `useAsyncData` wrapper was removed), and
+without a fix, full-corpus `pnpm generate` does not complete under the
+default heap (OOM'd at 87% of 10,313 routes in one measured run).
+
+Fix: `nuxt.config.ts`'s `hooks["build:manifest"]` calls
+`stripContentChunkPrefetchHints` (`shared/utils/manifestPrefetch.ts`,
+unit-tested — `tests/unit/manifest-prefetch.spec.ts`) against the client
+manifest before Nitro embeds it for runtime use. For every manifest entry
+whose own key/src lives under `content/parts/` or `content/toc.parts/`, it
+clears `prefetch`/`preload` so `vue-bundle-renderer` filters it out of any
+page's dependency set; and, belt-and-suspenders, strips any reference to
+such an id out of every entry's own `dynamicImports` list. Functionality is
+untouched — these chunks still load on demand via the glob's own dynamic
+`import()` the moment a page actually needs one; they were never
+legitimately prefetchable at this scale.

--- a/.agents/skills/tes-import-kabbalahmedia/SKILL.md
+++ b/.agents/skills/tes-import-kabbalahmedia/SKILL.md
@@ -1,0 +1,38 @@
+---
+name: tes-import-kabbalahmedia
+description: How scripts/import-kabbalahmedia.ts imports official Bnei Baruch translations as <language>-bb versions — collection walking, strict CLI, supported document dialects, the alignment boundaries it refuses to cross, and coverage/validation behaviour. Use when running, debugging, or modifying the KabbalahMedia importer.
+---
+
+# KabbalahMedia import
+
+`pnpm import:kabbalahmedia (--part <N> | --all) [--dry-run]`
+(`scripts/import-kabbalahmedia.ts`, run via `tsx`) imports official Bnei
+Baruch translations as `<language>-bb` versions. It walks the TES collection
+from KabbalahMedia's verified `sqdata` collection root, rather than keeping a
+per-chapter uid list. The CLI is deliberately strict: one of `--part` or
+`--all` is required; unknown, duplicate, conflicting, and valueless flags
+fail before any network request.
+
+- **HTTP hygiene**: it uses the shared cached client and the same descriptive
+  User-Agent, ≥600ms real-request interval, and retry/fail-fast policy as the
+  Sefaria importer. Cache entries live in `.superpowers/import-cache/`.
+- **Supported document dialects**: numbered per-chapter leaves are aligned to
+  Hebrew source/commentary ground truth; whole-part chapter documents are
+  positionally split into source-only chapter files; combined terminology and
+  topics Q&A tables write question and answer chapters positionally. Source
+  and commentary are written only when the relevant alignment is verified.
+- **Safe boundaries**: whole-part Ohr Pnimi/commentary is intentionally not
+  written — there is no reliable Hebrew/Sefaria commentary target for it.
+  Inner Observation and unmapped Cause/Consequence-style leaves are reported
+  and skipped, never guessed. Parts 9–15 have no non-Hebrew KabbalahMedia
+  files and remain explicit coverage absences.
+- **Output and validation**: a non-dry run updates layer files,
+  `versions.json`, `toc.json`, and derived ToC splits, then runs
+  `validateContent`. Only `--all` rewrites the KabbalahMedia-owned section of
+  `content/COVERAGE.md`; a scoped `--part` run prints its coverage but leaves
+  the committed full-corpus report intact. `--dry-run` performs
+  discovery/parsing and prints coverage without writing or validating a
+  changed tree.
+
+The content shapes this writes are described in the `tes-content-model`
+skill; read that first if you need the schema or the split-ToC rules.

--- a/.agents/skills/tes-import-sefaria/SKILL.md
+++ b/.agents/skills/tes-import-sefaria/SKILL.md
@@ -1,0 +1,45 @@
+---
+name: tes-import-sefaria
+description: How scripts/import-sefaria.ts pulls Talmud Eser HaSefirot from the Sefaria API into content/ — CLI flags, HTTP hygiene and caching, idempotency guarantees, what it refuses to guess, and the COVERAGE.md report. Use when running, debugging, or modifying the Sefaria importer or its helpers in scripts/lib/.
+---
+
+# Sefaria import
+
+`pnpm import:sefaria (--part <N> | --all) [--dry-run]` (`scripts/import-sefaria.ts`,
+run via `tsx`) imports _Talmud Eser HaSefirot_ from the Sefaria API into
+`content/`, one part (Sefaria "Section") at a time. It resolves each part's
+main-text node and sibling nodes straight from `GET /api/v2/index/...` (chapter
+counts come from the shape of the fetched text itself — never probed/guessed),
+builds `SourceSegment`/`CommentaryItem` items via the pure transforms in
+`scripts/lib/`, writes one file per (chapter, layer, version), rewrites that
+part's `toc.json` entry, and runs the same integrity checks as
+`pnpm validate:content` (imported from `scripts/validate-content.ts`, not
+duplicated) before exiting.
+
+- **HTTP hygiene**: a descriptive User-Agent, ≥600ms between real requests,
+  retries with backoff on 5xx/429, fails fast on other 4xx. An on-disk
+  response cache keyed by request URL lives at `.superpowers/import-cache/`
+  (gitignored, resumable — a re-run of unchanged data costs zero real
+  requests). Fetches whole nodes (not per-chapter) where the API allows it,
+  to keep total request counts low.
+- **Idempotent**: stable key ordering and 2-space JSON formatting mean
+  re-running the importer against unchanged upstream data produces a
+  byte-identical tree — `git diff` is empty after a second run.
+- **Never touches summary files.** `availableVersions`/`availableLayers` in
+  the rewritten `toc.json` chapters are derived from an on-disk directory
+  listing (unioned with what the current run wrote), so curated summaries
+  (`summary.en-curated.json`) are preserved automatically without the
+  importer needing to know about them.
+- **Unknown sibling nodes are reported, never guessed.** Sefaria's sibling
+  node set (Histaklut Penimit / Questions / Answers lists) varies slightly
+  per section (e.g. Section VI adds "List of Questions/Answers on Cause and
+  Effect", which have no `ChapterKind` yet) — an unmapped node title is
+  logged as a warning and skipped entirely, not silently imported under a
+  guessed kind.
+- **Coverage report**: `content/COVERAGE.md`, rewritten (and printed to the
+  console) at the end of every non-dry-run import — per part × layer ×
+  version, how many of the part's resolved chapters got text, and how many
+  total segments/commentary items. Commit it alongside the imported content.
+
+The content shapes this writes are described in the `tes-content-model`
+skill; read that first if you need the schema or the split-ToC rules.

--- a/.agents/skills/tes-pnpm-setup/SKILL.md
+++ b/.agents/skills/tes-pnpm-setup/SKILL.md
@@ -1,0 +1,30 @@
+---
+name: tes-pnpm-setup
+description: pnpm 11 setup gotchas for this repo — the ERR_PNPM_IGNORED_BUILDS / allowBuilds placeholder dance, why pnpm.onlyBuiltDependencies in package.json is ignored, and the no-workspaces-field rule. Use when a fresh clone fails to install, when pnpm prints an ignored-builds warning, or when changing dependency/build configuration.
+---
+
+# pnpm 11 setup and gotchas
+
+Use `pnpm`, never `npm`/`yarn`. `task setup` runs
+`pnpm install --frozen-lockfile`, cached on `package.json`/`pnpm-lock.yaml`.
+
+- **`allowBuilds` placeholders.** The first `pnpm install` in a fresh clone
+  writes an `allowBuilds:` map into `pnpm-workspace.yaml` for any dependency
+  with a build script (e.g. `esbuild`, `unrs-resolver`, `@parcel/watcher`,
+  `sharp`), with placeholder values `set this to true or false`, and stops
+  package build scripts short with `ERR_PNPM_IGNORED_BUILDS`. Replace each
+  placeholder with `true` (or `false` if you don't want the script to run)
+  and re-run `pnpm install`. The values are already resolved in this repo's
+  `pnpm-workspace.yaml` — this only bites on a from-scratch registry change.
+- **Config location.** `pnpm.onlyBuiltDependencies` / `pnpm.allowBuilds` in
+  `package.json` are **not** honored by pnpm 11 — only `pnpm-workspace.yaml`
+  is read. The key is `allowBuilds:` (a map), not the older list-shaped
+  `onlyBuiltDependencies:`.
+- **No `workspaces` field.** This is a single-package repo. Never add a
+  top-level `workspaces` field to `package.json` (an npm/yarn convention,
+  ignored by pnpm with a warning) — if the project ever needs a workspace,
+  use `packages:` in `pnpm-workspace.yaml`.
+- **`minimumReleaseAge`.** If a global `.npmrc` sets one, a freshly
+  scaffolded lockfile can fail with
+  `ERR_PNPM_MINIMUM_RELEASE_AGE_VIOLATION` because scaffolders resolve to
+  just-published versions. Fix with `pnpm clean --lockfile && pnpm install`.

--- a/.agents/skills/tes-seo-ssg/SKILL.md
+++ b/.agents/skills/tes-seo-ssg/SKILL.md
@@ -1,0 +1,83 @@
+---
+name: tes-seo-ssg
+description: Static-generation and SEO wiring — siteUrl runtime config, canonical/hreflang/og meta, prerendered sitemap.xml and robots.txt, Hebrew font subsetting, the 404.html shell, and the accessibility/contrast token conventions. Use when touching nuxt.config.ts, server/routes/, useLocalizedSeo, fonts, og-card assets, or any focus-ring/contrast styling.
+---
+
+# SSG / SEO
+
+- **`runtimeConfig.public.siteUrl`** (`nuxt.config.ts`) is the single source
+  of truth for every absolute URL the app emits — canonical links, hreflang
+  alternates, `og:url`/`og:image`, `sitemap.xml`, `robots.txt`'s `Sitemap:`
+  line. Default `https://readtes.org` (no domain is deployed yet);
+  override at build time with `NUXT_PUBLIC_SITE_URL` (Nuxt's standard
+  public-runtime-config env convention). `i18n.baseUrl` is wired from the
+  same value, so `useLocaleHead()` emits absolute alternates.
+- **`app.vue`/`error.vue`** forward `useLocaleHead()`'s `link`/`meta`
+  arrays into `useHead` (canonical, hreflang + x-default, `og:url`,
+  `og:locale`/`og:locale:alternate`) — every page gets these for free.
+  Per-page `<title>`/description/`og:title`/`og:description`/`og:type`/
+  `og:site_name`/`og:image` (+ dims/alt)/`twitter:card` come from
+  `useLocalizedSeo()` (`app/composables/useLocalizedSeo.ts`), called once
+  near the top of each page's `<script setup>`; description copy lives
+  under the `seo.*` i18n namespace (real English + Hebrew, not
+  placeholder). `public/images/og-card.png` (1200×630, rendered from
+  `designs/og-card.html`) is the shared `og:image` for every page — don't
+  modify either file.
+- **`sitemap.xml`/`robots.txt`** are Nitro server routes
+  (`server/routes/sitemap.xml.ts`, `robots.txt.ts`), prerendered into the
+  static output (both listed in `nitro.prerender.routes`, since nothing
+  links to them for the crawler to find). The URL-list logic is a pure,
+  unit-tested function (`shared/utils/sitemap.ts`,
+  `tests/unit/sitemap.spec.ts`) over `content/toc.json` — the site's route
+  universe is a pure function of the ToC, so no heavyweight sitemap/SEO
+  module is needed. `public/robots.txt` was deleted (it's now the dynamic
+  route, which derives its `Sitemap:` line from `siteUrl`).
+- **Hebrew font subsets.** `@nuxt/fonts`' default subset list is
+  latin-only and does not include `hebrew` — the three Hebrew faces
+  (Frank Ruhl Libre, David Libre, Heebo) each list
+  `subsets: ["latin", "hebrew"]` explicitly in `nuxt.config.ts`'s `fonts`
+  block. Inter and Taviraj (no Hebrew glyphs) are left alone. If you add a
+  new Hebrew-facing font family, give it the same `subsets` entry or it
+  will silently render with zero Hebrew glyph coverage.
+- **`404.html`.** `pnpm generate`'s static Nitro preset prerenders
+  `/404.html` automatically. Its raw HTML is an empty pre-hydration shell
+  (`data-ssr="false"` — Nuxt's standard static-hosting fallback: the file
+  exists so a static host serves _something_ with a 404 status for an
+  unmatched path, and client-side hydration then renders `error.vue`'s
+  styled 404 state once JS runs) — this is expected, not a bug. Verify
+  with a headless browser (not just `curl`/viewing raw HTML) if you need
+  to confirm the rendered state.
+
+## Accessibility conventions
+
+Every layout (`default`, `reader`, `error.vue`) starts with a
+visually-hidden skip link to `#main-content` (localized via
+`common.skipToContent`), and exactly one `<main id="main-content">`
+landmark. The reader page's toolbar carries that page's one `<h1>`
+(`sr-only`, the chapter title — `ReaderToolbar`'s `chapterTitle` prop),
+since nothing else on that page is heading-shaped.
+
+Interactive elements get a `focus-visible:outline focus-visible:outline-2
+focus-visible:outline-teal` (or the token-derived contrast-safe variants
+below) — match this exact utility set rather than inventing a new ring
+style.
+
+Four contrast-driven tokens live in `main.css`:
+
+- `--color-teal-strong` — a darkened teal that clears 4.5:1 against every
+  light-mode surface and against white text. Use for any "white text on a
+  teal background" active/selected state.
+- `--accent-text` — theme-aware semantic variable (teal-strong in light
+  mode, the bright `--color-teal` in dark mode). Use for teal-colored
+  _text_ sitting directly on the ambient surface, e.g. `.tes-anchor`.
+- `--color-orange-cta-strong` — a darkened orange that clears 4.5:1
+  against every light-mode surface.
+- `--warning-text` — theme-aware semantic variable (orange-cta-strong in
+  light mode, the brighter `--color-orange-cta` in dark mode, where the
+  original already clears 4.5:1). Use for the "AI translated" badge and
+  the missing-anchor notice text.
+
+Don't reintroduce plain `text-teal`/`bg-teal` or `text-orange-cta` for
+text-on-surface or white-on-teal contexts; all measured under WCAG AA's
+4.5:1 there. `--color-orange-cta` itself stays fine for non-text uses
+(badge/notice borders, decorative bullets).

--- a/.agents/skills/tes-testing/SKILL.md
+++ b/.agents/skills/tes-testing/SKILL.md
@@ -1,0 +1,38 @@
+---
+name: tes-testing
+description: How tests are written and run in this repo — Vitest under the @nuxt/test-utils nuxt environment, mountSuspended for components, and the guardrail specs that enforce content integrity and the no-full-ToC-import rule. Use when adding or fixing tests, or when a spec under tests/unit/ fails.
+---
+
+# Testing
+
+Tests live in `tests/unit/**/*.spec.ts` and run under Vitest with the
+`@nuxt/test-utils` `nuxt` environment — auto-imports and Nuxt context are
+available in tests. Use `mountSuspended` from `@nuxt/test-utils/runtime` to
+mount components (plain `@vue/test-utils` `mount` will not resolve Nuxt
+auto-imports or async setup).
+
+Run the suite with `task test` (or `pnpm test`, which is `vitest run`).
+
+## Guardrail specs
+
+Some specs exist to enforce architectural rules rather than to test a unit.
+Don't delete or weaken these to make a change pass — fix the change:
+
+- `tests/unit/content-integrity.spec.ts` — runs the full
+  `validate-content` integrity check over the committed `content/` tree, so
+  a bad content commit fails `pnpm test` and not just
+  `pnpm validate:content`. See the `tes-content-model` skill.
+- `tests/unit/no-full-toc-import.spec.ts` — greps `app/**/*.{ts,vue}` for a
+  quoted import of `content/toc.json` and fails if one appears. `app/` code
+  must use the split ToC files instead; see `tes-content-model`.
+- `tests/unit/sitemap.spec.ts` — covers the pure URL-list builder in
+  `shared/utils/sitemap.ts`. See the `tes-seo-ssg` skill.
+- `tests/unit/manifest-prefetch.spec.ts` — covers
+  `stripContentChunkPrefetchHints` in `shared/utils/manifestPrefetch.ts`,
+  the fix that keeps generated pages from carrying thousands of prefetch
+  links. See `tes-content-model`.
+
+## Definition of done
+
+Tests passing is not sufficient on its own. The full gate is `task check`
+— see the "Definition of done" section in `AGENTS.md`.

--- a/.claude/hooks/check-conventions.sh
+++ b/.claude/hooks/check-conventions.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+# PostToolUse hook — enforces the two conventions that fail silently:
+# physical CSS properties (breaks Hebrew RTL) and literal hex (bypasses tokens).
+#
+# Reads the hook payload on stdin, exits 2 with a message on stderr if the
+# edited file violates either. Exit 2 feeds the message back to Claude.
+
+set -uo pipefail
+
+# jq preferred, python3 fallback — a missing parser makes this hook fail open
+# (silently passing every edit), so don't let it depend on one binary. Never
+# add 2>/dev/null here: if parsing breaks, it must be loud.
+if command -v jq >/dev/null 2>&1; then
+  f=$(jq -r '.tool_response.filePath // .tool_input.file_path // empty')
+else
+  f=$(python3 -c 'import json,sys
+d = json.load(sys.stdin)
+print(d.get("tool_response", {}).get("filePath") or d.get("tool_input", {}).get("file_path") or "")')
+fi
+[ -n "$f" ] || exit 0
+[ -f "$f" ] || exit 0
+
+# Only app/ source files. Everything else is out of scope for these two rules.
+case "$f" in
+  */app/*.vue | */app/*.css | app/*.vue | app/*.css) ;;
+  *) exit 0 ;;
+esac
+
+violations=""
+
+# Physical CSS utilities — Hebrew RTL requires logical equivalents.
+# Suffixes are restricted to real Tailwind values (numeric, arbitrary [..],
+# px/auto/full) so prose like "right-to-left" in a comment doesn't match.
+physical=$(grep -nEo '(ml|mr|pl|pr|left|right)-(\[|[0-9]|px\b|auto\b|full\b)|(border|rounded)-[lr]-(\[|[0-9])|text-(left|right)\b' "$f" 2>/dev/null | head -5)
+if [ -n "$physical" ]; then
+  violations+="Physical CSS utilities found — use logical equivalents (ms-/me-/ps-/pe-/text-start/text-end/start-/end-):
+$physical
+"
+fi
+
+# Literal hex — everything comes from design tokens. main.css is where the
+# tokens are defined, so it is the one legitimate place for hex.
+case "$f" in
+  */main.css) ;;
+  *)
+    hex=$(grep -nE '#[0-9a-fA-F]{3}([0-9a-fA-F]{3})?\b' "$f" 2>/dev/null | head -5)
+    if [ -n "$hex" ]; then
+      violations+="Literal hex found — use a design token (semantic --surface/--text-* var, or a --color-* utility):
+$hex
+"
+    fi
+    ;;
+esac
+
+if [ -n "$violations" ]; then
+  printf '%s\n%s' "$f violates project conventions:" "$violations" >&2
+  exit 2
+fi
+
+exit 0

--- a/.claude/hooks/check-conventions.sh
+++ b/.claude/hooks/check-conventions.sh
@@ -20,9 +20,12 @@ fi
 [ -n "$f" ] || exit 0
 [ -f "$f" ] || exit 0
 
-# Only app/ source files. Everything else is out of scope for these two rules.
+# Only app/ source files inside THIS project. Without the project-dir guard a
+# project hook reaches into any repo — or the home directory — that the session
+# happens to touch.
+root=${CLAUDE_PROJECT_DIR:-$PWD}
 case "$f" in
-  */app/*.vue | */app/*.css | app/*.vue | app/*.css) ;;
+  "$root"/app/*.vue | "$root"/app/*.css | app/*.vue | app/*.css) ;;
   *) exit 0 ;;
 esac
 

--- a/.claude/rules/content.md
+++ b/.claude/rules/content.md
@@ -1,0 +1,33 @@
+---
+paths:
+  - "content/**"
+  - "shared/types/content.ts"
+  - "app/utils/toc.ts"
+  - "app/composables/useLocalizedParts.ts"
+  - "app/composables/useLocalizedVolumes.ts"
+  - "app/composables/useChapterContent.ts"
+  - "scripts/validate-content.ts"
+  - "scripts/lib/toc-splits.ts"
+---
+
+# Content model — invariants
+
+**Load the `tes-content-model` skill before changing anything here.** It has
+the full schema, the split-ToC design, and the prefetch-stripping rationale.
+
+The three that silently produce wrong output:
+
+- **`app/` must never import `content/toc.json`.** It's 2.9MB and Nuxt
+  serializes it into every page payload. Use `content/toc.volumes.json` and
+  `content/toc.parts/part-<NN>.json` instead. Guarded by
+  `tests/unit/no-full-toc-import.spec.ts`.
+- **Anchor ids are `op-<order>`**, where `order` is `data-order` from
+  Sefaria's inline `<i data-commentator="Ohr Penimi">` markers — not the
+  visible label.
+- **One file = one (chapter, layer, version).** `<layer>.<versionId>.json`,
+  and the file's own `chapterId`/`layer`/`versionId` must match its path.
+
+`zod` is a scripts/tests-only dependency — app code may only `import type`
+from `shared/types/content.ts`.
+
+Run `pnpm validate:content` after any change under `content/`.

--- a/.claude/rules/frontend.md
+++ b/.claude/rules/frontend.md
@@ -1,0 +1,32 @@
+---
+paths:
+  - "app/**/*.{vue,ts}"
+  - "app/assets/css/*.css"
+---
+
+# App code conventions
+
+- **Composable naming: `useAdjectiveX`** (`useFormattedDate`), not `useVerbX`.
+  The inner function can stay verb-shaped (`formatDate`).
+- **`computed()` wrappers for fetch-derived data.** Anything from
+  `useFetch`/`useAsyncData` that feeds a template or table gets wrapped up
+  front, before sort/filter/refresh consumers exist.
+- **Named unions over `unknown` in generics.** Widening a shared component's
+  constraint means listing concrete types (`Record<string, string | number |
+  Date>`) — `unknown` blocks sorting, comparators, and formatters later.
+- **`Intl.DateTimeFormat` instantiated once, reused.** Never repeated
+  `Date.prototype.toLocaleDateString()`.
+- **Design tokens.** Semantic vars (`--surface`, `--surface-raised`,
+  `--text-primary`, `--text-muted`, `--border`) for anything light/dark
+  dependent; raw `--color-*` / `--radius-*` / `--font-*` as Tailwind utilities
+  (`bg-navy-primary`, `rounded-card`, `font-hebrew`) otherwise. Tokens come
+  from `designs/untitled.pen` via the `@theme` block in
+  `app/assets/css/main.css`. Never a literal hex.
+- **Accessibility lint is error-level.** `eslint-plugin-vuejs-accessibility`
+  `flat/recommended`, plus explicit `alt-text`, `anchor-has-content`,
+  `click-events-have-key-events`, `form-control-has-label`,
+  `heading-has-content`, `label-has-for`. Fix violations; don't disable inline.
+- **Prettier owns formatting.** Run `pnpm format` — never hand-format.
+
+For focus-ring utilities and the contrast-safe token variants, load the
+`tes-seo-ssg` skill.

--- a/.claude/rules/importers.md
+++ b/.claude/rules/importers.md
@@ -1,0 +1,27 @@
+---
+paths:
+  - "scripts/import-sefaria.ts"
+  - "scripts/import-kabbalahmedia.ts"
+  - "scripts/lib/**"
+  - "scripts/emit-toc-splits.ts"
+---
+
+# Import scripts
+
+Load **`tes-import-sefaria`** or **`tes-import-kabbalahmedia`** before
+changing either importer — each documents its CLI contract, caching, and the
+alignment boundaries it deliberately refuses to cross.
+
+Shared invariants:
+
+- **Idempotent.** Stable key ordering and 2-space JSON — a second run against
+  unchanged upstream data must leave `git diff` empty.
+- **Report, never guess.** An unmapped node or unverified alignment is logged
+  and skipped, not imported under an assumed kind.
+- **HTTP hygiene**: descriptive User-Agent, ≥600ms between real requests,
+  backoff on 5xx/429, fail fast on other 4xx. Cache in
+  `.superpowers/import-cache/` (gitignored).
+- Both importers call `writeTocSplitFiles` after rewriting `toc.json` — the
+  split files can never be left stale.
+
+See the `tes-content-model` skill for the shapes they write.

--- a/.claude/rules/seo-ssg.md
+++ b/.claude/rules/seo-ssg.md
@@ -1,0 +1,35 @@
+---
+paths:
+  - "nuxt.config.ts"
+  - "server/routes/**"
+  - "app/composables/useLocalizedSeo.ts"
+  - "shared/utils/sitemap.ts"
+  - "shared/utils/manifestPrefetch.ts"
+  - "app/app.vue"
+  - "app/error.vue"
+  - "designs/og-card.html"
+---
+
+# SSG / SEO — invariants
+
+**Load the `tes-seo-ssg` skill** for the full wiring (canonical/hreflang, the
+sitemap route, the 404 shell, accessibility conventions).
+
+The ones that fail silently:
+
+- **`runtimeConfig.public.siteUrl` is the single source** for every absolute
+  URL. Override with `NUXT_PUBLIC_SITE_URL` at build time. Never hardcode a
+  domain.
+- **Hebrew font subsets.** `@nuxt/fonts` defaults to latin-only. Every
+  Hebrew-facing family needs `subsets: ["latin", "hebrew"]` explicitly in
+  `nuxt.config.ts`, or it ships with zero Hebrew glyph coverage and nothing
+  errors.
+- **Contrast tokens.** Use `--color-teal-strong` for white-on-teal,
+  `--accent-text` for teal text on ambient surface, `--color-orange-cta-strong`
+  and `--warning-text` for the orange equivalents. Plain `text-teal` /
+  `text-orange-cta` fail WCAG AA 4.5:1 for text.
+- **Don't modify `public/images/og-card.png` or `designs/og-card.html`**
+  without regenerating the PNG from the HTML.
+
+`content/toc.json` **is** allowed here — `server/routes/` and `nuxt.config.ts`
+are build-time, not `app/`.

--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -1,0 +1,17 @@
+---
+paths:
+  - "tests/**"
+  - "vitest.config.ts"
+---
+
+# Tests
+
+**Load the `tes-testing` skill** for setup detail and the guardrail inventory.
+
+- Vitest under the `@nuxt/test-utils` `nuxt` environment. Mount components
+  with `mountSuspended` from `@nuxt/test-utils/runtime` — plain `mount` won't
+  resolve auto-imports or async setup.
+- **Some specs are architectural guardrails, not unit tests**:
+  `no-full-toc-import`, `content-integrity`, `manifest-prefetch`, `sitemap`.
+  If one fails, fix the change — never weaken or delete the spec to make it
+  pass.

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -3,7 +3,41 @@
     "allow": [
       "Bash(git:*)",
       "Bash(task:*)",
-      "Bash(pnpm:*)"
+      "Bash(pnpm:*)",
+      "Bash(jq:*)",
+      "Bash(rg:*)",
+      "Bash(ls:*)",
+      "Bash(find:*)",
+      "Bash(wc:*)",
+      "Bash(du:*)",
+      "Bash(readlink:*)",
+      "Bash(gh pr view:*)",
+      "Bash(gh pr list:*)",
+      "Bash(gh pr diff:*)",
+      "Bash(gh pr checks:*)",
+      "Bash(gh issue view:*)",
+      "Bash(gh issue list:*)"
+    ]
+  },
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Write|Edit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "jq -r '.tool_response.filePath // .tool_input.file_path // empty' | { read -r f; [ -n \"$f\" ] && pnpm exec prettier --write --ignore-unknown \"$f\"; } >/dev/null 2>&1 || true",
+            "timeout": 30,
+            "statusMessage": "Formatting"
+          },
+          {
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/check-conventions.sh",
+            "timeout": 10,
+            "statusMessage": "Checking conventions"
+          }
+        ]
+      }
     ]
   }
 }

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -26,7 +26,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "jq -r '.tool_response.filePath // .tool_input.file_path // empty' | { read -r f; [ -n \"$f\" ] && pnpm exec prettier --write --ignore-unknown \"$f\"; } >/dev/null 2>&1 || true",
+            "command": "jq -r '.tool_response.filePath // .tool_input.file_path // empty' | { read -r f; case \"$f\" in \"$CLAUDE_PROJECT_DIR\"/*) pnpm exec prettier --write --ignore-unknown \"$f\";; esac; } >/dev/null 2>&1 || true",
             "timeout": 30,
             "statusMessage": "Formatting"
           },

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,9 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(git:*)",
+      "Bash(task:*)",
+      "Bash(pnpm:*)"
+    ]
+  }
+}

--- a/.claude/skills/tes-content-model
+++ b/.claude/skills/tes-content-model
@@ -1,0 +1,1 @@
+../../.agents/skills/tes-content-model

--- a/.claude/skills/tes-import-kabbalahmedia
+++ b/.claude/skills/tes-import-kabbalahmedia
@@ -1,0 +1,1 @@
+../../.agents/skills/tes-import-kabbalahmedia

--- a/.claude/skills/tes-import-sefaria
+++ b/.claude/skills/tes-import-sefaria
@@ -1,0 +1,1 @@
+../../.agents/skills/tes-import-sefaria

--- a/.claude/skills/tes-pnpm-setup
+++ b/.claude/skills/tes-pnpm-setup
@@ -1,0 +1,1 @@
+../../.agents/skills/tes-pnpm-setup

--- a/.claude/skills/tes-seo-ssg
+++ b/.claude/skills/tes-seo-ssg
@@ -1,0 +1,1 @@
+../../.agents/skills/tes-seo-ssg

--- a/.claude/skills/tes-testing
+++ b/.claude/skills/tes-testing
@@ -1,0 +1,1 @@
+../../.agents/skills/tes-testing

--- a/.cursorrules
+++ b/.cursorrules
@@ -1,1 +1,0 @@
-AGENTS.md

--- a/.cursorrules
+++ b/.cursorrules
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,34 @@
+# Build outputs and caches — 900MB+ combined, none of it belongs in context.
+node_modules
+.output
+.nuxt
+.nitro
+.cache
+dist
+coverage
+.task
+.superpowers
+
+# VCS and agent config
+.git
+.github
+.claude
+.agents
+
+# Local env
+.env
+.env.*
+!.env.example
+
+# Editor / OS
+.DS_Store
+.idea
+.fleet
+*.log
+logs
+
+# NOT ignored, deliberately:
+#   content/   (54MB) — `nuxt generate` reads it and nuxt.config.ts parses
+#                       content/toc.json at config load, so the build fails
+#                       without it.
+#   designs/   — og-card.html is the source for the committed social card.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,1 @@
+../AGENTS.md

--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,8 @@ coverage
 
 # go-task cache/checksum state
 .task/
+
+# Claude Code — share settings.json, keep personal/machine state local.
+# worktrees/ holds throwaway agent checkouts (each a full node_modules).
+.claude/settings.local.json
+.claude/worktrees/

--- a/.prettierignore
+++ b/.prettierignore
@@ -4,7 +4,5 @@ pnpm-lock.yaml
 content/
 .claude/
 
-# Symlinks to AGENTS.md — formatting the target once is enough
-GEMINI.md
-.cursorrules
+# Symlink to AGENTS.md — formatting the target once is enough
 .github/copilot-instructions.md

--- a/.prettierignore
+++ b/.prettierignore
@@ -3,3 +3,8 @@ pnpm-lock.yaml
 .output
 content/
 .claude/
+
+# Symlinks to AGENTS.md — formatting the target once is enough
+GEMINI.md
+.cursorrules
+.github/copilot-instructions.md

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,72 +5,87 @@ aligned text layers (summary / source / commentary), multilingual including
 Hebrew RTL, fully self-contained — no runtime APIs, everything ships as a
 prerendered static site.
 
+## Operating brief — read this first
+
+This file is the always-loaded instruction source for every agent. Keep it
+short: detail belongs in a skill (see "Skills" below), not here.
+
+Claude is the default implementer. Other agents are occasional, so assume you
+are starting cold:
+
+- **Git is allowed when explicitly requested** — branch, stage, commit, push,
+  open a PR. Never bypass branch protection or required review, and never
+  commit work nobody asked you to commit; when the brief doesn't mention git,
+  leave the changes in the working tree and stop. A `workspace-write` sandbox
+  may be unable to write `.git` at all — if so, say so rather than silently
+  skipping the commit.
+- **No AI attribution anywhere** — no `Co-Authored-By` trailers, no
+  "generated with" footers, no "written by" notes in code, comments, or docs.
+  The single exception is the `en-ai` translation version, which **must** be
+  badged "AI translated" in the UI.
+- **Sandboxed agents cannot reach `/var/run/docker.sock`.** Anything needing
+  Docker or Testcontainers will fail. Write such tests, but do not run them —
+  say so in your summary and leave them for a human to run outside.
+- **Run the gates.** Don't claim a change is done without `task check`
+  passing (see "Definition of done").
+- **Flag mismatches, never guess.** If this file disagrees with the code, or
+  a brief asks for something the repo can't support, say so explicitly in
+  your summary instead of silently picking an interpretation.
+- **Stay in scope.** Don't refactor product code beyond the brief. If you
+  believe an out-of-scope change is genuinely required, make it separately
+  and call it out so it can be split into its own commit.
+- Conventions in "Code conventions" are not suggestions.
+
+## Skills — load on demand
+
+Detailed reference lives in [Agent Skills](https://agentskills.io) under
+`.agents/skills/`, loaded only when a task needs them. Read the matching
+skill before working in these areas:
+
+| Skill                      | Read it when working on                                      |
+| -------------------------- | ------------------------------------------------------------ |
+| `tes-content-model`        | `content/`, schemas, ToC splits, anchors, `validate:content` |
+| `tes-import-sefaria`       | `scripts/import-sefaria.ts`                                  |
+| `tes-import-kabbalahmedia` | `scripts/import-kabbalahmedia.ts`                            |
+| `tes-seo-ssg`              | SEO, sitemap, canonical, prerender, fonts, contrast tokens   |
+| `tes-testing`              | `tests/unit/`, Vitest setup, guardrail specs                 |
+| `tes-pnpm-setup`           | A fresh clone or install failing                             |
+
+`.claude/skills/` holds symlinks to these same directories, because Claude
+Code reads only `.claude/skills/`. Edit the file under `.agents/skills/` —
+never replace a symlink with a copy.
+
 ## Commands
 
-This repo has a `Taskfile.yaml` (go-task v3) that wraps the pnpm scripts
-below — prefer it day to day:
+`Taskfile.yaml` (go-task v3) wraps the pnpm scripts — prefer it day to day.
+`task --list-all` shows every task. Without go-task, use the pnpm script of
+the same name.
 
-| Task                     | What it does                                                                                   |
-| ------------------------ | ---------------------------------------------------------------------------------------------- |
-| `task dev`               | `setup` then `pnpm dev` — dev server at http://localhost:6217 (see "Dev server ports").        |
-| `task setup`             | `pnpm install --frozen-lockfile`, cached on `package.json`/`pnpm-lock.yaml`.                   |
-| `task qa`                | `pnpm lint && pnpm format:check` — run before committing.                                      |
-| `task test`              | `pnpm test`.                                                                                   |
-| `task generate`          | `pnpm generate`.                                                                               |
-| `task import -- <flags>` | `pnpm import:sefaria <flags>` — flags after `--` pass through, e.g. `task import -- --part 1`. |
-| `task clean`             | Remove `.nuxt`, `.output`, `coverage`, `node_modules`, `.task`.                                |
+| Task                     | What it does                                                   |
+| ------------------------ | -------------------------------------------------------------- |
+| `task dev`               | `setup` then `pnpm dev` — dev server at http://localhost:6217  |
+| `task setup`             | `pnpm install --frozen-lockfile`                               |
+| `task check`             | The full gate — see "Definition of done"                       |
+| `task qa`                | `pnpm lint && pnpm format:check`                               |
+| `task test`              | `vitest run`                                                   |
+| `task generate`          | Static site generation — this is what gets deployed            |
+| `task import -- <flags>` | `pnpm import:sefaria <flags>`, e.g. `task import -- --part 1`  |
+| `task clean`             | Remove `.nuxt`, `.output`, `coverage`, `node_modules`, `.task` |
 
-`task --list-all` shows every task with its `desc`/`summary`. `task` requires
-go-task; if it isn't installed, use the underlying pnpm scripts directly.
+Other pnpm scripts: `build` (SSR build, not the deploy target), `preview`,
+`lint:fix`, `format`, `typecheck` (`nuxi typecheck` **and** `vue-tsc -p
+tsconfig.scripts.json` for `scripts/`/`tests/`/`shared/`), `validate:content`,
+`emit:toc-splits`, `import:kabbalahmedia`.
 
-Run `pnpm install` first if not using `task setup`. On the very first
-install, pnpm will print `ERR_PNPM_IGNORED_BUILDS` and stop package build
-scripts short — see the gotcha below before assuming something is broken.
-
-| Command                     | What it does                                                                                                                                                                                                                             |
-| --------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `pnpm install`              | Install dependencies.                                                                                                                                                                                                                    |
-| `pnpm dev`                  | Start the Nuxt dev server (port 6217).                                                                                                                                                                                                   |
-| `pnpm build`                | Production SSR build (not the deploy target — see `generate`).                                                                                                                                                                           |
-| `pnpm generate`             | Static site generation — this is what gets deployed.                                                                                                                                                                                     |
-| `pnpm preview`              | Preview the last `build`/`generate` output locally.                                                                                                                                                                                      |
-| `pnpm lint`                 | `eslint .`                                                                                                                                                                                                                               |
-| `pnpm lint:fix`             | `eslint . --fix`                                                                                                                                                                                                                         |
-| `pnpm format`               | `prettier --write .` — formats everything except `.prettierignore` entries.                                                                                                                                                              |
-| `pnpm format:check`         | `prettier --check .` — CI/pre-commit check, no writes.                                                                                                                                                                                   |
-| `pnpm test`                 | `vitest run`                                                                                                                                                                                                                             |
-| `pnpm typecheck`            | `nuxi typecheck` (app/, via `vue-tsc -b`) **and** `vue-tsc -p tsconfig.scripts.json` (`scripts/`, `tests/`, `shared/`, which sit outside Nuxt's own project references).                                                                 |
-| `pnpm validate:content`     | Validates every file under `content/` (schema + integrity).                                                                                                                                                                              |
-| `pnpm emit:toc-splits`      | Regenerates `content/toc.volumes.json` + `content/toc.parts/*.json` from `content/toc.json` (see "Content model"). Both importers call this automatically after writing `toc.json` — run by hand only after a manual edit to `toc.json`. |
-| `pnpm import:sefaria`       | Imports content from Sefaria — see "Sefaria import" below.                                                                                                                                                                               |
-| `pnpm import:kabbalahmedia` | Imports Bnei Baruch/KabbalahMedia translations (`scripts/import-kabbalahmedia.ts`) — see "KabbalahMedia import" below.                                                                                                                   |
+A first `pnpm install` in a fresh clone prints `ERR_PNPM_IGNORED_BUILDS` and
+stops build scripts short — that's expected; see the `tes-pnpm-setup` skill.
 
 ## Dev server ports
 
-`nuxt.config.ts` pins `devServer.port` to **6217** and Vite's HMR websocket
-to **6218** (`vite.server.ws.port`), instead of the Nuxt defaults (3000 /
-same port as the dev server). This repo runs alongside other local Nuxt dev
-servers (e.g. `weburz` on 3000) — 6217/6218 don't collide with any of them.
-Keep using these two ports if you ever need to reference the dev server
-directly (proxies, browser automation, etc.) rather than re-guessing 3000.
-
-## pnpm 11 gotchas
-
-- **`allowBuilds` placeholders.** The first `pnpm install` in a fresh clone
-  writes an `allowBuilds:` map into `pnpm-workspace.yaml` for any dependency
-  with a build script (e.g. `esbuild`, `unrs-resolver`, `@parcel/watcher`,
-  `sharp`), with placeholder values `set this to true or false`. Replace each
-  placeholder with `true` (or `false` if you don't want the script to run)
-  and re-run `pnpm install` — the values are already resolved in this repo's
-  `pnpm-workspace.yaml`, this only bites on a from-scratch registry change.
-- **Config location.** `pnpm.onlyBuiltDependencies` / `pnpm.allowBuilds` in
-  `package.json` are **not** honored by pnpm 11 — only `pnpm-workspace.yaml`
-  is read.
-- **No `workspaces` field.** This is a single-package repo. Never add a
-  top-level `workspaces` field to `package.json` (npm/yarn convention,
-  ignored by pnpm) — if the project ever needs a workspace, use `packages:`
-  in `pnpm-workspace.yaml`.
-- Use `pnpm`, never `npm`/`yarn`.
+`nuxt.config.ts` pins `devServer.port` to **6217** and Vite's HMR websocket to
+**6218** (`vite.server.ws.port`), instead of the Nuxt defaults, so it never
+collides with another local dev server. Use these ports when referencing the
+dev server directly (proxies, browser automation) rather than guessing 3000.
 
 ## Code conventions
 
@@ -81,45 +96,39 @@ directly (proxies, browser automation, etc.) rather than re-guessing 3000.
   stay verb-shaped (`formatDate`).
 - **`computed()` wrappers for fetch-derived data.** Data derived from
   `useFetch`/`useAsyncData` that feeds a template or a table should be
-  wrapped in `computed()` up front, even before sort/filter/refresh
-  consumers exist.
+  wrapped in `computed()` up front.
 - **Named unions over `unknown` in generics.** When a shared component's
   generic constraint needs widening, list the concrete value types (e.g.
-  `Record<string, string | number | Date>`), not `Record<string, unknown>`
-  — `unknown` blocks typed work later (sorting, comparators, formatters).
+  `Record<string, string | number | Date>`) — `unknown` blocks typed work
+  later (sorting, comparators, formatters).
 - **`Intl.DateTimeFormat` instantiated once, reused.** Don't call
-  `Date.prototype.toLocaleDateString()` repeatedly — create the
-  `Intl.DateTimeFormat` instance once (inside the composable) and reuse it.
+  `Date.prototype.toLocaleDateString()` repeatedly.
 - **Logical CSS properties/utilities only.** Hebrew RTL is first-class:
-  always use `ms-`/`me-`/`ps-`/`pe-`/`text-start`/`text-end` etc., never
-  the physical `ml-`/`mr-`/`pl-`/`pr-`/`left-`/`right-`.
-- **Design tokens only, never hardcoded hex.** All colours, radii, and
-  font families come from `designs/untitled.pen` via the `@theme` block in
+  always `ms-`/`me-`/`ps-`/`pe-`/`text-start`/`text-end`, never the physical
+  `ml-`/`mr-`/`pl-`/`pr-`/`left-`/`right-`.
+- **Design tokens only, never hardcoded hex.** Colours, radii, and font
+  families come from `designs/untitled.pen` via the `@theme` block in
   `app/assets/css/main.css`. Components read semantic CSS variables
   (`--surface`, `--surface-raised`, `--text-primary`, `--text-muted`,
   `--border`) for anything that changes between light/dark, and the raw
-  `--color-*` / `--radius-*` / `--font-*` tokens (as Tailwind utilities,
-  e.g. `bg-navy-primary`, `rounded-card`, `font-hebrew`) for anything that
-  doesn't. Never write a literal hex value in a component.
+  `--color-*` / `--radius-*` / `--font-*` tokens as Tailwind utilities
+  (`bg-navy-primary`, `rounded-card`, `font-hebrew`) otherwise. Never write
+  a literal hex value in a component. Contrast-safe variants: see
+  `tes-seo-ssg`.
 - **Prettier owns formatting, ESLint owns correctness.** `eslint.config.mjs`
-  has `stylistic` off and appends `eslint-config-prettier` last, so ESLint
-  never fights Prettier on style. Run `pnpm format` (or `task qa`, which
-  checks but doesn't write) instead of hand-formatting; `.prettierrc.json`
-  mirrors weburz's config (double quotes, trailing commas, plugin
-  `prettier-plugin-organize-imports`). `content/` is excluded via
-  `.prettierignore` — the Sefaria importer owns that formatting, see
-  "Content model".
-- **Accessibility lint is on and error-level.** `eslint-plugin-vuejs-accessibility`'s
-  `flat/recommended` preset is appended in `eslint.config.mjs`, plus explicit
-  `error`-level rules for `alt-text`, `anchor-has-content`,
+  has `stylistic` off and appends `eslint-config-prettier` last. Run
+  `pnpm format` instead of hand-formatting. `content/` is excluded via
+  `.prettierignore` — the importers own that formatting.
+- **Accessibility lint is on and error-level.**
+  `eslint-plugin-vuejs-accessibility`'s `flat/recommended`, plus explicit
+  `error`-level `alt-text`, `anchor-has-content`,
   `click-events-have-key-events`, `form-control-has-label`,
-  `heading-has-content`, and `label-has-for` (nesting or `id`). Fix real
-  violations rather than disabling the rule inline.
+  `heading-has-content`, `label-has-for`. Fix real violations rather than
+  disabling the rule inline.
 
 ## Git / PR rules
 
-- **No AI attribution anywhere** — no `Co-Authored-By` trailers, no
-  "generated with" footers, in commits, PRs, or issues.
+- **No AI attribution anywhere** — in commits, PRs, or issues.
 - Conventional-commit style subjects (`feat:`, `fix:`, `chore:`, …).
 
 ## Layout map
@@ -130,315 +139,48 @@ app/
   components/
     app/                App-shell components (header, nav, footer, …)
     ui/                 Generic/presentational primitives (button, card, …)
-    library/             Text-library browsing components (index, search, …)
-    reader/              Reader-view components (aligned summary/source/commentary layers)
-  composables/           useX composables (includes useLocalizedSeo — per-page SEO meta)
-  utils/                 Plain helper functions (non-composable)
-  layouts/               Nuxt layouts (default, reader)
-  pages/                 Nuxt file-based routes
-server/routes/           Nitro server routes — sitemap.xml.ts, robots.txt.ts (both prerendered
-                         into the static output; see "SSG / SEO" below)
-content/                 Source content (schema + data), committed JSON — see "Content model"
-i18n/locales/            Translation message files (en.json/he.json) for @nuxtjs/i18n
-scripts/                 One-off/import scripts (validate-content, import-sefaria,
-                         import-kabbalahmedia) + scripts/lib/ (their pure helpers)
-shared/types/            Types shared between app code and scripts/content tooling
-shared/utils/            Pure helpers shared between app and server code (e.g. the sitemap
-                         URL-list builder) — no Nuxt/Nitro runtime context, so directly
-                         unit-testable
-tests/unit/              Vitest unit tests
-designs/                 Design source files — untitled.pen (design tokens) and og-card.html
-                         (the source markup the committed public/images/og-card.png social
-                         card was rendered from; do not modify either without regenerating
-                         the PNG)
+    library/            Text-library browsing components (index, search, …)
+    reader/             Reader-view components (aligned summary/source/commentary layers)
+  composables/          useX composables (includes useLocalizedSeo — per-page SEO meta)
+  utils/                Plain helper functions (non-composable)
+  layouts/              Nuxt layouts (default, reader)
+  pages/                Nuxt file-based routes
+server/routes/          Nitro server routes — sitemap.xml.ts, robots.txt.ts (both prerendered)
+content/                Source content (schema + data), committed JSON
+i18n/locales/           Translation message files (en.json/he.json) for @nuxtjs/i18n
+scripts/                Import/validate scripts + scripts/lib/ (their pure helpers)
+shared/types/           Types shared between app code and scripts/content tooling
+shared/utils/           Pure helpers shared between app and server code — directly unit-testable
+tests/unit/             Vitest unit tests
+designs/                Design sources — untitled.pen (tokens), og-card.html (social card)
 ```
 
-## Content model
-
-Content is committed JSON under `content/`, validated by Zod schemas in
-`shared/types/content.ts` (schemas + `z.infer` types; the app must only
-`import type` from this file — `zod` is a scripts/tests-only dependency and
-must never end up in the client bundle).
+## Definition of done
 
 ```
-content/
-  versions.json                              ContentVersion[] — the version registry
-  toc.json                                    the canonical Toc (volumes -> parts -> chapters) — BUILD-TIME ONLY, see below
-  toc.volumes.json                            TocVolumesFile — volumes -> parts skeleton, no chapter lists (~17KB)
-  toc.parts/part-<NN>.json                    TocPartFile — one part's full TocChapter[] + its own/parent-volume identity
-  parts/part-<NN>/chapters/<chapterSlug>/
-    <layer>.<versionId>.json                  one ChapterLayerFile per (chapter, layer, version)
+task check
 ```
 
-- **One file = one (chapter, layer, version).** `layer` is `summary` |
-  `source` | `commentary`. Filenames follow `<layer>.<versionId>.json`,
-  e.g. `source.he-jerusalem-1956.json`, `summary.en-curated.json`. The
-  file's own `chapterId`/`layer`/`versionId` fields must match its location
-  and filename — `validate-content` enforces this.
-- **Chapter ids** are `<partId>/<chapterSlug>`, e.g. `part-01/chapter-01`,
-  `part-01/inner-observation-01`, `part-01/questions-terminology-01`.
-- **Anchor id grammar: `op-<order>`.** Sefaria's inline commentary markers
-  (`<i data-commentator="Ohr Penimi" data-label="…" data-order="N">`) become
-  anchor id `op-N`, where `N` is `data-order` (continuous per chapter). See
-  `app/utils/anchors.ts` (`extractAnchors`, `normalizeAnchors`) and
-  `app/utils/sanitizeHtml.ts` for the HTML transforms involved.
-- **`pnpm validate:content`** (`scripts/validate-content.ts`, run via
-  `tsx`) Zod-validates every JSON file under `content/`, then cross-checks
-  integrity: every source segment's `anchors[]` has a matching
-  `CommentaryItem.anchorId` in some commentary version of the same chapter;
-  every `CommentaryItem.targetSeif` exists as a source segment `n`; every
-  `toc.json` `availableVersions` entry has a corresponding file on disk, and
-  vice versa; and (see "Split ToC" below) `toc.volumes.json` +
-  `toc.parts/*.json` are exactly derivable from `toc.json`.
-  `tests/unit/content-integrity.spec.ts` runs the same check over the
-  committed tree as part of `pnpm test`.
-- `ContentVersion.source` includes `'ai'` for AI-generated translations
-  (the reader UI badges these); `ContentVersion.translatedFrom` optionally
-  names the source-language `versionId` an AI/human translation was made
-  from.
-
-### Split ToC (`toc.volumes.json` + `toc.parts/*.json`) — app-facing, `content/toc.json` is build-time only
-
-At full-corpus scale `content/toc.json` is 2.9MB+ (16 parts, 5,148+
-chapters). Loading it in `app/` code (the pre-T11 shape) meant Nuxt
-serialized the _entire_ ToC into every page's inlined payload — 391KB
-reader pages, 9-11s/route prerender times, hour-scale `pnpm generate` runs.
-**`app/` code must never import `content/toc.json` directly** — a unit test
-guardrail (`tests/unit/no-full-toc-import.spec.ts`) greps `app/**/*.{ts,vue}`
-for a quoted import of it and fails the suite if one appears. `toc.json`
-stays the single canonical file for everything build-time: the importers,
-`scripts/validate-content.ts`, `nuxt.config.ts`'s prerender route list, and
-`server/routes/sitemap.xml.ts` (a Nitro server route, not `app/` — prerendered
-once per build, not shipped as a client-facing payload) all still read it
-directly.
-
-Instead, `app/` loads two smaller, derived files:
-
-- **`content/toc.volumes.json`** (`TocVolumesFile`, ~17KB total) — every
-  volume's parts, _without_ chapter lists. Each part carries `chapterCount`,
-  `kindsPresent`, `firstChapterId`/`lastChapterId` +
-  `firstChapterTitle`/`lastChapterTitle` (in the same kind-then-number
-  reading order as `orderedPartChapters`, below), and a precomputed
-  `availableSummary: { he, en }` (`LanguageAvailability` — `"none" |
-"partial" | "full"`) for the volumes index's language chips. Loaded by
-  `useLocalizedVolumes()`.
-- **`content/toc.parts/part-<NN>.json`** (`TocPartFile`) — one part's full
-  `TocChapter[]` (exactly what `toc.json` holds for that part) plus the
-  part's own `{ id, number, title }` and its parent volume's — enough for
-  the reader page and a volume's contents page to render breadcrumbs/SEO
-  from this one file alone. Loaded by `useLocalizedParts(partIds)`, a lazy
-  `import.meta.glob` over `content/toc.parts/*.json` keyed by part id (same
-  style as `useChapterContent`'s glob over `content/parts/**`) — a reader
-  page loads only its own part; a volume's contents page loads only that
-  volume's 2-3 parts.
-
-Both composables do a direct `await import()` of the statically bundled
-JSON — **no `useAsyncData`** (same reasoning as `useChapterContent`: server
-and client resolve the identical module, there's no fetch to coordinate, and
-wrapping it would re-add the payload-serialization cost this split exists to
-avoid). `app/utils/toc.ts` holds the pure helpers over these two shapes
-(`orderedPartChapters`, `findChapterInPart`, `findVolumeBySlug`,
-`volumeHasContent`, `adjacentParts`, `prevNextChapterLinks` — the last
-crosses a part boundary using the _adjacent_ part's
-`firstChapterId`/`lastChapterId` + title from `toc.volumes.json`, never
-loading the neighbor part's full file just to label a nav link).
-
-**Who emits the split files**: `scripts/lib/toc-splits.ts`
-(`deriveTocVolumesFile`/`deriveTocPartFiles`, pure; `writeTocSplitFiles`,
-I/O — also removes any stale `toc.parts/*.json` for a part id no longer in
-`toc.json`). Both importers (`import-sefaria.ts`, `import-kabbalahmedia.ts`)
-call `writeTocSplitFiles` immediately after they rewrite `toc.json`, so the
-split files are always regenerated in the same run. `pnpm emit:toc-splits`
-(`scripts/emit-toc-splits.ts`) runs the same derivation standalone, for
-after a manual edit to `toc.json`. `scripts/validate-content.ts`'s
-equivalence check re-derives both files from the committed `toc.json` and
-structurally compares them against what's on disk — any drift (stale,
-missing, or mismatched file) is a validation error, so these files can never
-silently go stale.
-
-**Content-chunk prefetch-link stripping (`nuxt.config.ts`'s `build:manifest`
-hook).** `useChapterContent`'s `import.meta.glob("../../content/parts/**/*.json")`
-(and `useLocalizedParts`'s equivalent over `content/toc.parts/*.json`) gives
-every reader page's _built_ (`pnpm generate`/`pnpm build`) output a
-`<link rel="prefetch">` for nearly every chapter's content chunk,
-regardless of which chapter it is — Rollup's client manifest records every
-file a glob matches as a "dynamic import" of the module containing the
-glob, and Nitro's renderer (`vue-bundle-renderer`) turns every dynamic
-import of an always-touched module into a prefetch link, with no
-manifest-side or Nuxt-config opt-out (`experimental.prefetchPreloadTags`
-looks related but gates a different, unrelated opt-in feature). Measured
-before the fix, on a generated `read/part-05/chapter-01` page: 5,212
-prefetch links, 373KB of a 391KB page (95.4%) — the real rendered content
-is ~18KB, matching dev mode (unaffected — Vite dev doesn't build this
-manifest) almost exactly. This predates the split-ToC change above (the
-glob itself is unchanged, only its `useAsyncData` wrapper was removed), and
-without a fix, full-corpus `pnpm generate` does not complete under the
-default heap (OOM'd at 87% of 10,313 routes in one measured run).
-
-Fix: `nuxt.config.ts`'s `hooks["build:manifest"]` calls
-`stripContentChunkPrefetchHints` (`shared/utils/manifestPrefetch.ts`,
-unit-tested — `tests/unit/manifest-prefetch.spec.ts`) against the client
-manifest before Nitro embeds it for runtime use. For every manifest entry
-whose own key/src lives under `content/parts/` or `content/toc.parts/`, it
-clears `prefetch`/`preload` so `vue-bundle-renderer` filters it out of any
-page's dependency set; and, belt-and-suspenders, strips any reference to
-such an id out of every entry's own `dynamicImports` list. Functionality is
-untouched — these chunks still load on demand via the glob's own dynamic
-`import()` the moment a page actually needs one; they were never
-legitimately prefetchable at this scale.
-
-## Sefaria import
-
-`pnpm import:sefaria (--part <N> | --all) [--dry-run]` (`scripts/import-sefaria.ts`,
-run via `tsx`) imports _Talmud Eser HaSefirot_ from the Sefaria API into
-`content/`, one part (Sefaria "Section") at a time. It resolves each part's
-main-text node and sibling nodes straight from `GET /api/v2/index/...` (chapter
-counts come from the shape of the fetched text itself — never probed/guessed),
-builds `SourceSegment`/`CommentaryItem` items via the pure transforms in
-`scripts/lib/`, writes one file per (chapter, layer, version), rewrites that
-part's `toc.json` entry, and runs the same integrity checks as
-`pnpm validate:content` (imported from `scripts/validate-content.ts`, not
-duplicated) before exiting.
-
-- **HTTP hygiene**: a descriptive User-Agent, ≥600ms between real requests,
-  retries with backoff on 5xx/429, fails fast on other 4xx. An on-disk
-  response cache keyed by request URL lives at `.superpowers/import-cache/`
-  (gitignored, resumable — a re-run of unchanged data costs zero real
-  requests). Fetches whole nodes (not per-chapter) where the API allows it,
-  to keep total request counts low.
-- **Idempotent**: stable key ordering and 2-space JSON formatting mean
-  re-running the importer against unchanged upstream data produces a
-  byte-identical tree — `git diff` is empty after a second run.
-- **Never touches summary files.** `availableVersions`/`availableLayers` in
-  the rewritten `toc.json` chapters are derived from an on-disk directory
-  listing (unioned with what the current run wrote), so curated summaries
-  (`summary.en-curated.json`) are preserved automatically without the
-  importer needing to know about them.
-- **Unknown sibling nodes are reported, never guessed.** Sefaria's sibling
-  node set (Histaklut Penimit / Questions / Answers lists) varies slightly
-  per section (e.g. Section VI adds "List of Questions/Answers on Cause and
-  Effect", which have no `ChapterKind` yet) — an unmapped node title is
-  logged as a warning and skipped entirely, not silently imported under a
-  guessed kind.
-- **Coverage report**: `content/COVERAGE.md`, rewritten (and printed to the
-  console) at the end of every non-dry-run import — per part × layer ×
-  version, how many of the part's resolved chapters got text, and how many
-  total segments/commentary items. Commit it alongside the imported content.
-
-## KabbalahMedia import
-
-`pnpm import:kabbalahmedia (--part <N> | --all) [--dry-run]`
-(`scripts/import-kabbalahmedia.ts`, run via `tsx`) imports official Bnei
-Baruch translations as `<language>-bb` versions. It walks the TES collection
-from KabbalahMedia's verified `sqdata` collection root, rather than keeping a
-per-chapter uid list. The CLI is deliberately strict: one of `--part` or
-`--all` is required; unknown, duplicate, conflicting, and valueless flags
-fail before any network request.
-
-- **HTTP hygiene**: it uses the shared cached client and the same descriptive
-  User-Agent, ≥600ms real-request interval, and retry/fail-fast policy as the
-  Sefaria importer. Cache entries live in `.superpowers/import-cache/`.
-- **Supported document dialects**: numbered per-chapter leaves are aligned to
-  Hebrew source/commentary ground truth; whole-part chapter documents are
-  positionally split into source-only chapter files; combined terminology and
-  topics Q&A tables write question and answer chapters positionally. Source
-  and commentary are written only when the relevant alignment is verified.
-- **Safe boundaries**: whole-part Ohr Pnimi/commentary is intentionally not
-  written — there is no reliable Hebrew/Sefaria commentary target for it.
-  Inner Observation and unmapped Cause/Consequence-style leaves are reported
-  and skipped, never guessed. Parts 9–15 have no non-Hebrew KabbalahMedia
-  files and remain explicit coverage absences.
-- **Output and validation**: a non-dry run updates layer files,
-  `versions.json`, `toc.json`, and derived ToC splits, then runs
-  `validateContent`. Only `--all` rewrites the KabbalahMedia-owned section of
-  `content/COVERAGE.md`; a scoped `--part` run prints its coverage but leaves
-  the committed full-corpus report intact. `--dry-run` performs
-  discovery/parsing and prints coverage without writing or validating a
-  changed tree.
-
-## SSG / SEO (T10)
-
-- **`runtimeConfig.public.siteUrl`** (`nuxt.config.ts`) is the single source
-  of truth for every absolute URL the app emits — canonical links, hreflang
-  alternates, `og:url`/`og:image`, `sitemap.xml`, `robots.txt`'s `Sitemap:`
-  line. Default `https://readtes.org` (no domain is deployed yet);
-  override at build time with `NUXT_PUBLIC_SITE_URL` (Nuxt's standard
-  public-runtime-config env convention). `i18n.baseUrl` is wired from the
-  same value, so `useLocaleHead()` emits absolute alternates.
-- **`app.vue`/`error.vue`** forward `useLocaleHead()`'s `link`/`meta`
-  arrays into `useHead` (canonical, hreflang + x-default, `og:url`,
-  `og:locale`/`og:locale:alternate`) — every page gets these for free.
-  Per-page `<title>`/description/`og:title`/`og:description`/`og:type`/
-  `og:site_name`/`og:image` (+ dims/alt)/`twitter:card` come from
-  `useLocalizedSeo()` (`app/composables/useLocalizedSeo.ts`), called once
-  near the top of each page's `<script setup>`; description copy lives
-  under the `seo.*` i18n namespace (real English + Hebrew, not
-  placeholder). `public/images/og-card.png` (1200×630, rendered from
-  `designs/og-card.html`) is the shared `og:image` for every page — don't
-  modify either file.
-- **`sitemap.xml`/`robots.txt`** are Nitro server routes
-  (`server/routes/sitemap.xml.ts`, `robots.txt.ts`), prerendered into the
-  static output (both listed in `nitro.prerender.routes`, since nothing
-  links to them for the crawler to find). The URL-list logic is a pure,
-  unit-tested function (`shared/utils/sitemap.ts`,
-  `tests/unit/sitemap.spec.ts`) over `content/toc.json` — the site's route
-  universe is a pure function of the ToC, so no heavyweight sitemap/SEO
-  module is needed. `public/robots.txt` was deleted (it's now the dynamic
-  route, which derives its `Sitemap:` line from `siteUrl`).
-- **Hebrew font subsets.** `@nuxt/fonts`' default subset list is
-  latin-only and does not include `hebrew` — the three Hebrew faces
-  (Frank Ruhl Libre, David Libre, Heebo) each list
-  `subsets: ["latin", "hebrew"]` explicitly in `nuxt.config.ts`'s `fonts`
-  block. Inter and Taviraj (no Hebrew glyphs) are left alone. If you add a
-  new Hebrew-facing font family, give it the same `subsets` entry or it
-  will silently render with zero Hebrew glyph coverage.
-- **`404.html`.** `pnpm generate`'s static Nitro preset prerenders
-  `/404.html` automatically. Its raw HTML is an empty pre-hydration shell
-  (`data-ssr="false"` — Nuxt's standard static-hosting fallback: the file
-  exists so a static host serves _something_ with a 404 status for an
-  unmatched path, and client-side hydration then renders `error.vue`'s
-  styled 404 state once JS runs) — this is expected, not a bug. Verify
-  with a headless browser (not just `curl`/viewing raw HTML) if you need
-  to confirm the rendered state.
-- **Accessibility conventions**: every layout (`default`, `reader`,
-  `error.vue`) starts with a visually-hidden skip link to `#main-content`
-  (localized via `common.skipToContent`), and exactly one `<main
-id="main-content">` landmark. The reader page's toolbar carries that
-  page's one `<h1>` (`sr-only`, the chapter title — `ReaderToolbar`'s
-  `chapterTitle` prop), since nothing else on that page is heading-shaped.
-  Interactive elements get a `focus-visible:outline focus-visible:outline-2
-focus-visible:outline-teal` (or the token-derived contrast-safe
-  variants below) — match this exact utility set rather than inventing a
-  new ring style. Four contrast-driven tokens live in `main.css`:
-  `--color-teal-strong` (a darkened teal that clears 4.5:1 against every
-  light-mode surface and against white text — use for any "white text on
-  a teal background" active/selected state) and the theme-aware
-  `--accent-text` semantic variable (teal-strong in light mode, the
-  bright `--color-teal` in dark mode — use for teal-colored _text_ sitting
-  directly on the ambient surface, e.g. `.tes-anchor`); the same pattern
-  repeats for orange — `--color-orange-cta-strong` (a darkened orange
-  that clears 4.5:1 against every light-mode surface) and the theme-aware
-  `--warning-text` semantic variable (orange-cta-strong in light mode,
-  the brighter `--color-orange-cta` in dark mode, where the original
-  already clears 4.5:1 — use for the "AI translated" badge / missing-
-  anchor notice text). Don't reintroduce plain `text-teal`/`bg-teal` or
-  `text-orange-cta` for text-on-surface or white-on-teal contexts; all
-  measured under WCAG AA's 4.5:1 there. `--color-orange-cta` itself stays
-  fine for non-text uses (badge/notice borders, decorative bullets).
-
-## Testing
-
-Tests live in `tests/unit/**/*.spec.ts` and run under Vitest with the
-`@nuxt/test-utils` `nuxt` environment (auto-imports and Nuxt context are
-available in tests; use `mountSuspended` from `@nuxt/test-utils/runtime` to
-mount components).
-
-Definition of done for any change:
+Runs every gate: `qa` (lint + format:check), `typecheck`, `validate:content`,
+`test`, and `generate`. Without go-task:
 
 ```
-task qa && pnpm typecheck && pnpm test && pnpm generate
+pnpm lint && pnpm format:check && pnpm typecheck && pnpm validate:content && pnpm test && pnpm generate
 ```
 
-(`task qa` runs `pnpm lint && pnpm format:check`; without go-task, run
-`pnpm lint && pnpm format:check && pnpm typecheck && pnpm test && pnpm generate`
-directly.) All of it must pass before committing.
+All of it must pass before committing.
+
+## Instruction files
+
+- **`AGENTS.md`** (this file) — the complete standalone reference, read
+  natively by Codex, Cursor, Copilot, Gemini CLI, Zed, Amp and others. Kept
+  self-contained so a cold non-Claude run is productive with this file alone.
+- **`CLAUDE.md`** — Claude Code reads only this. It does **not** import
+  `AGENTS.md`; Claude gets a short always-on rule set plus `.claude/rules/`
+  (path-scoped, auto-loading) and `.agents/skills/` on demand. The ~15 lines
+  of invariants duplicated between the two files are deliberate: each tool
+  needs them always-on, and neither reads the other's file. Change both.
+- **`GEMINI.md`, `.cursorrules`, `.github/copilot-instructions.md`** —
+  symlinks to this file. Their tools now read `AGENTS.md` natively, so these
+  are redundancy for older versions, not the primary mechanism. Never
+  replace them with copies.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,9 +23,11 @@ are starting cold:
   "generated with" footers, no "written by" notes in code, comments, or docs.
   The single exception is the `en-ai` translation version, which **must** be
   badged "AI translated" in the UI.
-- **Sandboxed agents cannot reach `/var/run/docker.sock`.** Anything needing
-  Docker or Testcontainers will fail. Write such tests, but do not run them —
-  say so in your summary and leave them for a human to run outside.
+- **Docker is available** — verified reachable from an agent shell on
+  2026-07-27 (`docker run` and `docker compose` both work; Compose v5.3.0).
+  An earlier version of this file claimed the socket was unreachable; that is
+  no longer true. Build and run containers rather than handing them over
+  untested. If a sandbox _does_ block it, say so instead of assuming.
 - **Run the gates.** Don't claim a change is done without `task check`
   passing (see "Definition of done").
 - **Flag mismatches, never guess.** If this file disagrees with the code, or
@@ -63,7 +65,8 @@ the same name.
 
 | Task                     | What it does                                                   |
 | ------------------------ | -------------------------------------------------------------- |
-| `task dev`               | `setup` then `pnpm dev` — dev server at http://localhost:6217  |
+| `task dev`               | Dev server in Docker — http://localhost:6217                   |
+| `task dev:host`          | Dev server on the host, no container — same ports              |
 | `task setup`             | `pnpm install --frozen-lockfile`                               |
 | `task check`             | The full gate — see "Definition of done"                       |
 | `task qa`                | `pnpm lint && pnpm format:check`                               |
@@ -71,6 +74,9 @@ the same name.
 | `task generate`          | Static site generation — this is what gets deployed            |
 | `task import -- <flags>` | `pnpm import:sefaria <flags>`, e.g. `task import -- --part 1`  |
 | `task clean`             | Remove `.nuxt`, `.output`, `coverage`, `node_modules`, `.task` |
+| `task docker:prod`       | Build + serve the static output via nginx — :6219              |
+| `task docker:build`      | Build both images without starting anything                    |
+| `task docker:clean`      | Remove this project's containers, volumes, images              |
 
 Other pnpm scripts: `build` (SSR build, not the deploy target), `preview`,
 `lint:fix`, `format`, `typecheck` (`nuxi typecheck` **and** `vue-tsc -p
@@ -86,6 +92,27 @@ stops build scripts short — that's expected; see the `tes-pnpm-setup` skill.
 **6218** (`vite.server.ws.port`), instead of the Nuxt defaults, so it never
 collides with another local dev server. Use these ports when referencing the
 dev server directly (proxies, browser automation) rather than guessing 3000.
+
+## Docker
+
+`Dockerfile` is multi-stage: `base` (node 24 + pnpm pinned to the
+`packageManager` field) → `deps` → `development` / `build` → `production`.
+
+- **`deps` installs with `--ignore-scripts`.** This package's postinstall is
+  `nuxt prepare`, which needs `nuxt.config.ts` and the source tree; neither
+  exists at that layer. Every downstream stage runs `nuxt prepare` itself.
+- **`PNPM_HOME=/pnpm` is load-bearing.** pnpm's store goes to
+  `$PNPM_HOME/store`, which is what the `--mount=type=cache` targets. Without
+  it the cache mount is a silent no-op and every build re-downloads.
+- **`production` is nginx, not node.** `nuxt generate` emits static files with
+  no server entrypoint, so there is nothing for `node .output/server/index.mjs`
+  to run. `docker/nginx.conf` handles the 404 status, immutable asset caching,
+  and gzip.
+- **`NUXT_PUBLIC_SITE_URL` is a build arg**, baked into every absolute URL. A
+  static site has no runtime config to correct it afterwards.
+- Dev bind-mounts the whole repo root with anonymous volumes shadowing
+  `node_modules` and `.nuxt` — the host's are glibc, the container is
+  alpine/musl.
 
 ## Code conventions
 
@@ -180,7 +207,8 @@ All of it must pass before committing.
   (path-scoped, auto-loading) and `.agents/skills/` on demand. The ~15 lines
   of invariants duplicated between the two files are deliberate: each tool
   needs them always-on, and neither reads the other's file. Change both.
-- **`GEMINI.md`, `.cursorrules`, `.github/copilot-instructions.md`** —
-  symlinks to this file. Their tools now read `AGENTS.md` natively, so these
-  are redundancy for older versions, not the primary mechanism. Never
-  replace them with copies.
+- **`.github/copilot-instructions.md`** — a symlink to this file, kept
+  because VS Code Copilot still prefers that path. `GEMINI.md` and
+  `.cursorrules` were removed: Gemini CLI and Cursor both read `AGENTS.md`
+  natively now, and Cursor has deprecated `.cursorrules` outright. Never
+  replace the remaining symlink with a copy.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,44 @@
+# Read TES — Claude context
+
+Static (SSG) Nuxt 4 app for reading _Talmud Eser Sefirot_ as three aligned text
+layers (summary / source / commentary), multilingual with first-class Hebrew
+RTL. No runtime APIs — everything prerenders.
+
+## Always-on rules
+
+Breaking these produces code that looks fine and is wrong:
+
+- **Arrow functions only** — `const doThing = () => {}`, never `function`.
+- **Logical CSS only** — `ms-`/`me-`/`ps-`/`pe-`/`text-start`/`text-end`.
+  Never `ml-`/`mr-`/`pl-`/`pr-`/`left-`/`right-`. Hebrew RTL is first-class.
+- **Design tokens only, never a literal hex.**
+- **pnpm only**, never npm/yarn. Dev server **6217** (HMR **6218**).
+- **No AI attribution** in commits, PRs, issues, or comments. Conventional
+  commit subjects. The one exception: the `en-ai` translation version **must**
+  be badged "AI translated" in the UI.
+- **Git only when asked.** Otherwise leave changes in the working tree.
+
+## Definition of done
+
+```
+task check
+```
+
+Runs lint, format:check, typecheck, validate:content, test, and generate. All
+of it passes before committing.
+
+## Where the detail lives
+
+Nothing else is preloaded. Two mechanisms fill in context as you work:
+
+- **`.claude/rules/`** — conventions, loaded **automatically** when you read a
+  matching file (app code, content, tests, importers, SEO). You don't invoke
+  these; they fire on path match.
+- **`.agents/skills/`** — procedures and reference (`tes-content-model`,
+  `tes-seo-ssg`, `tes-testing`, `tes-import-sefaria`,
+  `tes-import-kabbalahmedia`, `tes-pnpm-setup`), loaded when you invoke them.
+  `.claude/skills/` symlinks to the same directories.
+
+`AGENTS.md` is the full standalone reference, kept complete so a cold Codex or
+Cursor run is productive. It is **not** imported here — don't read it whole;
+the rule or skill for your task already has what you need.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,80 @@
+# syntax=docker/dockerfile:1
+
+###############################################################################
+# Base — node + pinned pnpm, shared by every stage
+###############################################################################
+FROM node:24-alpine AS base
+
+# pnpm pinned to the `packageManager` field in package.json, not `latest`, so
+# the container and the host resolve dependencies identically.
+#
+# PNPM_HOME matters: pnpm puts its store at $PNPM_HOME/store, which is what
+# the cache mounts below target. Without it the store lands elsewhere and the
+# cache mount is a silent no-op — every build re-downloads the whole tree.
+ENV PNPM_HOME=/pnpm
+ENV PATH=$PNPM_HOME:$PATH
+RUN npm install -g pnpm@11.15.1
+
+WORKDIR /app
+
+###############################################################################
+# Deps — dependency install only, so source edits don't bust the layer
+###############################################################################
+FROM base AS deps
+
+COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
+
+# --ignore-scripts: this package's postinstall is `nuxt prepare`, which needs
+# nuxt.config.ts and the source tree — neither exists at this layer. Every
+# stage below runs `nuxt prepare` itself once the source is in place.
+RUN --mount=type=cache,id=pnpm,target=/pnpm/store \
+    pnpm install --frozen-lockfile --ignore-scripts
+
+###############################################################################
+# Development — hot reload; compose bind-mounts the source over this
+###############################################################################
+FROM base AS development
+
+COPY --from=deps /app/node_modules ./node_modules
+COPY . .
+RUN pnpm exec nuxt prepare
+
+# 6217 dev server, 6218 Vite HMR websocket — both pinned in nuxt.config.ts.
+EXPOSE 6217 6218
+
+# --host is required: Nuxt binds to localhost by default, which inside a
+# container means unreachable from the host. The port itself still comes from
+# nuxt.config.ts, so the 6217/6218 convention holds.
+CMD ["pnpm", "dev", "--host", "0.0.0.0"]
+
+###############################################################################
+# Build — static site generation
+###############################################################################
+FROM base AS build
+
+# Baked into every absolute URL the site emits (canonical, hreflang, og:url,
+# sitemap, robots). Must be correct at BUILD time — this is a static site,
+# there is no runtime config to override later.
+ARG NUXT_PUBLIC_SITE_URL=https://readtes.org
+ENV NUXT_PUBLIC_SITE_URL=${NUXT_PUBLIC_SITE_URL}
+
+COPY --from=deps /app/node_modules ./node_modules
+COPY . .
+RUN pnpm exec nuxt prepare && pnpm generate
+
+###############################################################################
+# Production — nginx serving the prerendered output
+#
+# Deliberately not a Node image. `nuxt generate` emits static files to
+# .output/public with no server entrypoint, so weburz's
+# `node .output/server/index.mjs` has nothing to run here.
+###############################################################################
+FROM nginx:1.27-alpine AS production
+
+COPY docker/nginx.conf /etc/nginx/conf.d/default.conf
+COPY --from=build /app/.output/public /usr/share/nginx/html
+
+EXPOSE 80
+
+HEALTHCHECK --interval=30s --timeout=3s --start-period=5s --retries=3 \
+  CMD wget -qO- http://localhost/ >/dev/null 2>&1 || exit 1

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -1,1 +1,0 @@
-AGENTS.md

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/README.md
+++ b/README.md
@@ -1,3 +1,192 @@
+<div align="center">
+
+<img src="public/images/og-card.png" alt="Read TES" width="640">
+
 # Read TES
 
-This is the project to help people read the TES in a more interactive manner.
+**Read _Talmud Eser Sefirot_ the way it's studied — summary, source, and commentary side by side.**
+
+[![Nuxt](https://img.shields.io/badge/Nuxt-4.5-00DC82?logo=nuxt&logoColor=white)](https://nuxt.com)
+[![Vue](https://img.shields.io/badge/Vue-3.5-4FC08D?logo=vuedotjs&logoColor=white)](https://vuejs.org)
+[![TypeScript](https://img.shields.io/badge/TypeScript-5.9-3178C6?logo=typescript&logoColor=white)](https://www.typescriptlang.org)
+[![Tailwind CSS](https://img.shields.io/badge/Tailwind-4.3-06B6D4?logo=tailwindcss&logoColor=white)](https://tailwindcss.com)
+[![Vitest](https://img.shields.io/badge/Vitest-4.1-6E9F18?logo=vitest&logoColor=white)](https://vitest.dev)
+[![pnpm](https://img.shields.io/badge/pnpm-11.15-F69220?logo=pnpm&logoColor=white)](https://pnpm.io)
+[![Static](https://img.shields.io/badge/deploy-static%20SSG-0EA5E9)](#deployment)
+
+</div>
+
+---
+
+## What this is
+
+_Talmud Eser Sefirot_ ("The Study of the Ten Sefirot") is Baal HaSulam's
+systematic exposition of Kabbalah — six volumes, sixteen parts, **5,148
+chapters**. It is hard to read linearly, because each passage of the ARI's
+source text is meant to be read alongside its commentary.
+
+Read TES presents three aligned layers at once:
+
+| Layer          | What it is                                                   |
+| -------------- | ------------------------------------------------------------ |
+| **Summary**    | A plain-language orientation to the chapter                  |
+| **Source**     | The ARI's text, with numbered `seif` anchors                 |
+| **Commentary** | _Ohr Pnimi_ and _Histaklut Pnimit_, anchored to those `seif` |
+
+Anchors are bidirectional: tap a marker in the source and the matching
+commentary scrolls into view, and the reverse.
+
+**Hebrew is first-class, not an afterthought.** RTL layout, Hebrew display and
+reading faces with proper glyph subsets, and logical CSS properties throughout —
+the interface mirrors rather than breaks.
+
+---
+
+## Quick start
+
+### With Docker
+
+```bash
+task dev                 # http://localhost:6217
+```
+
+Hot reload against your working tree, with `node_modules` kept container-local.
+
+### Without Docker
+
+```bash
+task dev:host            # http://localhost:6217
+```
+
+Requires **pnpm 11** and **Node 24+**. Without [go-task](https://taskfile.dev),
+use the underlying `pnpm` scripts of the same name.
+
+> **Ports are deliberately odd.** The dev server is **6217** and Vite's HMR
+> socket is **6218**, not the Nuxt defaults, so this never collides with another
+> local project.
+
+---
+
+## Commands
+
+| Task                   | What it does                                                      |
+| ---------------------- | ----------------------------------------------------------------- |
+| `task dev`             | Dev server in Docker, hot reload                                  |
+| `task check`           | **The full gate** — lint, format, typecheck, content, test, build |
+| `task test`            | Vitest suite (47 spec files)                                      |
+| `task generate`        | Static site generation — this is the deploy artifact              |
+| `task dev:host`        | Dev server on the host, no container                              |
+| `task docker:prod`     | Build + serve the real static output via nginx (`:6219`)          |
+| `task import -- --all` | Re-import the corpus from Sefaria                                 |
+| `task clean`           | Remove build artifacts and dependencies                           |
+
+`task --list-all` shows everything.
+
+---
+
+## The corpus
+
+|               |                                      |
+| ------------- | ------------------------------------ |
+| **Volumes**   | 6                                    |
+| **Parts**     | 16                                   |
+| **Chapters**  | 5,148                                |
+| **Languages** | Hebrew (complete), English (partial) |
+
+### Text versions and licensing
+
+Every passage is attributed. The reader lets you switch between versions and
+shows which one you're reading.
+
+| Version                | Lang | Source        | License              |
+| ---------------------- | ---- | ------------- | -------------------- |
+| `he-jerusalem-1956`    | he   | Sefaria       | Public Domain        |
+| `en-sefaria-community` | en   | Sefaria       | CC0                  |
+| `en-curated`           | en   | Read TES      | CC-BY                |
+| `en-bb`                | en   | KabbalahMedia | Used with permission |
+| `en-ai`                | en   | Machine       | CC0                  |
+
+> **`en-ai` is machine-translated and always carries a visible "AI translated"
+> badge in the interface.** Where an official Bnei Baruch translation exists it
+> is preferred; `en-ai` only fills gaps, and never silently.
+
+---
+
+## Architecture
+
+**Zero runtime APIs.** Every page is prerendered. All content is committed JSON
+under `content/`, validated by Zod schemas — the import scripts are build-time
+tooling, and the shipped site makes no network calls for text.
+
+**The ToC is split three ways.** `content/toc.json` is 2.9 MB, and loading it in
+app code put the entire table of contents into every page's payload — 391 KB
+reader pages and hour-scale builds. App code reads `toc.volumes.json` (~17 KB)
+and one `toc.parts/part-NN.json` at a time instead. A unit test fails the suite
+if anything under `app/` imports the full file again.
+
+```
+app/           Components, composables, pages, layouts
+content/       Committed JSON corpus + schemas
+i18n/locales/  en.json / he.json
+scripts/       Import + validation tooling (build-time only)
+server/routes/ Prerendered sitemap.xml and robots.txt
+shared/        Types and pure helpers used by both app and scripts
+tests/unit/    Vitest specs, including architectural guardrails
+designs/       Design tokens and the social-card source
+```
+
+---
+
+## Testing
+
+```bash
+task test
+```
+
+47 spec files. Four of them are **guardrails rather than unit tests** — they
+enforce the no-full-ToC-import rule, content integrity across the committed
+tree, sitemap generation, and the build-manifest prefetch fix. If one fails,
+the change is wrong, not the test.
+
+---
+
+## Deployment
+
+`task generate` emits a static site to `.output/public`. Any static host will
+serve it.
+
+Set `NUXT_PUBLIC_SITE_URL` at **build** time — it is baked into every canonical
+link, hreflang alternate, `og:url`, and the sitemap. There is no runtime config
+to correct it afterwards.
+
+```bash
+NUXT_PUBLIC_SITE_URL=https://your-domain task generate
+```
+
+To check the real artifact — 404 status codes, cache headers, the prerendered
+sitemap — before shipping:
+
+```bash
+task docker:prod         # http://localhost:6219
+```
+
+---
+
+## Working on this
+
+`CLAUDE.md` and `AGENTS.md` carry the conventions, and `.agents/skills/` holds
+task-specific reference that loads on demand. The short version:
+
+- Arrow functions only; composables are `useAdjectiveX`
+- Logical CSS properties only — never `ml-`/`mr-`/`left-`/`right-`
+- Design tokens only, never a literal hex
+- `task check` passes before every commit
+
+---
+
+## License
+
+The code in this repository is **not yet licensed** — no `LICENSE` file has been
+chosen, so default copyright applies. Text content is licensed per version; see
+the table above. The Bnei Baruch / KabbalahMedia translations are used with
+permission and are not covered by any repository-wide license.

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -2,14 +2,29 @@ version: "3"
 
 tasks:
   dev:
-    desc: Setup the development environment and spin up the dev server
+    desc: Spin up the dev server in Docker (http://localhost:6217)
     summary: |
-      Start the development environment with hot-reloading.
+      Start the development environment with hot-reloading, in a container.
 
-      The dev server binds to the non-standard port 6217 (not 3000) so it
-      never collides with other local Nuxt dev servers (e.g. weburz on
-      3000) — see "Dev server ports" in AGENTS.md. It will be accessible
-      at http://localhost:6217.
+      The working tree is bind-mounted, so edits reload normally. node_modules
+      and .nuxt stay container-local — the host's are built for glibc, the
+      container is alpine/musl, and sharing them produces native-module errors
+      that look like Nuxt bugs.
+
+      The dev server binds to the non-standard port 6217 (not 3000), with
+      Vite's HMR socket on 6218, so it never collides with another local dev
+      server — see "Dev server ports" in AGENTS.md.
+
+      Use `task dev:host` to run it directly on the host instead.
+    cmds:
+      - docker compose up dev
+
+  dev:host:
+    desc: Spin up the dev server on the host, without Docker
+    summary: |
+      Same ports as `task dev`, running straight from your local pnpm install.
+      Faster startup; requires pnpm 11 and Node 24+ locally. Don't run this and
+      `task dev` at the same time — they both bind 6217.
     deps:
       - task: setup
     cmds:
@@ -126,3 +141,28 @@ tasks:
         done
         test ! -d ./node_modules
       - rm -rf ./.task
+
+  docker:prod:
+    desc: Build and serve the generated static site (http://localhost:6219)
+    summary: |
+      Runs `nuxt generate` inside the image and serves .output/public with
+      nginx. Use this to verify the real deploy artifact — 404 status codes,
+      cache headers, the prerendered sitemap — which `pnpm preview` does not
+      exercise the same way.
+
+      Set NUXT_PUBLIC_SITE_URL to bake the correct absolute URLs; it defaults
+      to https://readtes.org and cannot be changed after the build.
+    cmds:
+      - docker compose build prod
+      - docker compose up prod
+
+  docker:build:
+    desc: Build both Docker images without starting anything
+    cmd: docker compose build
+
+  docker:clean:
+    desc: Remove this project's containers, volumes, and images
+    summary: |
+      Docker-only teardown. `task clean` handles host-side build artifacts;
+      this handles everything Docker created.
+    cmd: docker compose down --remove-orphans --volumes --rmi all

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,53 @@
+services:
+  # Development — hot reload against the working tree.
+  dev:
+    build:
+      context: .
+      target: development
+    container_name: readtes-dev
+    image: readtes:dev
+    ports:
+      - "6217:6217" # dev server
+      - "6218:6218" # Vite HMR websocket
+    volumes:
+      # Whole-root bind rather than weburz's per-directory list: readtes has
+      # eight top-level source dirs and content/ is the main edit loop, so an
+      # explicit list goes stale the first time someone adds a directory.
+      - type: bind
+        source: .
+        target: /app
+
+      # Anonymous volumes shadowing the host's copies. The host tree is built
+      # for glibc under WSL; the container is alpine/musl, so sharing
+      # node_modules gives you native-module errors that look like Nuxt bugs.
+      - /app/node_modules
+      - /app/.nuxt
+    environment:
+      - NODE_ENV=development
+      - NUXT_PUBLIC_SITE_URL=${NUXT_PUBLIC_SITE_URL:-http://localhost:6217}
+    restart: unless-stopped
+
+  # Production — serves the generated static site, for verifying the real
+  # artifact (404 status, cache headers, prerendered sitemap) before deploy.
+  prod:
+    build:
+      context: .
+      target: production
+      args:
+        # Baked in at build time; a static site has no runtime config.
+        NUXT_PUBLIC_SITE_URL: ${NUXT_PUBLIC_SITE_URL:-https://readtes.org}
+    container_name: readtes-prod
+    image: readtes:prod
+    ports:
+      - "6219:80"
+    restart: always
+    security_opt:
+      - no-new-privileges:true
+    deploy:
+      resources:
+        limits:
+          cpus: "1.0"
+          memory: 1G
+        reservations:
+          cpus: "0.5"
+          memory: 512M

--- a/docker/nginx.conf
+++ b/docker/nginx.conf
@@ -1,0 +1,41 @@
+server {
+    listen      80;
+    server_name _;
+    root        /usr/share/nginx/html;
+    index       index.html;
+
+    # Nuxt's static preset prerenders /404.html. Serving it with a real 404
+    # status is the point — the file itself is an empty pre-hydration shell
+    # that renders error.vue once JS runs (see the tes-seo-ssg skill), so a
+    # 200 here would tell crawlers a missing page exists.
+    error_page 404 /404.html;
+
+    # Hashed build assets never change under the same name.
+    location /_nuxt/ {
+        # Single header on purpose: `expires 1y` would emit its own
+        # Cache-Control alongside this one.
+        add_header Cache-Control "public, max-age=31536000, immutable";
+        try_files  $uri =404;
+    }
+
+    # Fonts are also content-hashed by @nuxt/fonts.
+    location /_fonts/ {
+        # Single header on purpose: `expires 1y` would emit its own
+        # Cache-Control alongside this one.
+        add_header Cache-Control "public, max-age=31536000, immutable";
+        try_files  $uri =404;
+    }
+
+    # sitemap.xml and robots.txt are prerendered Nitro routes, served as files.
+    location / {
+        # $uri/ picks up the directory-index form nuxt generate emits for
+        # routes; $uri.html covers the flat form.
+        try_files $uri $uri/ $uri.html =404;
+    }
+
+    gzip            on;
+    gzip_vary       on;
+    gzip_min_length 1024;
+    gzip_types      text/plain text/css application/json application/javascript
+                    application/xml text/xml image/svg+xml application/wasm;
+}


### PR DESCRIPTION
Four commits, each independently verified. Splits into two themes: how agent
context is loaded, and a containerised dev environment.

## Agent context — three loading tiers

Claude Code read a 2.9 KB `CLAUDE.md` and never saw `AGENTS.md` at all, while
Codex, Cursor and Copilot auto-loaded all 33 KB of it every session. The
pointer table only worked for Claude; every other tool paid full freight.

Split by *when* context is needed:

| Tier | Size | Loads |
| --- | --- | --- |
| `CLAUDE.md` | 1.8 KB | every session |
| `.claude/rules/` | 5.8 KB | automatically, on path match |
| `.agents/skills/` | 22.8 KB | on invocation |

`AGENTS.md` stays complete and standalone so a cold Codex or Cursor run is
productive from that file alone; `CLAUDE.md` deliberately does not import it.
The ~15 duplicated lines of invariants are intentional — neither tool reads
the other's file.

Rules beat skills for invariants: rules fire automatically on path match,
skills need the model to *choose* to load them. Anything whose violation
silently produces wrong code is a rule.

**Verified:** reading a file under `content/` loads `.claude/rules/content.md`
and the session surfaced the no-full-ToC-import rule unprompted.

## Convention enforcement

`CLAUDE.md` and rules are context, not enforcement. Two `PostToolUse` hooks
make the silent-failure rules actually bind:

- prettier on every edited file, so `format:check` cannot drift
- `check-conventions.sh` rejects physical CSS utilities (breaks Hebrew RTL)
  and literal hex (bypasses design tokens) in `app/**/*.{vue,css}`, exit 2 so
  the violation is corrected in-turn rather than at lint time

Suffix matching is restricted to real Tailwind values so prose like
"right-to-left" in a comment doesn't trip it — zero false positives across all
68 app files. Parser is jq with a python3 fallback; a missing parser makes this
class of hook fail open, passing every edit while looking configured.

Both hooks are scoped to `$CLAUDE_PROJECT_DIR` after the formatter was caught
reaching outside the repo.

## Docker

Mirrors the weburz setup. `task dev` now runs the container; `task dev:host`
keeps the direct pnpm path.

Deviates from weburz in three places, each because readtes is SSG: production
is nginx rather than node (there is no server entrypoint to run),
`NUXT_PUBLIC_SITE_URL` is a build arg rather than runtime env, and dev
bind-mounts the repo root rather than listing eight source directories.

Two fixes to the inherited pattern: `PNPM_HOME` is set so the pnpm store lands
where `--mount=type=cache` targets (otherwise the cache mount is a no-op), and
`deps` installs with `--ignore-scripts` because postinstall is `nuxt prepare`,
which needs a source tree that doesn't exist at that layer.

**Verified:** dev serves 200 with the HMR port open; prod serves 200 with a
real 404 on missing paths, plus sitemap.xml, robots.txt, the Hebrew locale, and
immutable + gzip on hashed assets.

## Also

- README rewritten from three lines
- `GEMINI.md` and `.cursorrules` removed — Gemini CLI and Cursor read
  `AGENTS.md` natively, and Cursor has deprecated `.cursorrules`.
  `.github/copilot-instructions.md` stays; VS Code Copilot still prefers it.
- Corrects a stale `AGENTS.md` claim that agents cannot reach the Docker
  socket — they can, verified today

## Verification

`task check` passes in full, including `generate`: lint, format:check,
typecheck, validate:content, 469 tests across 47 files, and static generation.

## Not included

Pre-existing uncommitted changes to `nuxt.config.ts`, `eslint.config.mjs`,
`app/components/**`, and `tests/unit/segmented-control.spec.ts` were left in
the working tree — they predate this work.