### PR TITLE
fix: centre the hero composition and stop the RTL copy colliding

### DIFF
--- a/app/pages/index.vue
+++ b/app/pages/index.vue
@@ -129,7 +129,7 @@ const layers = computed(() => [
 
       <div
         dir="ltr"
-        class="relative mx-auto grid max-w-6xl items-end gap-x-10 px-4 sm:grid-cols-[17rem_minmax(0,1fr)] sm:px-6 lg:grid-cols-[20rem_minmax(0,1fr)]"
+        class="relative mx-auto grid max-w-7xl items-end gap-x-10 px-4 sm:grid-cols-[17rem_minmax(0,1fr)] sm:px-6 lg:grid-cols-[20rem_minmax(0,1fr)]"
       >
         <!-- Portrait: duotone, rising out of the hero's bottom edge -->
         <div
@@ -159,7 +159,7 @@ const layers = computed(() => [
         <!-- Content -->
         <div
           :dir="locale === 'he' ? 'rtl' : 'ltr'"
-          class="hero-enter-content order-1 py-12 text-surface-white sm:order-2 sm:py-16"
+          class="hero-copy hero-enter-content order-1 py-12 text-surface-white sm:order-2 sm:py-16"
         >
           <!-- inline-block shrink-wraps the RTL run so the lockup sits at
                the content column's inline-start instead of drifting to the
@@ -360,6 +360,23 @@ const layers = computed(() => [
   text-align: center;
 }
 
+/*
+ * Physical padding-right, not padding-inline-end. The plate is pinned to the
+ * physical right in both directions, so the copy needs to clear it on that
+ * same side regardless of writing direction — a logical property would move
+ * the gutter to the left under RTL and let the Hebrew, which right-aligns,
+ * run straight across the drawing.
+ */
+.hero-copy {
+  padding-right: 0;
+}
+
+@media (min-width: 48rem) {
+  .hero-copy {
+    padding-right: clamp(13rem, 17vw, 21rem);
+  }
+}
+
 .hero-circles {
   inset-block-start: 50%;
   /*
@@ -367,8 +384,11 @@ const layers = computed(() => [
    * Hebrew annotations are already RTL, so mirroring it would flip the
    * handwriting. Everything that is layout in this file stays logical.
    */
-  right: 2.5rem;
-  width: clamp(15rem, 20vw, 24rem);
+  /* Same gutter as the content grid (max-w-7xl + px-6), so the plate's right
+     margin matches the portrait's left one instead of hugging the viewport
+     edge. Tracks the capped frame, so it stays aligned on wide monitors. */
+  right: calc(max(0px, (100% - 80rem) / 2) + 1.5rem);
+  width: clamp(14rem, 18vw, 22rem);
   height: auto;
   /* Fully inside the frame — at negative offsets the vessel sketches on the
      plate's right edge were being clipped. Held back from full strength so


### PR DESCRIPTION
Measured rather than eyeballed. At 1440 the portrait sat **168px** from the left edge while the plate sat **40px** from the right — the grid was centred at `max-w-6xl` but the plate was pinned to the viewport, so they never shared a margin. That mismatch is what read as a wide empty band down the left.

- Grid widened to `max-w-7xl`
- Plate offset now tracks the grid's own gutter, `calc(max(0px, (100% - 80rem) / 2) + 1.5rem)` — stays aligned as the frame grows, still respects the 120rem cap. **Both sides measure 104px at 1440**
- Physical `padding-right` on the copy, *not* `padding-inline-end`. The plate is pinned physically right in both directions; a logical gutter moves to the left under RTL and lets the Hebrew — which right-aligns — run straight across the drawing. That collision was visible in the RTL render

Verified by measuring element rects in both directions: every decorative layer reports **identical coordinates in LTR and RTL**. Contained at 2560 (frame 1920, plate right edge 1896). `task check` passes.