### PR TITLE
fix: give the hero a height floor so it matches across locales

### DIFF
--- a/app/pages/index.vue
+++ b/app/pages/index.vue
@@ -89,7 +89,10 @@ const layers = computed(() => [
 <template>
   <div>
     <!-- Hero: full-bleed night field, deliberately dark in both themes -->
-    <section ref="heroEl" class="tes-starfield relative overflow-hidden">
+    <section
+      ref="heroEl"
+      class="tes-starfield hero-section relative overflow-hidden"
+    >
       <!-- Decorative layers are positioned against this capped frame, not the
            viewport: past ~1920px they would otherwise drift to the far edges
            and leave the composition strung out across the middle. The night
@@ -313,6 +316,18 @@ const layers = computed(() => [
  * set from the scroll position in <script> — absent (reduced motion, or
  * before hydration) the calc() falls back to 0 and the layers hold still.
  */
+/*
+ * The hero's height was whatever the copy happened to need, and Hebrew sets
+ * more compactly than English — 462px against 526px at 1440. Because the
+ * portrait is bottom-anchored and bleeds past the edge, that shorter section
+ * cropped more of him off, which read as the image being a different size
+ * between languages. It never was: both render at exactly 320x400. A floor
+ * keeps the frame identical whatever the copy does.
+ */
+.hero-section {
+  min-block-size: clamp(26rem, 38vw, 34rem);
+}
+
 .hero-frame {
   inline-size: min(100%, 120rem);
   margin-inline: auto;


### PR DESCRIPTION
The hero's height was whatever the copy needed, and Hebrew sets more compactly than English — **462px vs 526px** at 1440. The portrait is bottom-anchored and bleeds past the section edge, so the shorter Hebrew section cropped more of him away. That read as the image being a different size per language.

Measured, it never was:

| | EN | HE |
|---|---|---|
| portrait | `320×400` @ l=104 | `320×400` @ l=104 |
| Tzimtzum plate | `259×213` @ l=1077 | `259×213` @ l=1077 |
| **hero section** | **526px** | **462px** |

Only the container differed. A `min-block-size` floor pins the frame regardless of copy length — both locales now report **544px**.

No change to the nav. It mirrors correctly under RTL (brand at the reading-start edge, items flowing right-to-left), which is what Hebrew readers expect; confirmed as intended rather than assumed.

`task check` passes.