### PR TITLE
fix: ground the portrait and clear the copy from the Tzimtzum plate

### DIFF
--- a/app/pages/index.vue
+++ b/app/pages/index.vue
@@ -326,6 +326,16 @@ const layers = computed(() => [
  */
 .hero-section {
   min-block-size: clamp(26rem, 38vw, 34rem);
+  /*
+   * The min-height above can exceed what the copy needs. Without this the
+   * grid stays at the top of the section and the bottom-aligned portrait
+   * floats, with starfield showing beneath his coat. Ending the flex column
+   * puts the grid's bottom on the section's bottom, so he still rises out of
+   * the edge.
+   */
+  display: flex;
+  flex-direction: column;
+  justify-content: flex-end;
 }
 
 .hero-frame {
@@ -388,7 +398,7 @@ const layers = computed(() => [
 
 @media (min-width: 48rem) {
   .hero-copy {
-    padding-right: clamp(13rem, 17vw, 21rem);
+    padding-right: clamp(15rem, 23vw, 27rem);
   }
 }
 


### PR DESCRIPTION
Two regressions from the height floor in #47.

**Portrait floating.** The min-height can exceed what the copy needs, and the grid is a normal-flow child — so it stayed at the top of the section while the bottom-aligned portrait hung in mid-air with starfield visible under his coat. Section is now a flex column justified to the end.

Measured: portrait extends **32px past** the section edge (its intended bleed) instead of floating above it.

**Copy/plate collision.** The physical right gutter was `17vw`, leaving ~17px of overlap at 1440 — and the plate's handwritten annotations reach further left than its outer ring. Widened to `clamp(15rem, 23vw, 27rem)`.

Measured: text reaches **1005**, plate starts **1077** — 72px clearance, identical in EN and HE.

`task check` passes.