### PR TITLE
feat: twinkling stars in the hero, drop the faint text layer

### DIFF
--- a/app/assets/css/main.css
+++ b/app/assets/css/main.css
@@ -306,23 +306,75 @@ html {
  * the repeat never reads as a grid.
  */
 .tes-starfield {
+  /* isolation: creates a stacking context so the z-index:-1 twinkle layers
+     below sit above this element's own background but under its content. */
+  isolation: isolate;
   background-color: var(--color-navy-night);
-  background-image:
-    radial-gradient(
-      ellipse 90% 75% at 50% 0%,
-      color-mix(in srgb, var(--color-navy-dusk) 85%, var(--color-teal)) 0%,
-      transparent 65%
-    ),
-    url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='260' height='260'%3E%3Cg fill='%23ffffff'%3E%3Ccircle cx='86' cy='42' r='0.8' opacity='0.5'/%3E%3Ccircle cx='168' cy='22' r='0.8' opacity='0.9'/%3E%3Ccircle cx='139' cy='96' r='1.0' opacity='0.9'/%3E%3Ccircle cx='19' cy='132' r='1.0' opacity='0.25'/%3E%3Ccircle cx='22' cy='27' r='0.6' opacity='0.5'/%3E%3Ccircle cx='111' cy='212' r='1.0' opacity='0.25'/%3E%3Ccircle cx='35' cy='60' r='0.6' opacity='0.5'/%3E%3Ccircle cx='162' cy='243' r='1.2' opacity='0.7'/%3E%3Ccircle cx='250' cy='16' r='0.8' opacity='0.7'/%3E%3Ccircle cx='220' cy='77' r='0.8' opacity='0.25'/%3E%3Ccircle cx='50' cy='151' r='1.0' opacity='0.5'/%3E%3Ccircle cx='175' cy='112' r='0.7' opacity='0.9'/%3E%3Ccircle cx='83' cy='152' r='0.6' opacity='0.7'/%3E%3Ccircle cx='204' cy='180' r='0.6' opacity='0.35'/%3E%3Ccircle cx='188' cy='77' r='0.8' opacity='0.35'/%3E%3Ccircle cx='14' cy='172' r='0.7' opacity='0.7'/%3E%3Ccircle cx='197' cy='148' r='1.0' opacity='0.7'/%3E%3C/g%3E%3C/svg%3E"),
-    url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='260' height='260'%3E%3Cg fill='%23ffffff'%3E%3Ccircle cx='86' cy='42' r='0.8' opacity='0.5'/%3E%3Ccircle cx='168' cy='22' r='0.8' opacity='0.9'/%3E%3Ccircle cx='139' cy='96' r='1.0' opacity='0.9'/%3E%3Ccircle cx='19' cy='132' r='1.0' opacity='0.25'/%3E%3Ccircle cx='22' cy='27' r='0.6' opacity='0.5'/%3E%3Ccircle cx='111' cy='212' r='1.0' opacity='0.25'/%3E%3Ccircle cx='35' cy='60' r='0.6' opacity='0.5'/%3E%3Ccircle cx='162' cy='243' r='1.2' opacity='0.7'/%3E%3Ccircle cx='250' cy='16' r='0.8' opacity='0.7'/%3E%3Ccircle cx='220' cy='77' r='0.8' opacity='0.25'/%3E%3Ccircle cx='50' cy='151' r='1.0' opacity='0.5'/%3E%3Ccircle cx='175' cy='112' r='0.7' opacity='0.9'/%3E%3Ccircle cx='83' cy='152' r='0.6' opacity='0.7'/%3E%3Ccircle cx='204' cy='180' r='0.6' opacity='0.35'/%3E%3Ccircle cx='188' cy='77' r='0.8' opacity='0.35'/%3E%3Ccircle cx='14' cy='172' r='0.7' opacity='0.7'/%3E%3Ccircle cx='197' cy='148' r='1.0' opacity='0.7'/%3E%3C/g%3E%3C/svg%3E");
-  background-size:
-    100% 100%,
-    260px 260px,
-    417px 417px;
-  background-position:
-    0 0,
-    0 0,
-    130px 47px;
+  background-image: radial-gradient(
+    ellipse 90% 75% at 50% 0%,
+    color-mix(in srgb, var(--color-navy-dusk) 85%, var(--color-teal)) 0%,
+    transparent 65%
+  );
+}
+
+/*
+ * Twinkle. The two star tiles moved off the element and onto pseudo-elements
+ * so each can breathe on its own cycle — a single shared layer would pulse
+ * the whole sky in lockstep, which reads as a screen flicker rather than
+ * stars. Durations are coprime (7s / 11s) so the two passes drift in and out
+ * of phase instead of resolving to a visible beat.
+ *
+ * Opacity only: no layout, no paint of anything but these two layers, and no
+ * JavaScript. GPU-composited, and free when reduced motion is requested.
+ */
+.tes-starfield::before,
+.tes-starfield::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  z-index: -1;
+  pointer-events: none;
+  will-change: opacity;
+}
+
+.tes-starfield::before {
+  background: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='260' height='260'%3E%3Cg fill='%23ffffff'%3E%3Ccircle cx='86' cy='42' r='0.8' opacity='0.5'/%3E%3Ccircle cx='168' cy='22' r='0.8' opacity='0.9'/%3E%3Ccircle cx='139' cy='96' r='1.0' opacity='0.9'/%3E%3Ccircle cx='19' cy='132' r='1.0' opacity='0.25'/%3E%3Ccircle cx='22' cy='27' r='0.6' opacity='0.5'/%3E%3Ccircle cx='111' cy='212' r='1.0' opacity='0.25'/%3E%3Ccircle cx='35' cy='60' r='0.6' opacity='0.5'/%3E%3Ccircle cx='162' cy='243' r='1.2' opacity='0.7'/%3E%3Ccircle cx='250' cy='16' r='0.8' opacity='0.7'/%3E%3Ccircle cx='220' cy='77' r='0.8' opacity='0.25'/%3E%3Ccircle cx='50' cy='151' r='1.0' opacity='0.5'/%3E%3Ccircle cx='175' cy='112' r='0.7' opacity='0.9'/%3E%3Ccircle cx='83' cy='152' r='0.6' opacity='0.7'/%3E%3Ccircle cx='204' cy='180' r='0.6' opacity='0.35'/%3E%3Ccircle cx='188' cy='77' r='0.8' opacity='0.35'/%3E%3Ccircle cx='14' cy='172' r='0.7' opacity='0.7'/%3E%3Ccircle cx='197' cy='148' r='1.0' opacity='0.7'/%3E%3C/g%3E%3C/svg%3E")
+    0 0 / 260px 260px repeat;
+  animation: star-twinkle-near 7s ease-in-out infinite;
+}
+
+.tes-starfield::after {
+  background: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='260' height='260'%3E%3Cg fill='%23ffffff'%3E%3Ccircle cx='86' cy='42' r='0.8' opacity='0.5'/%3E%3Ccircle cx='168' cy='22' r='0.8' opacity='0.9'/%3E%3Ccircle cx='139' cy='96' r='1.0' opacity='0.9'/%3E%3Ccircle cx='19' cy='132' r='1.0' opacity='0.25'/%3E%3Ccircle cx='22' cy='27' r='0.6' opacity='0.5'/%3E%3Ccircle cx='111' cy='212' r='1.0' opacity='0.25'/%3E%3Ccircle cx='35' cy='60' r='0.6' opacity='0.5'/%3E%3Ccircle cx='162' cy='243' r='1.2' opacity='0.7'/%3E%3Ccircle cx='250' cy='16' r='0.8' opacity='0.7'/%3E%3Ccircle cx='220' cy='77' r='0.8' opacity='0.25'/%3E%3Ccircle cx='50' cy='151' r='1.0' opacity='0.5'/%3E%3Ccircle cx='175' cy='112' r='0.7' opacity='0.9'/%3E%3Ccircle cx='83' cy='152' r='0.6' opacity='0.7'/%3E%3Ccircle cx='204' cy='180' r='0.6' opacity='0.35'/%3E%3Ccircle cx='188' cy='77' r='0.8' opacity='0.35'/%3E%3Ccircle cx='14' cy='172' r='0.7' opacity='0.7'/%3E%3Ccircle cx='197' cy='148' r='1.0' opacity='0.7'/%3E%3C/g%3E%3C/svg%3E")
+    130px 47px / 417px 417px repeat;
+  animation: star-twinkle-far 11s ease-in-out infinite;
+  animation-delay: -3.5s;
+}
+
+@keyframes star-twinkle-near {
+  0%,
+  100% {
+    opacity: 0.55;
+  }
+  50% {
+    opacity: 1;
+  }
+}
+
+@keyframes star-twinkle-far {
+  0%,
+  100% {
+    opacity: 0.9;
+  }
+  50% {
+    opacity: 0.4;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .tes-starfield::before,
+  .tes-starfield::after {
+    animation: none;
+  }
 }
 
 /*

--- a/app/pages/index.vue
+++ b/app/pages/index.vue
@@ -19,16 +19,24 @@ const openingLine: Record<string, string> = {
 
 const quote = computed(() => openingLine[locale.value] ?? openingLine.en);
 
-// The typographic texture layer: the actual opening of Chapter 1 from the
-// 1956 Jerusalem edition (source.he-jerusalem-1956.json, items 1–3),
-// inline anchor letters and footnote stars stripped. Hardcoded as plain
-// strings — importing the chapter JSON here would ship the whole file in
-// the client bundle for what is a purely decorative layer.
-const heroTexture = [
-  "מבאר ענין הצמצום הא' שנצטמצם אור אין סוף ב\"ה בכדי להאציל הנאצלים ולברוא הנבראים. ובו ה' ענינים: — לפני הצמצום היה אין סוף ממלא כל המציאות",
-  "דע כי טרם שנאצלו הנאצלים ונבראו הנבראים, היה אור עליון פשוט ממלא כל המציאות. ולא היה שום מקום פנוי בבחינת אויר ריקני וחלל, אלא היה הכל ממולא מן אור א\"ס פשוט ההוא, ולא היה לו לא בחינת ראש ולא בחינת סוף, אלא הכל היה אור א' פשוט שוה בהשואה א', והוא הנקרא אור א\"ס.",
-  "וכאשר עלה ברצונו הפשוט, לברוא העולמות ולהאציל הנאצלים. להוציא לאור שלימות פעולותיו ושמותיו וכינויו, אשר זאת היה סיבת בריאת העולמות.",
-  'והנה אז צמצם את עצמו א"ס בנקודה האמצעית, אשר בו באמצע ממש, וצמצם האור ההוא, ונתרחק אל צדדי סביבות הנקודה האמצעית.',
+// A handful of brighter stars that twinkle individually, over the two
+// repeating tile layers in `.tes-starfield`. Same data-driven approach as the
+// fireflies in the chatpatka home page: one keyframe set, per-star custom
+// properties, no per-star CSS. Coprime-ish durations so they never resolve
+// into a visible pulse together.
+const stars = [
+  { x: 9, y: 22, size: 2.4, dur: 4.3, delay: 0 },
+  { x: 17, y: 68, size: 1.8, dur: 6.1, delay: 1.4 },
+  { x: 26, y: 12, size: 2.0, dur: 5.2, delay: 2.7 },
+  { x: 34, y: 84, size: 1.6, dur: 7.4, delay: 0.6 },
+  { x: 48, y: 18, size: 2.6, dur: 5.8, delay: 3.1 },
+  { x: 57, y: 74, size: 1.7, dur: 4.9, delay: 1.9 },
+  { x: 66, y: 30, size: 2.1, dur: 6.6, delay: 0.3 },
+  { x: 73, y: 62, size: 1.9, dur: 5.5, delay: 2.2 },
+  { x: 82, y: 16, size: 2.8, dur: 7.1, delay: 1.1 },
+  { x: 88, y: 78, size: 1.7, dur: 4.6, delay: 3.4 },
+  { x: 94, y: 42, size: 2.2, dur: 6.3, delay: 0.9 },
+  { x: 41, y: 52, size: 1.5, dur: 8.2, delay: 2.5 },
 ];
 
 // Subtle scroll parallax on the two decorative layers (transform-only, so
@@ -97,20 +105,22 @@ const layers = computed(() => [
            viewport: past ~1920px they would otherwise drift to the far edges
            and leave the composition strung out across the middle. The night
            field itself stays full-bleed. -->
-      <div aria-hidden="true" class="hero-frame absolute inset-0">
-        <!-- Chapter 1 as texture: real text, purely atmospheric -->
-        <div
-          aria-hidden="true"
-          lang="he"
-          dir="rtl"
-          class="hero-texture absolute hidden select-none sm:block"
-        >
-          <p class="hero-texture-heading">{{ heroTexture[0] }}</p>
-          <p v-for="line in heroTexture.slice(1)" :key="line.slice(0, 24)">
-            {{ line }}
-          </p>
-        </div>
+      <div aria-hidden="true" class="hero-stars absolute inset-0">
+        <span
+          v-for="(s, i) in stars"
+          :key="i"
+          class="hero-star absolute"
+          :style="{
+            '--star-x': `${s.x}%`,
+            '--star-y': `${s.y}%`,
+            '--star-size': `${s.size}px`,
+            '--star-dur': `${s.dur}s`,
+            '--star-delay': `${s.delay}s`,
+          }"
+        />
+      </div>
 
+      <div aria-hidden="true" class="hero-frame absolute inset-0">
         <!--
         The ARI's own Tzimtzum plate (Figma node 109:3) — the drawn figure
         with its annotations and vessel sketches, not an SVG approximation
@@ -338,51 +348,45 @@ const layers = computed(() => [
   justify-content: flex-end;
 }
 
+/*
+ * Brighter individual stars over the tiled field. Opacity + scale only, both
+ * compositor-friendly; the glow is a static box-shadow that rides along
+ * rather than being re-rendered.
+ */
+.hero-stars {
+  pointer-events: none;
+}
+
+.hero-star {
+  top: var(--star-y);
+  left: var(--star-x);
+  inline-size: var(--star-size);
+  block-size: var(--star-size);
+  border-radius: 50%;
+  background: var(--color-surface-white);
+  box-shadow: 0 0 calc(var(--star-size) * 2.5) calc(var(--star-size) * 0.4)
+    color-mix(in srgb, var(--color-surface-white) 45%, transparent);
+  opacity: 0.35;
+  animation: hero-star-twinkle var(--star-dur) ease-in-out var(--star-delay)
+    infinite;
+}
+
+@keyframes hero-star-twinkle {
+  0%,
+  100% {
+    opacity: 0.2;
+    transform: scale(0.85);
+  }
+  50% {
+    opacity: 1;
+    transform: scale(1.15);
+  }
+}
+
 .hero-frame {
   inline-size: min(100%, 120rem);
   margin-inline: auto;
   pointer-events: none;
-}
-
-.hero-texture {
-  /* Physical on purpose: this is the book's own page set as artwork, already
-     RTL Hebrew. Mirroring it just moves the block for no reason. */
-  inset-block: 0;
-  left: 30%;
-  right: 24%;
-  padding-block-start: 3.5rem;
-  font-size: 1.0625rem;
-  line-height: 2.1;
-  text-align: justify;
-  /*
-   * This layer sits directly behind the headline and body copy (it spans
-   * 34%–96% of the inline axis, and the content column starts around 37%).
-   * At a legible opacity the Hebrew reads as *text competing with the copy*
-   * rather than as atmosphere. Two changes keep it subliminal: a lower
-   * alpha, and a small blur so the glyphs never resolve into words.
-   */
-  color: color-mix(in srgb, var(--color-surface-white) 5%, transparent);
-  filter: blur(1.1px);
-  pointer-events: none;
-  transform: translateY(calc(var(--hero-drift, 0) * 0.045px));
-  mask-image: linear-gradient(
-    to bottom,
-    transparent 0%,
-    black 12%,
-    black 62%,
-    transparent 96%
-  );
-}
-
-.hero-texture p + p {
-  margin-block-start: 1.4em;
-}
-
-.hero-texture-heading {
-  font-size: 1.35rem;
-  font-weight: 700;
-  line-height: 1.9;
-  text-align: center;
 }
 
 /*
@@ -473,8 +477,15 @@ const layers = computed(() => [
 @media (prefers-reduced-motion: reduce) {
   .hero-enter-content,
   .hero-enter-portrait,
+  .hero-star,
   .layer-card {
     animation: none;
+  }
+
+  /* Held at a legible steady brightness rather than hidden — they are part
+     of the composition, only their motion is the problem. */
+  .hero-star {
+    opacity: 0.55;
   }
 
   .layer-card:hover {


### PR DESCRIPTION
Stars shimmer now, in **pure CSS with no new dependency** — matching the house approach in `chatpatka`, whose entire animated home page (sun, clouds, bird, leaves, fireflies) runs on hand-written keyframes with zero animation libraries.

**Two layers:**

- Existing star tiles moved onto `::before`/`::after` so each breathes on its own cycle. One shared layer would pulse the sky in lockstep — that reads as screen flicker, not stars. 7s and 11s so they drift in and out of phase rather than resolving to a beat.
- Twelve brighter individual stars over the top, using chatpatka's data-driven firefly pattern: one keyframe set, per-star `--star-x/-y/-size/-dur/-delay`. Opacity and scale only.

**Library options considered:**

| Option | Cost | Verdict |
|---|---|---|
| CSS keyframes | 0 KB | **chosen** |
| `@weburz/particle-canvas` | ~3 KB gz | Viable — Nuxt 4, published, ResizeObserver + DPR. No reduced-motion support. Worth it for real particle physics, overkill here |
| GSAP | ~25 KB gz | Disproportionate for opacity cycling |
| three.js | ~150 KB gz | Against an 84 KB baseline, for dots |

`@weburz/nuxt-particles` is unusable — Nuxt 3 only, and its `@weburz/particles` dep is `file:`-linked so it can't install standalone.

**Also:** removed the faint Hebrew text behind the hero as requested, plus the hardcoded chapter strings that fed it.

**Verified, not assumed:** star opacity sampled live at `0.84 → 0.61 → 0.37 → 0.23`, 19 animations running. Under `prefers-reduced-motion`: **0 running animations**, stars held at 0.55 rather than hidden — they're part of the composition, only the motion is the problem.

`task check` passes.