### PR TITLE
fix: make the stars actually twinkle

### DIFF
--- a/app/assets/css/main.css
+++ b/app/assets/css/main.css
@@ -340,20 +340,20 @@ html {
 .tes-starfield::before {
   background: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='260' height='260'%3E%3Cg fill='%23ffffff'%3E%3Ccircle cx='86' cy='42' r='0.8' opacity='0.5'/%3E%3Ccircle cx='168' cy='22' r='0.8' opacity='0.9'/%3E%3Ccircle cx='139' cy='96' r='1.0' opacity='0.9'/%3E%3Ccircle cx='19' cy='132' r='1.0' opacity='0.25'/%3E%3Ccircle cx='22' cy='27' r='0.6' opacity='0.5'/%3E%3Ccircle cx='111' cy='212' r='1.0' opacity='0.25'/%3E%3Ccircle cx='35' cy='60' r='0.6' opacity='0.5'/%3E%3Ccircle cx='162' cy='243' r='1.2' opacity='0.7'/%3E%3Ccircle cx='250' cy='16' r='0.8' opacity='0.7'/%3E%3Ccircle cx='220' cy='77' r='0.8' opacity='0.25'/%3E%3Ccircle cx='50' cy='151' r='1.0' opacity='0.5'/%3E%3Ccircle cx='175' cy='112' r='0.7' opacity='0.9'/%3E%3Ccircle cx='83' cy='152' r='0.6' opacity='0.7'/%3E%3Ccircle cx='204' cy='180' r='0.6' opacity='0.35'/%3E%3Ccircle cx='188' cy='77' r='0.8' opacity='0.35'/%3E%3Ccircle cx='14' cy='172' r='0.7' opacity='0.7'/%3E%3Ccircle cx='197' cy='148' r='1.0' opacity='0.7'/%3E%3C/g%3E%3C/svg%3E")
     0 0 / 260px 260px repeat;
-  animation: star-twinkle-near 7s ease-in-out infinite;
+  animation: star-twinkle-near 4.5s ease-in-out infinite;
 }
 
 .tes-starfield::after {
   background: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='260' height='260'%3E%3Cg fill='%23ffffff'%3E%3Ccircle cx='86' cy='42' r='0.8' opacity='0.5'/%3E%3Ccircle cx='168' cy='22' r='0.8' opacity='0.9'/%3E%3Ccircle cx='139' cy='96' r='1.0' opacity='0.9'/%3E%3Ccircle cx='19' cy='132' r='1.0' opacity='0.25'/%3E%3Ccircle cx='22' cy='27' r='0.6' opacity='0.5'/%3E%3Ccircle cx='111' cy='212' r='1.0' opacity='0.25'/%3E%3Ccircle cx='35' cy='60' r='0.6' opacity='0.5'/%3E%3Ccircle cx='162' cy='243' r='1.2' opacity='0.7'/%3E%3Ccircle cx='250' cy='16' r='0.8' opacity='0.7'/%3E%3Ccircle cx='220' cy='77' r='0.8' opacity='0.25'/%3E%3Ccircle cx='50' cy='151' r='1.0' opacity='0.5'/%3E%3Ccircle cx='175' cy='112' r='0.7' opacity='0.9'/%3E%3Ccircle cx='83' cy='152' r='0.6' opacity='0.7'/%3E%3Ccircle cx='204' cy='180' r='0.6' opacity='0.35'/%3E%3Ccircle cx='188' cy='77' r='0.8' opacity='0.35'/%3E%3Ccircle cx='14' cy='172' r='0.7' opacity='0.7'/%3E%3Ccircle cx='197' cy='148' r='1.0' opacity='0.7'/%3E%3C/g%3E%3C/svg%3E")
     130px 47px / 417px 417px repeat;
-  animation: star-twinkle-far 11s ease-in-out infinite;
+  animation: star-twinkle-far 7s ease-in-out infinite;
   animation-delay: -3.5s;
 }
 
 @keyframes star-twinkle-near {
   0%,
   100% {
-    opacity: 0.55;
+    opacity: 0.3;
   }
   50% {
     opacity: 1;
@@ -363,10 +363,10 @@ html {
 @keyframes star-twinkle-far {
   0%,
   100% {
-    opacity: 0.9;
+    opacity: 1;
   }
   50% {
-    opacity: 0.4;
+    opacity: 0.2;
   }
 }
 

--- a/app/pages/index.vue
+++ b/app/pages/index.vue
@@ -19,25 +19,31 @@ const openingLine: Record<string, string> = {
 
 const quote = computed(() => openingLine[locale.value] ?? openingLine.en);
 
-// A handful of brighter stars that twinkle individually, over the two
-// repeating tile layers in `.tes-starfield`. Same data-driven approach as the
-// fireflies in the chatpatka home page: one keyframe set, per-star custom
-// properties, no per-star CSS. Coprime-ish durations so they never resolve
-// into a visible pulse together.
-const stars = [
-  { x: 9, y: 22, size: 2.4, dur: 4.3, delay: 0 },
-  { x: 17, y: 68, size: 1.8, dur: 6.1, delay: 1.4 },
-  { x: 26, y: 12, size: 2.0, dur: 5.2, delay: 2.7 },
-  { x: 34, y: 84, size: 1.6, dur: 7.4, delay: 0.6 },
-  { x: 48, y: 18, size: 2.6, dur: 5.8, delay: 3.1 },
-  { x: 57, y: 74, size: 1.7, dur: 4.9, delay: 1.9 },
-  { x: 66, y: 30, size: 2.1, dur: 6.6, delay: 0.3 },
-  { x: 73, y: 62, size: 1.9, dur: 5.5, delay: 2.2 },
-  { x: 82, y: 16, size: 2.8, dur: 7.1, delay: 1.1 },
-  { x: 88, y: 78, size: 1.7, dur: 4.6, delay: 3.4 },
-  { x: 94, y: 42, size: 2.2, dur: 6.3, delay: 0.9 },
-  { x: 41, y: 52, size: 1.5, dur: 8.2, delay: 2.5 },
-];
+// Twinkling stars over the two tile layers in `.tes-starfield`. Same
+// data-driven idea as the fireflies in chatpatka's home page — one keyframe
+// set, per-star custom properties — but there are enough of them, popping
+// briefly rather than fading smoothly, that the sky actually sparkles.
+//
+// Positions come from a seeded LCG rather than Math.random(): the list has to
+// be byte-identical on the server and the client or hydration mismatches, and
+// a fixed seed also means the layout never shifts between builds.
+const makeStars = (count: number) => {
+  let seed = 20241127;
+  const next = () => {
+    seed = (seed * 1664525 + 1013904223) % 4294967296;
+    return seed / 4294967296;
+  };
+  return Array.from({ length: count }, () => ({
+    x: +(next() * 98 + 1).toFixed(2),
+    y: +(next() * 92 + 2).toFixed(2),
+    size: +(next() * 1.9 + 1.1).toFixed(2),
+    // 2.2-5.2s: short enough to read as a twinkle, long enough not to strobe.
+    dur: +(next() * 3 + 2.2).toFixed(2),
+    delay: +(next() * 6).toFixed(2),
+  }));
+};
+
+const stars = makeStars(54);
 
 // Subtle scroll parallax on the two decorative layers (transform-only, so
 // no layout shift). Skipped entirely under prefers-reduced-motion — the
@@ -366,20 +372,25 @@ const layers = computed(() => [
   background: var(--color-surface-white);
   box-shadow: 0 0 calc(var(--star-size) * 2.5) calc(var(--star-size) * 0.4)
     color-mix(in srgb, var(--color-surface-white) 45%, transparent);
-  opacity: 0.35;
-  animation: hero-star-twinkle var(--star-dur) ease-in-out var(--star-delay)
+  opacity: 0.12;
+  animation: hero-star-twinkle var(--star-dur) ease-out var(--star-delay)
     infinite;
 }
 
 @keyframes hero-star-twinkle {
   0%,
+  58%,
   100% {
-    opacity: 0.2;
-    transform: scale(0.85);
+    opacity: 0.12;
+    transform: scale(0.7);
   }
-  50% {
+  72% {
     opacity: 1;
-    transform: scale(1.15);
+    transform: scale(1.35);
+  }
+  86% {
+    opacity: 0.3;
+    transform: scale(0.9);
   }
 }
 


### PR DESCRIPTION
The first pass barely read as motion. Three causes:

| | Before | After |
|---|---|---|
| Count | 12 | **54** |
| Cycle | 4.3–8.2s | **2.2–5.2s** |
| Curve | symmetric `ease-in-out` | dim ~58% of cycle, brief bright pop |

The curve was the main one — a symmetric fade spends most of its time at mid-brightness, which reads as a slow wash rather than a sparkle. Same fix on the two tiled passes: swings widened to 0.3–1.0 and 1.0–0.2, over 4.5s and 7s instead of 7s and 11s.

Positions come from a **seeded LCG, not `Math.random()`** — the list has to be byte-identical server- and client-side or hydration mismatches, and a fixed seed keeps the sky from rearranging between builds. Verified: no hydration warnings.

**Measured, not eyeballed.** Sampling all 54 every 350ms:

```
t+0.00s  max=0.93  bright(>0.6)=2
t+0.70s  max=0.99  bright(>0.6)=6
t+1.05s  max=0.98  bright(>0.6)=9
t+1.75s  max=1.00  bright(>0.6)=2
```

Rest hold at 0.12, and the lit set turns over continuously.

Still zero JS dependencies. Reduced motion unchanged. `task check` passes.