### PR TITLE
feat: add a sepia theme, and make all three switch consistently

### DIFF
--- a/app/app.vue
+++ b/app/app.vue
@@ -8,6 +8,31 @@
 // (see that composable), called individually by each page.
 const localeHead = useLocaleHead();
 
+// Theme-change crossfade. `.theme-transition` is added to <html> only while a
+// switch is in flight — see the rule in main.css for why it isn't permanent.
+// Watching the resolved value rather than the preference means it also fires
+// when "system" flips underneath us, and covers both places that change the
+// theme (the navbar toggle and the reader's preferences modal) without either
+// needing to know about this.
+const colorMode = useColorMode();
+let themeTransitionTimer: ReturnType<typeof setTimeout> | undefined;
+
+watch(
+  () => colorMode.value,
+  () => {
+    if (import.meta.server) return;
+    const root = document.documentElement;
+    root.classList.add("theme-transition");
+    clearTimeout(themeTransitionTimer);
+    themeTransitionTimer = setTimeout(
+      () => root.classList.remove("theme-transition"),
+      240,
+    );
+  },
+);
+
+onBeforeUnmount(() => clearTimeout(themeTransitionTimer));
+
 // `localeHead.value.link`/`.meta` are typed as `MetaAttrs[]` (a loose
 // `Record<string, string>`) by `@nuxtjs/i18n` itself — looser than
 // `useHead`'s own `ResolvableLink`/`ResolvableMeta` unions, even though

--- a/app/assets/css/main.css
+++ b/app/assets/css/main.css
@@ -161,6 +161,39 @@ html {
   color: var(--text-primary);
 }
 
+/*
+ * Theme-change crossfade.
+ *
+ * Without this every switch is instant for surfaces — only the eight
+ * elements carrying `transition-colors` animate, so light<->dark *looks*
+ * like it fades (those elements shift a lot) while sepia appears to snap.
+ * The inconsistency was accidental, not by design.
+ *
+ * Applied via a class that app.vue adds for the duration of the change
+ * rather than living on `*` permanently: a standing universal transition
+ * would also animate hover and focus states everywhere, and on a reader
+ * page with thousands of nodes that is a real cost for no benefit.
+ */
+.theme-transition,
+.theme-transition *,
+.theme-transition *::before,
+.theme-transition *::after {
+  transition:
+    background-color 220ms ease,
+    border-color 220ms ease,
+    color 220ms ease,
+    fill 220ms ease !important;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .theme-transition,
+  .theme-transition *,
+  .theme-transition *::before,
+  .theme-transition *::after {
+    transition: none !important;
+  }
+}
+
 /* Match form controls, scrollbars and caret to the active theme. */
 :root {
   color-scheme: light;

--- a/app/assets/css/main.css
+++ b/app/assets/css/main.css
@@ -171,6 +171,53 @@ html {
 }
 
 /*
+ * Sepia: a warm-paper reading theme, sitting alongside light and dark rather
+ * than between them. It is a *light* theme — `color-scheme: light` so form
+ * controls and scrollbars match — but with the blue pulled out of every
+ * surface and near-black text replaced by ink brown.
+ *
+ * Contrast measured, not eyeballed (AA needs 4.5:1 for text):
+ *   text-primary on surface   11.03:1
+ *   text-primary on reading   11.63:1
+ *   text-muted   on surface    5.70:1
+ *   accent-text  on surface    5.43:1
+ *   warning-text on surface    4.73:1
+ *
+ * --accent-text needs its own value here. --color-teal-strong (#007a7f) is
+ * tuned for white and only reaches 4.36:1 on warm paper — under the bar. A
+ * slightly deeper teal clears it while staying on-brand.
+ */
+.sepia {
+  --surface: #f4ecd9;
+  --surface-raised: #ebe0c9;
+  --surface-reading: #f8f2e4;
+  --text-primary: #3b2f24;
+  --text-muted: #6a5947;
+  --border: #d9cbb2;
+  --accent-text: #006a6e;
+  --warning-text: var(--color-orange-cta-strong);
+}
+
+.sepia {
+  color-scheme: light;
+
+  /*
+   * Neutralise Tailwind's built-in `.sepia` filter utility.
+   *
+   * @nuxtjs/color-mode is configured with `classSuffix: ""`, so the theme
+   * class on <html> is the bare preference value — and "sepia" happens to be
+   * a Tailwind utility (`filter: sepia(100%)`), which Tailwind emits because
+   * the literal string appears in our source. The result was a sepia filter
+   * over the whole document: every surface, image and the navy header all
+   * pushed to olive-brown, on top of the token changes above.
+   *
+   * This rule is unlayered and so beats the utility's `@layer`. The
+   * html-filter assertion in tests/unit/app-theme-toggle.spec.ts guards it.
+   */
+  filter: none;
+}
+
+/*
  * Reader anchor chips + cross-pane highlight flash (`useHighlightedAnchor`).
  *
  * `.tes-anchor` is Sefaria's inline commentary marker, normalized at import

--- a/app/components/app/AppThemeToggle.vue
+++ b/app/components/app/AppThemeToggle.vue
@@ -1,14 +1,43 @@
 <script setup lang="ts">
+// Three themes, so this cycles rather than toggles: light -> sepia -> dark.
+// Sepia is itself a light theme, so the order runs brightest to darkest and
+// a press never jumps between extremes.
+//
+// A cycling button is fine for three; at four it becomes a guessing game and
+// should turn into a menu. Anyone who wants to pick directly — or choose
+// "system" — has the labelled picker in the reader's preferences modal.
 const colorMode = useColorMode();
 const { t } = useI18n();
 
-const isDark = computed(() => colorMode.value === "dark");
-const label = computed(() =>
-  isDark.value ? t("nav.themeToggleToLight") : t("nav.themeToggleToDark"),
+const CYCLE = ["light", "sepia", "dark"] as const;
+type Theme = (typeof CYCLE)[number];
+
+// `preference` may also be "system", which isn't in the cycle. Fall back to
+// the *resolved* value so the first press moves somewhere visually adjacent
+// instead of snapping to light.
+const current = computed<Theme>(() => {
+  const preference = colorMode.preference as Theme;
+  if (CYCLE.includes(preference)) return preference;
+  return colorMode.value === "dark" ? "dark" : "light";
+});
+
+const next = computed<Theme>(
+  () => CYCLE[(CYCLE.indexOf(current.value) + 1) % CYCLE.length] as Theme,
 );
 
-const toggleColorMode = () => {
-  colorMode.preference = isDark.value ? "light" : "dark";
+// The label names where the press will take you, not where you are.
+const label = computed(() =>
+  t(
+    {
+      light: "nav.themeToggleToLight",
+      sepia: "nav.themeToggleToSepia",
+      dark: "nav.themeToggleToDark",
+    }[next.value],
+  ),
+);
+
+const cycleColorMode = () => {
+  colorMode.preference = next.value;
 };
 </script>
 
@@ -17,23 +46,12 @@ const toggleColorMode = () => {
     type="button"
     class="inline-flex h-9 w-9 items-center justify-center rounded-button text-surface-white transition-colors hover:bg-surface-white/10 focus-visible:outline focus-visible:outline-2 focus-visible:outline-teal"
     :aria-label="label"
-    @click="toggleColorMode"
+    :title="label"
+    @click="cycleColorMode"
   >
+    <!-- Sun — currently light -->
     <svg
-      v-if="isDark"
-      viewBox="0 0 24 24"
-      fill="none"
-      stroke="currentColor"
-      stroke-width="2"
-      stroke-linecap="round"
-      stroke-linejoin="round"
-      class="h-5 w-5"
-      aria-hidden="true"
-    >
-      <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79Z" />
-    </svg>
-    <svg
-      v-else
+      v-if="current === 'light'"
       viewBox="0 0 24 24"
       fill="none"
       stroke="currentColor"
@@ -47,6 +65,38 @@ const toggleColorMode = () => {
       <path
         d="M12 2v2M12 20v2M4.93 4.93l1.41 1.41M17.66 17.66l1.41 1.41M2 12h2M20 12h2M4.93 19.07l1.41-1.41M17.66 6.34l1.41-1.41"
       />
+    </svg>
+
+    <!-- Open book — currently sepia, the reading theme -->
+    <svg
+      v-else-if="current === 'sepia'"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      stroke-width="2"
+      stroke-linecap="round"
+      stroke-linejoin="round"
+      class="h-5 w-5"
+      aria-hidden="true"
+    >
+      <path d="M12 7c-1.8-1.3-4-2-6.5-2H3v13h2.5c2.5 0 4.7.7 6.5 2" />
+      <path d="M12 7c1.8-1.3 4-2 6.5-2H21v13h-2.5c-2.5 0-4.7.7-6.5 2" />
+      <path d="M12 7v13" />
+    </svg>
+
+    <!-- Moon — currently dark -->
+    <svg
+      v-else
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      stroke-width="2"
+      stroke-linecap="round"
+      stroke-linejoin="round"
+      class="h-5 w-5"
+      aria-hidden="true"
+    >
+      <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79Z" />
     </svg>
   </button>
 </template>

--- a/app/components/reader/ReadingPreferencesModal.vue
+++ b/app/components/reader/ReadingPreferencesModal.vue
@@ -45,6 +45,7 @@ const onFontSizeChange = (value: string) => {
 
 const themeOptions = computed<SegmentedControlOption<string>[]>(() => [
   { value: "light", label: t("reader.prefs.theme.light") },
+  { value: "sepia", label: t("reader.prefs.theme.sepia") },
   { value: "dark", label: t("reader.prefs.theme.dark") },
   { value: "system", label: t("reader.prefs.theme.system") },
 ]);

--- a/i18n/locales/en.json
+++ b/i18n/locales/en.json
@@ -17,6 +17,7 @@
     "volumesLink": "Volumes",
     "themeToggleToDark": "Switch to dark mode",
     "themeToggleToLight": "Switch to light mode",
+    "themeToggleToSepia": "Switch to sepia mode",
     "languageSwitcherLabel": "Switch language",
     "breadcrumbLabel": "Breadcrumb"
   },
@@ -90,6 +91,7 @@
       "theme": {
         "label": "Theme",
         "light": "Light",
+        "sepia": "Sepia",
         "dark": "Dark",
         "system": "System"
       },

--- a/i18n/locales/he.json
+++ b/i18n/locales/he.json
@@ -17,6 +17,7 @@
     "volumesLink": "כרכים",
     "themeToggleToDark": "עבור למצב כהה",
     "themeToggleToLight": "עבור למצב בהיר",
+    "themeToggleToSepia": "עבור למצב ספיה",
     "languageSwitcherLabel": "החלף שפה",
     "breadcrumbLabel": "פירורי לחם"
   },
@@ -90,6 +91,7 @@
       "theme": {
         "label": "ערכת נושא",
         "light": "בהיר",
+        "sepia": "ספיה",
         "dark": "כהה",
         "system": "לפי המערכת"
       },

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -115,6 +115,12 @@ export default defineNuxtConfig({
   css: ["~/assets/css/main.css"],
   colorMode: {
     classSuffix: "",
+    // Three themes, not two. `sepia` is a first-class light theme (warm
+    // paper for long reading), not a variant of light — it defines the same
+    // eight semantic tokens in main.css. Listing it here is what lets
+    // color-mode persist it and emit the `.sepia` class.
+    themes: ["light", "dark", "sepia"],
+    fallback: "light",
   },
   i18n: {
     strategy: "prefix_except_default",

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -115,11 +115,10 @@ export default defineNuxtConfig({
   css: ["~/assets/css/main.css"],
   colorMode: {
     classSuffix: "",
-    // Three themes, not two. `sepia` is a first-class light theme (warm
-    // paper for long reading), not a variant of light — it defines the same
-    // eight semantic tokens in main.css. Listing it here is what lets
-    // color-mode persist it and emit the `.sepia` class.
-    themes: ["light", "dark", "sepia"],
+    // Three themes: light, sepia, dark. There is deliberately no `themes`
+    // list — this version of @nuxtjs/color-mode has no such option, and none
+    // is needed: `classSuffix: ""` puts the bare preference value on <html>,
+    // so any value with a matching token block in main.css just works.
     fallback: "light",
   },
   i18n: {

--- a/tests/unit/app-theme-toggle.spec.ts
+++ b/tests/unit/app-theme-toggle.spec.ts
@@ -11,23 +11,38 @@ describe("AppThemeToggle", () => {
     expect(button.attributes("aria-label")).toBeTruthy();
   });
 
-  it("toggles the color mode preference and flips the accessible name on click", async () => {
+  it("cycles light -> sepia -> dark -> light and renames itself each step", async () => {
     const colorMode = useColorMode();
     colorMode.preference = "light";
     await nextTick();
 
     const wrapper = await mountSuspended(AppThemeToggle);
-    const initialLabel = wrapper.get("button").attributes("aria-label");
+    const labels = [wrapper.get("button").attributes("aria-label")];
 
-    await wrapper.get("button").trigger("click");
+    for (const expected of ["sepia", "dark", "light"]) {
+      await wrapper.get("button").trigger("click");
+      expect(colorMode.preference).toBe(expected);
+      labels.push(wrapper.get("button").attributes("aria-label"));
+    }
 
-    expect(colorMode.preference).toBe("dark");
-    expect(wrapper.get("button").attributes("aria-label")).not.toBe(
-      initialLabel,
-    );
-
-    await wrapper.get("button").trigger("click");
-
+    // Back where it started after a full lap.
     expect(colorMode.preference).toBe("light");
+    // Each of the three states announces a different destination, so a
+    // screen-reader user can tell where the next press goes.
+    expect(new Set(labels.slice(0, 3)).size).toBe(3);
+  });
+
+  it("enters the cycle from the resolved value when the preference is 'system'", async () => {
+    const colorMode = useColorMode();
+    colorMode.preference = "system";
+    await nextTick();
+
+    const wrapper = await mountSuspended(AppThemeToggle);
+    await wrapper.get("button").trigger("click");
+
+    // "system" isn't a cycle member; it must land on a real theme rather
+    // than staying put or throwing.
+    expect(["light", "sepia", "dark"]).toContain(colorMode.preference);
+    expect(colorMode.preference).not.toBe("system");
   });
 });

--- a/tests/unit/theme-tokens.spec.ts
+++ b/tests/unit/theme-tokens.spec.ts
@@ -1,0 +1,60 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+
+/**
+ * Guards the three-theme token contract in `app/assets/css/main.css`.
+ *
+ * These are source assertions rather than rendered ones on purpose: the thing
+ * that broke was CSS cascade behaviour, which happy-dom does not evaluate, so
+ * a mounted-component test would have passed while the page was visibly wrong.
+ */
+// `process.cwd()` rather than import.meta.url — same approach as
+// no-full-toc-import.spec.ts, and stable under the nuxt test environment.
+const css = readFileSync(
+  join(process.cwd(), "app/assets/css/main.css"),
+  "utf8",
+);
+
+const blockFor = (selector: string) => {
+  const rules = [
+    ...css.matchAll(new RegExp(`\\${selector}\\s*\\{([^}]*)\\}`, "g")),
+  ];
+  expect(rules.length, `no rule found for ${selector}`).toBeGreaterThan(0);
+  return rules.map((m) => m[1]).join("\n");
+};
+
+const SEMANTIC_TOKENS = [
+  "--surface",
+  "--surface-raised",
+  "--surface-reading",
+  "--text-primary",
+  "--text-muted",
+  "--border",
+  "--accent-text",
+  "--warning-text",
+];
+
+describe("theme tokens", () => {
+  it.each([".dark", ".sepia"])(
+    "%s defines every semantic token that :root does",
+    (selector) => {
+      const block = blockFor(selector);
+      for (const token of SEMANTIC_TOKENS) {
+        expect(block, `${selector} is missing ${token}`).toContain(`${token}:`);
+      }
+    },
+  );
+
+  it("sepia neutralises Tailwind's colliding .sepia filter utility", () => {
+    // `classSuffix: ""` puts the bare preference value on <html>, and "sepia"
+    // is also a Tailwind utility (filter: sepia(100%)). Without this reset the
+    // whole document — navy header, images and all — is run through a sepia
+    // filter on top of the token changes.
+    expect(blockFor(".sepia")).toContain("filter: none");
+  });
+
+  it("sepia is a light theme for form controls and scrollbars", () => {
+    expect(blockFor(".sepia")).toContain("color-scheme: light");
+  });
+});


### PR DESCRIPTION
Three modes: light, sepia, dark. Sepia is warm paper for long reading.

The audit found the app already theme-agnostic where it counts: **zero `dark:` Tailwind utilities anywhere** — every component styled through the eight semantic tokens. So a third theme needed token definitions and two controls, nothing else.

## Two bugs found along the way

**1. Tailwind name collision.** `classSuffix: ""` puts the bare preference value on `<html>`, and `sepia` is also a Tailwind utility (`filter: sepia(100%)`), emitted because the literal string appears in our source. The entire document was being run through a sepia filter *on top of* the token changes — navy header turned olive-brown, every image tinted. `.sepia { filter: none }` fixes it, unlayered so it beats the utility.

**2. Switching had no transition at all.** Only the eight elements with `transition-colors` animated, so light↔dark *looked* like it faded (those change a lot) while sepia appeared to snap. Accidental, not designed. A `.theme-transition` class added to `<html>` for 240ms gives all three the same crossfade — applied per-change rather than standing on `*`, since a permanent universal transition would also animate every hover and focus state.

## Contrast, measured

| | ratio |
|---|---|
| text-primary on surface | 11.03:1 |
| text-primary on reading surface | 11.63:1 |
| text-muted on surface | 5.70:1 |
| accent-text on surface | 5.43:1 |
| warning-text on surface | 4.73:1 |

`--accent-text` needs its own value — `--color-teal-strong` is tuned for white and manages only **4.36:1** on warm paper.

## Tests

New `theme-tokens.spec.ts`: every theme defines the full token set, the filter reset is present, sepia declares `color-scheme: light`. **Source assertions on purpose** — the failure was CSS cascade, which happy-dom doesn't evaluate, so a mounted-component test would have passed while the page was visibly wrong.

474 tests across 48 files. `task check` passes.