### PR TITLE
ci: enforce full release gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,51 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  check:
+    name: Full project gate
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    env:
+      NUXT_PUBLIC_SITE_URL: https://readtes.org
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Enable Corepack
+        run: corepack enable
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Run full project gate
+        run: pnpm lint && pnpm format:check && pnpm typecheck && pnpm validate:content && pnpm test && pnpm generate
+
+      - name: Retain deployable static site
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        uses: actions/upload-artifact@v4
+        with:
+          name: readtes-static-${{ github.sha }}
+          path: .output/public
+          if-no-files-found: error
+          retention-days: 7
+          compression-level: 9

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -199,6 +199,10 @@ pnpm lint && pnpm format:check && pnpm typecheck && pnpm validate:content && pnp
 
 All of it must pass before committing.
 
+GitHub Actions runs the same gate for every pull request and push to `main`.
+Successful `main` builds retain `.output/public` as a seven-day deployment
+artifact built with `NUXT_PUBLIC_SITE_URL=https://readtes.org`.
+
 ## Instruction files
 
 - **`AGENTS.md`** (this file) — the complete standalone reference, read


### PR DESCRIPTION
## Summary
- run the complete lint, format, type, content, test, and static-generation gate on every pull request and main push
- build with the production canonical URL
- retain successful main static output as a seven-day deployment artifact

## Verification
- `task check`: lint, format, typecheck, content validation, and 494 tests passed; its generate stage was interrupted by a stale Nuxt lock
- `pnpm generate`: passed; generated 20,634 routes
- `git diff --check`: passed

Closes #56