### PR TITLE
perf: confine prerender routes to prod and split content glob maps per part

### DIFF
--- a/app/composables/useChapterContent.ts
+++ b/app/composables/useChapterContent.ts
@@ -1,8 +1,8 @@
 /**
  * Loads a chapter's layer/version content files. Only the specific files a
  * chapter actually has (per `toc.json`'s `availableVersions`) are ever
- * fetched — `import.meta.glob(..., { lazy: default })` over every content
- * file under `content/parts/**` gives each one its own dynamically-imported
+ * fetched — `import.meta.glob(..., { lazy: default })`, one per part (see
+ * `~/utils/content-loaders`), gives each file its own dynamically-imported
  * chunk, so a chapter's route bundle never pulls in the other 500+ files.
  *
  * All of a chapter's available versions (not just the currently-selected
@@ -28,10 +28,18 @@
  * the whole corpus) and `useInnerObservationContent` covers the part-scoped
  * Inner Observation reference pane separately, so nothing here needs the
  * `summary` layer any more. `loadLayerFile` is exported for that composable
- * to reuse — same per-file lazy chunk map, not a second `import.meta.glob`
- * over the same files.
+ * to reuse — same per-part lazy chunk maps, not a second set of
+ * `import.meta.glob`s over the same files.
+ *
+ * T13 scaling fix — one `import.meta.glob` over all of `content/parts/**`
+ * compiled its path→import-thunk map into a 1.4MB (135KB gz) chunk that
+ * every reader page loaded in prod, plus a 2.1MB dev module. `findLoader` is
+ * now async: it resolves only the requested chapter's *part* via
+ * `~/utils/content-loaders`'s dispatcher, so a page only ever loads its own
+ * part's map.
  */
 import type { ComputedRef } from "vue";
+import { loadPartContentModules } from "~/utils/content-loaders";
 import type {
   ChapterLayerFile,
   CommentaryItem,
@@ -43,25 +51,20 @@ import type {
 
 type AvailableVersions = TocChapter["availableVersions"];
 
-// A relative path, not the `~~` alias: `import.meta.glob` patterns are
-// statically analyzed (by Vite's own glob-import plugin) rather than run
-// through normal module resolution, so a plain relative path is the safest
-// choice — verified against the actual generated output, not assumed.
-const chapterLayerModules = import.meta.glob<{ default: unknown }>(
-  "../../content/parts/**/*.json",
-);
-
-const findLoader = (
+const findLoader = async (
   partId: string,
   chapterSlug: string,
   layer: LayerKind,
   versionId: string,
 ) => {
+  const partContentModules = await loadPartContentModules(partId);
+  if (!partContentModules) return undefined;
+
   const suffix = `/parts/${partId}/chapters/${chapterSlug}/${layer}.${versionId}.json`;
-  const key = Object.keys(chapterLayerModules).find((candidate) =>
+  const key = Object.keys(partContentModules).find((candidate) =>
     candidate.endsWith(suffix),
   );
-  return key ? chapterLayerModules[key] : undefined;
+  return key ? partContentModules[key] : undefined;
 };
 
 export const loadLayerFile = async <T extends LayerItem>(
@@ -70,7 +73,7 @@ export const loadLayerFile = async <T extends LayerItem>(
   layer: LayerKind,
   versionId: string,
 ): Promise<ChapterLayerFile<T> | null> => {
-  const loader = findLoader(partId, chapterSlug, layer, versionId);
+  const loader = await findLoader(partId, chapterSlug, layer, versionId);
   if (!loader) return null;
 
   const mod = await loader();

--- a/app/utils/content-loaders/index.ts
+++ b/app/utils/content-loaders/index.ts
@@ -1,0 +1,53 @@
+/**
+ * Dispatches to one part's `content/parts/part-NN/**` glob map
+ * (`useChapterContent`'s docblock has the measurement/rationale for why
+ * this is split per part). The map is one hand-written file per part
+ * (`part-01.ts`…`part-16.ts`) rather than a single helper parameterized by
+ * `partId`, because `import.meta.glob` patterns are statically analyzed by
+ * Vite's glob-import plugin at build time and must be literal strings — a
+ * template-literal or computed pattern simply isn't seen by the plugin.
+ *
+ * Resolved modules are cached in `resolvedModules` keyed by `partId` so
+ * loading a second chapter from the same part (the common case — a reader
+ * page's own part, then `useInnerObservationContent`'s part-scoped pane)
+ * doesn't re-run `import()` for a module already resolved.
+ */
+type PartContentModules = Record<string, () => Promise<{ default: unknown }>>;
+
+const partLoaders: Record<
+  string,
+  () => Promise<{ default: PartContentModules }>
+> = {
+  "part-01": () => import("./part-01"),
+  "part-02": () => import("./part-02"),
+  "part-03": () => import("./part-03"),
+  "part-04": () => import("./part-04"),
+  "part-05": () => import("./part-05"),
+  "part-06": () => import("./part-06"),
+  "part-07": () => import("./part-07"),
+  "part-08": () => import("./part-08"),
+  "part-09": () => import("./part-09"),
+  "part-10": () => import("./part-10"),
+  "part-11": () => import("./part-11"),
+  "part-12": () => import("./part-12"),
+  "part-13": () => import("./part-13"),
+  "part-14": () => import("./part-14"),
+  "part-15": () => import("./part-15"),
+  "part-16": () => import("./part-16"),
+};
+
+const resolvedModules = new Map<string, PartContentModules>();
+
+export const loadPartContentModules = async (
+  partId: string,
+): Promise<PartContentModules | null> => {
+  const cached = resolvedModules.get(partId);
+  if (cached) return cached;
+
+  const loader = partLoaders[partId];
+  if (!loader) return null;
+
+  const mod = (await loader()).default;
+  resolvedModules.set(partId, mod);
+  return mod;
+};

--- a/app/utils/content-loaders/part-01.ts
+++ b/app/utils/content-loaders/part-01.ts
@@ -1,0 +1,3 @@
+export default import.meta.glob<{ default: unknown }>(
+  "../../../content/parts/part-01/**/*.json",
+);

--- a/app/utils/content-loaders/part-02.ts
+++ b/app/utils/content-loaders/part-02.ts
@@ -1,0 +1,3 @@
+export default import.meta.glob<{ default: unknown }>(
+  "../../../content/parts/part-02/**/*.json",
+);

--- a/app/utils/content-loaders/part-03.ts
+++ b/app/utils/content-loaders/part-03.ts
@@ -1,0 +1,3 @@
+export default import.meta.glob<{ default: unknown }>(
+  "../../../content/parts/part-03/**/*.json",
+);

--- a/app/utils/content-loaders/part-04.ts
+++ b/app/utils/content-loaders/part-04.ts
@@ -1,0 +1,3 @@
+export default import.meta.glob<{ default: unknown }>(
+  "../../../content/parts/part-04/**/*.json",
+);

--- a/app/utils/content-loaders/part-05.ts
+++ b/app/utils/content-loaders/part-05.ts
@@ -1,0 +1,3 @@
+export default import.meta.glob<{ default: unknown }>(
+  "../../../content/parts/part-05/**/*.json",
+);

--- a/app/utils/content-loaders/part-06.ts
+++ b/app/utils/content-loaders/part-06.ts
@@ -1,0 +1,3 @@
+export default import.meta.glob<{ default: unknown }>(
+  "../../../content/parts/part-06/**/*.json",
+);

--- a/app/utils/content-loaders/part-07.ts
+++ b/app/utils/content-loaders/part-07.ts
@@ -1,0 +1,3 @@
+export default import.meta.glob<{ default: unknown }>(
+  "../../../content/parts/part-07/**/*.json",
+);

--- a/app/utils/content-loaders/part-08.ts
+++ b/app/utils/content-loaders/part-08.ts
@@ -1,0 +1,3 @@
+export default import.meta.glob<{ default: unknown }>(
+  "../../../content/parts/part-08/**/*.json",
+);

--- a/app/utils/content-loaders/part-09.ts
+++ b/app/utils/content-loaders/part-09.ts
@@ -1,0 +1,3 @@
+export default import.meta.glob<{ default: unknown }>(
+  "../../../content/parts/part-09/**/*.json",
+);

--- a/app/utils/content-loaders/part-10.ts
+++ b/app/utils/content-loaders/part-10.ts
@@ -1,0 +1,3 @@
+export default import.meta.glob<{ default: unknown }>(
+  "../../../content/parts/part-10/**/*.json",
+);

--- a/app/utils/content-loaders/part-11.ts
+++ b/app/utils/content-loaders/part-11.ts
@@ -1,0 +1,3 @@
+export default import.meta.glob<{ default: unknown }>(
+  "../../../content/parts/part-11/**/*.json",
+);

--- a/app/utils/content-loaders/part-12.ts
+++ b/app/utils/content-loaders/part-12.ts
@@ -1,0 +1,3 @@
+export default import.meta.glob<{ default: unknown }>(
+  "../../../content/parts/part-12/**/*.json",
+);

--- a/app/utils/content-loaders/part-13.ts
+++ b/app/utils/content-loaders/part-13.ts
@@ -1,0 +1,3 @@
+export default import.meta.glob<{ default: unknown }>(
+  "../../../content/parts/part-13/**/*.json",
+);

--- a/app/utils/content-loaders/part-14.ts
+++ b/app/utils/content-loaders/part-14.ts
@@ -1,0 +1,3 @@
+export default import.meta.glob<{ default: unknown }>(
+  "../../../content/parts/part-14/**/*.json",
+);

--- a/app/utils/content-loaders/part-15.ts
+++ b/app/utils/content-loaders/part-15.ts
@@ -1,0 +1,3 @@
+export default import.meta.glob<{ default: unknown }>(
+  "../../../content/parts/part-15/**/*.json",
+);

--- a/app/utils/content-loaders/part-16.ts
+++ b/app/utils/content-loaders/part-16.ts
@@ -1,0 +1,3 @@
+export default import.meta.glob<{ default: unknown }>(
+  "../../../content/parts/part-16/**/*.json",
+);

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -157,24 +157,35 @@ export default defineNuxtConfig({
     "/design-tokens": { prerender: false },
     "/he/design-tokens": { prerender: false },
   },
-  nitro: {
-    prerender: {
-      // The volumes index is reachable by crawling the homepage's link to
-      // it, but each `/volumes/[volume]` page's own link only exists for
-      // Volume 1 (the rest render disabled/"coming soon", with no <a> for
-      // the crawler to follow) — list every volume explicitly so all six
-      // contents pages still ship in the generated static site. Reader
-      // routes are listed explicitly for the same reason (see
-      // `readerPrerenderRoutes` above) — the crawler alone would miss most
-      // of the answers-terminology/answers-topics clusters.
-      routes: [
-        ...volumePrerenderRoutes,
-        ...readerPrerenderRoutes,
-        // Nitro server routes (`server/routes/`) with no `<a>` anywhere for
-        // the crawler to find — need the same explicit treatment.
-        "/sitemap.xml",
-        "/robots.txt",
-      ],
+  // T12 scaling fix — dev-only route-rules matcher bloat: Nuxt turns every
+  // explicit `nitro.prerender.routes` entry into a client route rule, and
+  // the resulting matcher (`virtual:nuxt:.nuxt/route-rules.mjs`) is an
+  // unminified 3.5MB module the dev server serves to the browser on *every*
+  // page load — dev never prerenders, so none of this is needed there.
+  // `$production` is a Nuxt env override key that only applies when
+  // `NODE_ENV=production`, which `nuxi generate`/`nuxi build` set and `nuxi
+  // dev` does not, so the 20,634-entry route list still reaches the actual
+  // static build while `pnpm dev` never pays for it.
+  $production: {
+    nitro: {
+      prerender: {
+        // The volumes index is reachable by crawling the homepage's link to
+        // it, but each `/volumes/[volume]` page's own link only exists for
+        // Volume 1 (the rest render disabled/"coming soon", with no <a> for
+        // the crawler to follow) — list every volume explicitly so all six
+        // contents pages still ship in the generated static site. Reader
+        // routes are listed explicitly for the same reason (see
+        // `readerPrerenderRoutes` above) — the crawler alone would miss most
+        // of the answers-terminology/answers-topics clusters.
+        routes: [
+          ...volumePrerenderRoutes,
+          ...readerPrerenderRoutes,
+          // Nitro server routes (`server/routes/`) with no `<a>` anywhere for
+          // the crawler to find — need the same explicit treatment.
+          "/sitemap.xml",
+          "/robots.txt",
+        ],
+      },
     },
   },
   // T11 scaling fix — content-chunk prefetch-link bloat: strip every

--- a/shared/utils/manifestPrefetch.ts
+++ b/shared/utils/manifestPrefetch.ts
@@ -47,9 +47,21 @@ export interface PrefetchableManifestEntry {
   dynamicImports?: string[];
 }
 
-/** Matches a manifest entry's key/src, or a `dynamicImports` target id. */
+/**
+ * Matches a manifest entry's key/src, or a `dynamicImports` target id.
+ *
+ * `utils/content-loaders/part-` covers the 16 per-part glob-map modules the
+ * T13 split introduced (see `useChapterContent`'s docblock): each map is a
+ * dynamic import of `useChapterContent`'s always-touched chunk, so without
+ * this the renderer prefetches all 16 maps (~1.4MB, the whole corpus's
+ * path→thunk tables) on every reader page — the same disease T11 fixed for
+ * the content chunks themselves, one level up. Each page still loads its
+ * own part's map on demand via the dispatcher's `import()`.
+ */
 export const isContentChunkId = (id: string): boolean =>
-  id.includes("content/parts/") || id.includes("content/toc.parts/");
+  id.includes("content/parts/") ||
+  id.includes("content/toc.parts/") ||
+  id.includes("utils/content-loaders/part-");
 
 /**
  * Mutates `manifest` in place: clears `prefetch`/`preload` on every

--- a/tests/unit/manifest-prefetch.spec.ts
+++ b/tests/unit/manifest-prefetch.spec.ts
@@ -18,11 +18,19 @@ describe("isContentChunkId", () => {
     expect(isContentChunkId("../content/toc.parts/part-01.json")).toBe(true);
   });
 
+  it("matches the per-part content-loader glob-map modules (T13)", () => {
+    expect(isContentChunkId("app/utils/content-loaders/part-16.ts")).toBe(true);
+    expect(isContentChunkId("utils/content-loaders/part-01.ts")).toBe(true);
+  });
+
   it("does not match app-code chunk ids", () => {
     expect(isContentChunkId("app/composables/useChapterContent.ts")).toBe(
       false,
     );
     expect(isContentChunkId("app/pages/read/[part]/[chapter].vue")).toBe(false);
+    // The dispatcher stays prefetchable — it's a tiny static map, not one of
+    // the heavy per-part glob-map modules its entries lazily import.
+    expect(isContentChunkId("app/utils/content-loaders/index.ts")).toBe(false);
   });
 
   it("does not match content/toc.volumes.json (not a per-chapter/part chunk)", () => {


### PR DESCRIPTION
Closes #60.

Measured on a cold dev chapter page before this change: 371 requests, 19.7 MB transferred, ~7.7 s to network-idle — dominated by two megabyte-scale modules. In prod, every reader page also carried a 1.4 MB script chunk.

### What changed

1. **`nitro.prerender` moved under `$production`** (T12). Nuxt turns every explicit prerender route into a client route rule; with 20,634 routes the dev server served the matcher (`virtual:nuxt:.nuxt/route-rules.mjs`) as an unminified **3.5 MB** module on every page — useless there, since dev never prerenders. `nuxi generate`/`build` still see the full list.
2. **The `content/parts/**` glob split into 16 per-part loader modules** (T13) behind a static dispatcher (`app/utils/content-loaders/`). `import.meta.glob` compiles its path→thunk map into the chunk that owns it — one glob over 10,356 files made a **1.4 MB (135 KB gz)** map every reader page loaded. A page now pulls only its own part's map. `loadLayerFile`'s contract is unchanged, so `useInnerObservationContent` needed no changes.
3. **The T11 manifest prefetch strip now also covers the 16 loader maps**, which the renderer otherwise prefetch-hinted wholesale on every reader page (the same disease T11 fixed for content chunks, one level up).

### Measured after

| Metric | Before | After |
| --- | --- | --- |
| Dev route-rules module | 3,597,787 B | 5,621 B |
| Dev `useChapterContent` module | 2.1 MB | 10 KB |
| Largest script chunk on a reader page (prod) | 1,412 KB | 84 KB |
| `rel="prefetch"` scripts on a reader page (prod) | 19 | 3 |
| Routes prerendered | 20,634 | 20,634 (unchanged) |

### Verification

`task check` fully green on this branch: lint, format:check, typecheck, validate:content, 50 spec files / 495 tests, full generate (20,634 routes), and the 4 Playwright e2e specs.