### PR TITLE
feat(deploy): Cloudflare Pages headers, docs, and env-gated Umami analytics

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,6 +179,30 @@ prerendered sitemap — before shipping:
 task docker:prod         # http://localhost:6219
 ```
 
+### Cloudflare Pages
+
+| Setting                | Value            |
+| ---------------------- | ---------------- |
+| Build command          | `pnpm generate`  |
+| Build output directory | `.output/public` |
+| `NODE_VERSION`         | `24`             |
+
+pnpm 11 is picked up automatically on Cloudflare's v2/v3 build system via
+corepack and the `packageManager` field in `package.json` — no separate pnpm
+install step needed.
+
+Environment variables (Pages project → Settings → Environment variables):
+
+| Variable                       | Required | Effect                                                                         |
+| ------------------------------ | -------- | ------------------------------------------------------------------------------ |
+| `NUXT_PUBLIC_SITE_URL`         | Yes      | Baked into every canonical link, hreflang alternate, `og:url`, and the sitemap |
+| `NUXT_PUBLIC_UMAMI_SRC`        | No       | Umami script `src` — set together with the website ID to enable analytics      |
+| `NUXT_PUBLIC_UMAMI_WEBSITE_ID` | No       | Umami `data-website-id` — leave both unset for no analytics tag                |
+
+`public/_headers` ships with the generated output and gives `/_nuxt/*` and
+`/_fonts/*` (content-hashed filenames only) immutable caching automatically —
+no Pages-side configuration needed.
+
 ---
 
 ## Working on this

--- a/app/app.vue
+++ b/app/app.vue
@@ -50,6 +50,21 @@ useHead((() => ({
   link: localeHead.value.link,
   meta: localeHead.value.meta,
 })) as unknown as Parameters<typeof useHead>[0]);
+
+// Umami analytics, env-gated. Both values are baked in at `pnpm generate`
+// time from `NUXT_PUBLIC_UMAMI_SRC`/`NUXT_PUBLIC_UMAMI_WEBSITE_ID` (see the
+// `runtimeConfig.public` comment in nuxt.config.ts for why a static site
+// only ever sets these at build time) and default to empty strings, so a
+// deploy that doesn't set them emits no script at all — local, dev and CI
+// builds stay clean. Kept as its own `useHead` call rather than folded into
+// the one above: that one is purely `useLocaleHead`'s per-route output,
+// this is static and conditional.
+const { umamiSrc, umamiWebsiteId } = useRuntimeConfig().public;
+if (umamiSrc && umamiWebsiteId) {
+  useHead({
+    script: [{ defer: true, src: umamiSrc, "data-website-id": umamiWebsiteId }],
+  });
+}
 </script>
 
 <template>

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -146,6 +146,14 @@ export default defineNuxtConfig({
       // standard public-runtime-config env override) — see the `siteUrl`
       // comment above for what derives from this.
       siteUrl,
+      // Umami analytics, both empty by default. There is no runtime config
+      // on a static site — Cloudflare Pages serves prerendered HTML, so
+      // these are only ever settable at `pnpm generate` time via
+      // `NUXT_PUBLIC_UMAMI_SRC`/`NUXT_PUBLIC_UMAMI_WEBSITE_ID` and get baked
+      // into the output. Empty means "no analytics": local/dev/CI builds
+      // stay clean, and app.vue only emits the script tag when both are set.
+      umamiSrc: "",
+      umamiWebsiteId: "",
     },
   },
   compatibilityDate: "2025-07-15",

--- a/public/_headers
+++ b/public/_headers
@@ -1,0 +1,9 @@
+# Cloudflare Pages reads this file from the deploy root (this directory is
+# copied verbatim into `.output/public` by `pnpm generate`). Both dirs below
+# contain only content-hashed filenames — Vite chunks under /_nuxt/, @nuxt/fonts
+# subsets under /_fonts/ — so a new deploy always ships new paths and it is
+# safe to cache them forever.
+/_nuxt/*
+  Cache-Control: public, max-age=31536000, immutable
+/_fonts/*
+  Cache-Control: public, max-age=31536000, immutable


### PR DESCRIPTION
Closes #62.

Prepares the repo for its hosting target: Cloudflare Pages serving the static `.output/public` from `pnpm generate`.

### What changed

- **`public/_headers`** (copied verbatim into the deploy root): immutable `Cache-Control` for `/_nuxt/*` and `/_fonts/*` — both contain only content-hashed filenames, so forever-caching is safe. The `#`-comment and splat syntax were verified against Cloudflare's Pages headers documentation.
- **Umami analytics, env-gated at build time**: `runtimeConfig.public.umamiSrc`/`umamiWebsiteId` default to empty strings; `app.vue` emits the `<script defer src data-website-id>` tag only when both are set via `NUXT_PUBLIC_UMAMI_SRC` / `NUXT_PUBLIC_UMAMI_WEBSITE_ID`. Unset (local/dev/CI) builds ship no analytics at all.
- **README**: a Cloudflare Pages subsection under Deployment — build command, output directory, `NODE_VERSION=24`, the env-var table, and a note that pnpm 11 comes from the `packageManager` field via corepack.

### Verification

- `task check` fully green: lint, format:check, typecheck, validate:content, 50 spec files / 494 tests, full generate (20,634 routes), 4 e2e specs.
- With the env vars set, the served HTML contains `<script defer src="…" data-website-id="…">`; without them, the generated output contains no Umami script tag (only the empty config keys in the serialized runtime config).
- `.output/public/_headers` present in the generated output.

**Not verifiable from here:** Cloudflare's live behavior (header application, build-system env injection) — worth a one-time check on the first real deploy.