### PR TITLE
docs(license): adopt the MIT License for repository code

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Read TES contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -219,7 +219,7 @@ task-specific reference that loads on demand. The short version:
 
 ## License
 
-The code in this repository is **not yet licensed** — no `LICENSE` file has been
-chosen, so default copyright applies. Text content is licensed per version; see
-the table above. The Bnei Baruch / KabbalahMedia translations are used with
-permission and are not covered by any repository-wide license.
+The code in this repository is licensed under the **MIT License** — see
+`LICENSE`. Text content is licensed per version; see the table above. The Bnei
+Baruch / KabbalahMedia translations are used with permission and are not
+covered by the repository-wide license.


### PR DESCRIPTION
Adds the MIT `LICENSE` file and updates the README license section to match. Text content keeps its per-version licenses; Bnei Baruch / KabbalahMedia translations remain used with permission and are not covered by the repository-wide license.

Resolves decision 3 of #55 (repository code license). Domain and hosting cut-over remain open on that issue.

Verified with `task check`: lint, format:check, typecheck, validate:content, 503 unit tests, full static generate, and the 4-test Playwright production suite all pass.