### PR TITLE
chore(deploy): set readtes.com as the production domain

### DIFF
--- a/.agents/skills/tes-seo-ssg/SKILL.md
+++ b/.agents/skills/tes-seo-ssg/SKILL.md
@@ -8,7 +8,7 @@ description: Static-generation and SEO wiring — siteUrl runtime config, canoni
 - **`runtimeConfig.public.siteUrl`** (`nuxt.config.ts`) is the single source
   of truth for every absolute URL the app emits — canonical links, hreflang
   alternates, `og:url`/`og:image`, `sitemap.xml`, `robots.txt`'s `Sitemap:`
-  line. Default `https://readtes.org` (no domain is deployed yet);
+  line. Default `https://readtes.com` (the production domain);
   override at build time with `NUXT_PUBLIC_SITE_URL` (Nuxt's standard
   public-runtime-config env convention). `i18n.baseUrl` is wired from the
   same value, so `useLocaleHead()` emits absolute alternates.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     env:
-      NUXT_PUBLIC_SITE_URL: https://readtes.org
+      NUXT_PUBLIC_SITE_URL: https://readtes.com
 
     steps:
       - name: Check out repository

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -210,7 +210,7 @@ All of it must pass before committing.
 
 GitHub Actions runs the same gate for every pull request and push to `main`.
 Successful `main` builds retain `.output/public` as a seven-day deployment
-artifact built with `NUXT_PUBLIC_SITE_URL=https://readtes.org`.
+artifact built with `NUXT_PUBLIC_SITE_URL=https://readtes.com`.
 
 ## Instruction files
 

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -71,7 +71,7 @@ const readerPrerenderRoutes = toc.volumes.flatMap((volume) =>
 // producing a double slash — this is the single normalization point, so
 // no call site needs its own `.replace(/\/$/, "")` footgun-guard.
 const siteUrl = (
-  process.env.NUXT_PUBLIC_SITE_URL ?? "https://readtes.org"
+  process.env.NUXT_PUBLIC_SITE_URL ?? "https://readtes.com"
 ).replace(/\/$/, "");
 
 // https://nuxt.com/docs/api/configuration/nuxt-config

--- a/tests/unit/sitemap.spec.ts
+++ b/tests/unit/sitemap.spec.ts
@@ -8,7 +8,7 @@ import {
   sitemapPaths,
 } from "../../shared/utils/sitemap";
 
-const SITE_URL = "https://readtes.org";
+const SITE_URL = "https://readtes.com";
 const realToc = toc as Toc;
 
 const allChapterIds = realToc.volumes.flatMap((volume) =>


### PR DESCRIPTION
The production domain is confirmed as `https://readtes.com`. Flips the baked-in `siteUrl` default in `nuxt.config.ts`, the CI artifact's `NUXT_PUBLIC_SITE_URL`, and the matching references in AGENTS.md, the tes-seo-ssg skill, and the sitemap spec constant, so no build can fall back to the old placeholder host.

Resolves decision 1 of #55; hosting (decision 2, Cloudflare Pages) and the license (decision 3, PR #66) are already settled — only the DNS/hosting cut-over remains.

Verified with `task check`: lint, format:check, typecheck, validate:content, 503 unit tests, full static generate, and the 4-test Playwright production suite all pass.