### PR TITLE
docs(deploy): document pnpm generate command and NODE_OPTIONS for Pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,6 +187,12 @@ task docker:prod         # http://localhost:6219
 | Build output directory | `dist`          |
 | `NODE_VERSION`         | `24`            |
 
+Unlike this org's server-rendered Nuxt apps (which deploy with `pnpm build`),
+this site ships as fully prerendered static output — the Pages build command
+must be `pnpm generate`. A `nuxt build` here would try to bundle the entire
+corpus into a server worker, which OOMs on Pages' build machines and would
+deploy an unverified SSR site.
+
 The output directory is `dist` (not the local `.output/public`): on Pages'
 build machines Nitro detects the Cloudflare environment and switches to its
 `cloudflare_pages` preset, which emits the static site to `dist/` and merges
@@ -198,11 +204,12 @@ install step needed.
 
 Environment variables (Pages project → Settings → Environment variables):
 
-| Variable                       | Required | Effect                                                                         |
-| ------------------------------ | -------- | ------------------------------------------------------------------------------ |
-| `NUXT_PUBLIC_SITE_URL`         | Yes      | Baked into every canonical link, hreflang alternate, `og:url`, and the sitemap |
-| `NUXT_PUBLIC_UMAMI_SRC`        | No       | Umami script `src` — set together with the website ID to enable analytics      |
-| `NUXT_PUBLIC_UMAMI_WEBSITE_ID` | No       | Umami `data-website-id` — leave both unset for no analytics tag                |
+| Variable                       | Required | Effect                                                                                                                    |
+| ------------------------------ | -------- | ------------------------------------------------------------------------------------------------------------------------- |
+| `NUXT_PUBLIC_SITE_URL`         | Yes      | Baked into every canonical link, hreflang alternate, `og:url`, and the sitemap                                            |
+| `NODE_OPTIONS`                 | Yes      | `--max-old-space-size=6144` — prerendering ~20k routes needs more than Node's default ~4 GB heap on Pages' build machines |
+| `NUXT_PUBLIC_UMAMI_SRC`        | No       | Umami script `src` — set together with the website ID to enable analytics                                                 |
+| `NUXT_PUBLIC_UMAMI_WEBSITE_ID` | No       | Umami `data-website-id` — leave both unset for no analytics tag                                                           |
 
 `public/_headers` ships with the generated output and gives `/_nuxt/*` and
 `/_fonts/*` (content-hashed filenames only) immutable caching automatically —


### PR DESCRIPTION
Documents the two Cloudflare Pages settings that tonight's failed builds traced to:

- The build command must be `pnpm generate` — unlike this org's server-rendered Nuxt apps, which deploy with `pnpm build`. A `nuxt build` here bundles the whole corpus into a server worker, which OOMs on Pages' machines and would ship an unverified SSR site. The README now states the difference and the reason.
- `NODE_OPTIONS=--max-old-space-size=6144` is required: prerendering ~20k routes needs more than Node's default ~4 GB heap (measured peak locally: ~5.4 GB).

Docs-only diff. Gate at time of commit: lint, format:check, typecheck, validate:content, and 503 unit tests passed; the generate stage was still completing and has passed unchanged three times today.