### PR TITLE
perf: shrink static artifact to ~15.6k files (under Pages' 20k cap)

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,6 +198,13 @@ build machines Nitro detects the Cloudflare environment and switches to its
 `cloudflare_pages` preset, which emits the static site to `dist/` and merges
 the committed `public/_headers` with its own generated `_headers`/`_redirects`.
 
+The generated artifact is ~15,600 files — comfortably under Cloudflare Pages'
+free-plan 20,000-file deployment cap. Two build-time measures keep it there:
+payload extraction is disabled (`experimental.payloadExtraction: false`), so
+routes ship no per-page `_payload.json`, and the per-chapter content JSON is
+bundled one chunk per chapter (`vite.build.rollupOptions.output.manualChunks`)
+instead of one chunk per JSON file.
+
 pnpm 11 is picked up automatically on Cloudflare's v2/v3 build system via
 corepack and the `packageManager` field in `package.json` — no separate pnpm
 install step needed.

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -226,6 +226,37 @@ export default defineNuxtConfig({
   },
   vite: {
     plugins: [tailwindcss()],
+    build: {
+      rollupOptions: {
+        output: {
+          // T14 scaling fix — one Rollup chunk per content JSON file (the
+          // `import.meta.glob` in `app/utils/content-loaders/part-NN.ts`
+          // emits ~10,356 of them) is what puts the artifact at 31,096
+          // files total, over Cloudflare Pages' 20,000 cap. Every JSON
+          // belonging to one chapter is always fetched together
+          // (`useChapterContent` loads all of a chapter's layer/version
+          // files up front — see its docblock), so grouping per chapter
+          // changes zero runtime behavior. `manualChunks` must return
+          // `undefined` for everything else so Vite's default chunking is
+          // untouched. Matched on the module id without query string
+          // (Rollup ids carry no query here anyway, defensive). Content
+          // JSON outside a chapter dir groups per part.
+          manualChunks(id) {
+            const cleanId = id.split("?")[0] as string;
+            const chapterMatch =
+              /content\/parts\/(part-\d+)\/chapters\/([^/]+)\//.exec(cleanId);
+            if (chapterMatch) {
+              return `content-${chapterMatch[1]}-${chapterMatch[2]}`;
+            }
+            const partMatch = /content\/parts\/(part-\d+)\//.exec(cleanId);
+            if (partMatch) {
+              return `content-${partMatch[1]}`;
+            }
+            return undefined;
+          },
+        },
+      },
+    },
     server: {
       ws: {
         port: 6218,

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -157,6 +157,14 @@ export default defineNuxtConfig({
     },
   },
   compatibilityDate: "2025-07-15",
+  // T14 scaling fix — artifact is over Cloudflare Pages' 20,000-file limit
+  // without this: `experimental.payloadExtraction` emits one `_payload.json`
+  // per prerendered route (10,314 extra files). Safe here because chapter
+  // text is deliberately NOT loaded through `useAsyncData` —
+  // `useChapterContent`/`useLocalizedParts` ride statically bundled JSON
+  // modules via direct `await import()`, so the payload carries only
+  // incidental route state, duplicated per route.
+  experimental: { payloadExtraction: false },
   // /design-tokens is a dev-only debug page kept around from the token
   // scaffolding task; never ship it (or its localized variants — @nuxtjs/i18n
   // seeds every locale's copy of every static page into the prerender crawl,

--- a/shared/utils/manifestPrefetch.ts
+++ b/shared/utils/manifestPrefetch.ts
@@ -40,10 +40,13 @@
  * entire point of splitting content into per-chapter chunks).
  */
 
-/** The subset of a `vue-bundle-renderer` manifest entry this mutates. */
+/**
+ * The subset of a `vue-bundle-renderer` manifest entry this mutates.
+ */
 export interface PrefetchableManifestEntry {
   prefetch?: boolean;
   preload?: boolean;
+  name?: string;
   dynamicImports?: string[];
 }
 
@@ -57,11 +60,29 @@ export interface PrefetchableManifestEntry {
  * path→thunk tables) on every reader page — the same disease T11 fixed for
  * the content chunks themselves, one level up. Each page still loads its
  * own part's map on demand via the dispatcher's `import()`.
+ *
+ * `content-part-` covers the T14 merged chunks (one per chapter, see the
+ * `manualChunks` function in `nuxt.config.ts`): once Rollup groups a
+ * chapter's JSON files into one chunk, the manifest entry loses the
+ * `content/parts/...` source path — its key becomes the opaque emitted file
+ * id (`_-XXXXXX.js`) and only the entry `name` keeps the `content-part-`
+ * marker (`content-part-14-answers-terminology-141`). Both the entry-key
+ * check and the per-entry `dynamicImports` filter consult the name via
+ * `entryHasContentName` so the strip keeps covering the merged chunks.
  */
 export const isContentChunkId = (id: string): boolean =>
   id.includes("content/parts/") ||
   id.includes("content/toc.parts/") ||
-  id.includes("utils/content-loaders/part-");
+  id.includes("utils/content-loaders/part-") ||
+  id.startsWith("content-part-");
+
+/**
+ * True when an entry's `name` claims it is one of the T14 merged
+ * per-chapter content chunks (their manifest keys are opaque file ids, so
+ * the name is the only reliable marker — see `isContentChunkId`).
+ */
+const entryHasContentName = (name: string | undefined): boolean =>
+  name !== undefined && isContentChunkId(name);
 
 /**
  * Mutates `manifest` in place: clears `prefetch`/`preload` on every
@@ -74,12 +95,12 @@ export const stripContentChunkPrefetchHints = <
   manifest: Record<string, T>,
 ): Record<string, T> => {
   for (const [key, entry] of Object.entries(manifest)) {
-    if (isContentChunkId(key)) {
+    if (isContentChunkId(key) || entryHasContentName(entry.name)) {
       entry.prefetch = false;
       entry.preload = false;
     }
     entry.dynamicImports = entry.dynamicImports?.filter(
-      (id) => !isContentChunkId(id),
+      (id) => !isContentChunkId(id) && !entryHasContentName(manifest[id]?.name),
     );
   }
 


### PR DESCRIPTION
Closes #73

## What changed

Two build-time measures, both in `nuxt.config.ts`:

1. **`experimental: { payloadExtraction: false }`** — removes the 10,314 per-route `_payload.json` files. Safe because chapter text never rides the payload (`useChapterContent` loads statically bundled JSON via direct `await import()`, no `useAsyncData`).
2. **`vite.build.rollupOptions.output.manualChunks`** — groups every JSON under a chapter dir into one chunk (`content-<part>-<slug>`); non-content modules fall back to Vite's default chunking. `useChapterContent` always fetches all of a chapter's files together, so runtime behavior is unchanged. Cuts `_nuxt` from 10,417 to 5,209 files.

The merged chunks lose the `content/parts/` source path in the client manifest (keys become opaque file ids), so the T11 prefetch strip (`shared/utils/manifestPrefetch.ts`) now also matches entries whose `name` starts with `content-part-`, and resolves `dynamicImports` targets by manifest id. Guardrail specs pass unmodified.

## Acceptance criteria evidence

1. **`task check` passes** — run on this branch:
   - `pnpm lint` ✓, `pnpm format:check` ✓
   - `pnpm typecheck` ✓
   - `pnpm validate:content` → `✓ Content validation passed.`
   - `pnpm test` → 51 files / 503 tests passed (incl. `manifest-prefetch.spec.ts`, `no-full-toc-import.spec.ts` unmodified)
   - `pnpm generate` → `Prerendered 10320 routes in 147.152 seconds`, no errors
   - `pnpm test:e2e` → 4 passed (Playwright chromium)

2. **File counts** (from `pnpm generate` artifact, `.output/public`):
   ```
   total files:     15,574   << 20,000  ✓
   *.html:          10,316   (5,148 chapters × 2 locales + static — unchanged)
   _payload.json:        0   ✓
   _nuxt/*.js:       5,209   (5,148 content chunks + 61 app chunks)
   other static:        45   (fonts, images, sitemap, robots, icons, _headers…)
   ```

3. **Chunk sizes** — largest `_nuxt` chunks, none ≥ 1MB:
   ```
   208K  B-EPNCYG2.js
   204K  DGtRIFC22.js
   192K  D2_SG7322.js
   176K  8IPKIBay2.js
   152K  rsvM-zs7.js
   ```

4. **Browser verification** against `npx serve .output/public` (headless Chromium, no `_payload.json` requests, no HTTP ≥400, no console errors):
   - home → `/volumes` → `/volumes/volume-1` → `/read/part-01/chapter-01` → next chapter (`chapter-02`) → locale switch `/he/read/part-01/chapter-02` — all client-side SPA navigation, no full reloads
   - `/read/part-05/chapter-01` renders with **0 prefetch links** in the raw HTML (T11 strip still effective on merged chunks)
   - Edition switch / AI badge / themes / RTL covered by the unmodified e2e specs

5. **Guardrail/e2e specs pass unmodified** — 51 unit spec files (503 tests) incl. both guardrails; 4 Playwright specs.

Not merged — left open for review.