### PR TITLE
fix: mobile pane sync, Pnimit normalization, VolumeCard clickability, styled sitemap

### DIFF
--- a/app/components/library/VolumeCard.vue
+++ b/app/components/library/VolumeCard.vue
@@ -50,9 +50,13 @@ const languageLabel = (
 </script>
 
 <template>
+  <!-- The stretched link (`after:absolute after:inset-0`, see the title
+       link below) makes the WHOLE card clickable — the volume list is the
+       page's whole purpose, so clicking anywhere on the card should open
+       its contents page, not just the title line. -->
   <div
-    class="flex overflow-hidden rounded-card border border-(--border) bg-(--surface) shadow-sm"
-    :class="{ 'opacity-60': !active }"
+    class="relative flex overflow-hidden rounded-card border border-(--border) bg-(--surface) shadow-sm transition-colors"
+    :class="{ 'hover:border-teal/60': active, 'opacity-60': !active }"
   >
     <div
       class="flex w-14 shrink-0 items-center justify-center bg-navy-primary font-display text-2xl text-surface-white sm:w-16"
@@ -67,7 +71,7 @@ const languageLabel = (
           <NuxtLink
             v-if="active"
             :to="href"
-            class="rounded-button hover:text-teal focus-visible:outline focus-visible:outline-2 focus-visible:outline-teal"
+            class="after:absolute after:inset-0 rounded-button hover:text-teal focus-visible:outline focus-visible:outline-2 focus-visible:outline-teal"
           >
             {{ title }}
           </NuxtLink>

--- a/app/components/reader/MobileSwipePanes.vue
+++ b/app/components/reader/MobileSwipePanes.vue
@@ -30,20 +30,24 @@
 // Sync is geometry-based, not `scrollLeft`-arithmetic — see
 // `~/utils/mobilePaneSync`'s doc comment for why. An `IntersectionObserver`
 // (scoped to the track as its own `root`) tracks each slide's visibility
-// ratio continuously; `scrollend` (supported by every evergreen browser
-// except Safari <17.4) is the commit point that turns those ratios into an
-// `activePane` update. Where `scrollend` isn't available, a small settle
-// timer (`createScrollSettleTimer`) polyfills the same "gesture has ended"
-// semantics instead of committing on every single ratio change — see that
-// util's doc comment for why an un-debounced fallback would fight a live
-// touch-drag and mis-commit on a multi-slide programmatic jump. Tab/pill
-// taps and cross-pane anchor jumps both just set `activePane`; the `watch`
-// below is the only thing that turns that into an actual `scrollIntoView`
-// (via `inline: "start"`, a logical value, so it's RTL-correct without a
-// `dir` check) — including on mount, so a fresh load lands snapped to
-// whichever pane is already `activePane` (source, by default) instead of
-// sitting on the DOM-first slide the browser scrolls to by default with
-// nothing else to say otherwise.
+// ratio continuously; the commit point is a short settle debounce
+// (`createScrollSettleTimer`) fed by every observer callback — NOT the
+// native `scrollend` event itself. `scrollend` fires the instant the
+// gesture stops, which is one rendering step ahead of the observer's final
+// ratio batch; resolving `activePane` from the ratios available at that
+// moment resolves the *pre-swipe* layout (stale "source: 1") and there is
+// no later scroll event to trigger a re-commit — the pill stays stuck on
+// the old tab with the track showing another slide. The settlement timer
+// instead fires once ~`settleMs` after the last ratio change, by which
+// point the final (settled) frame has been observed, so the commit always
+// resolves the post-swipe layout. Tab/pill taps and cross-pane anchor
+// jumps both just set `activePane`; the `watch` below is the only thing
+// that turns that into an actual `scrollIntoView` (via `inline: "start"`,
+// a logical value, so it's RTL-correct without a `dir` check) — including
+// on mount, so a fresh load lands snapped to whichever pane is already
+// `activePane` (source, by default) instead of sitting on the DOM-first
+// slide the browser scrolls to by default with nothing else to say
+// otherwise.
 //
 // `[contain:layout]` on the track + `min-w-0` on every slide (mobile-only —
 // both reset back to none/auto at `lg:`) are load-bearing, not decoration:
@@ -115,7 +119,6 @@ watch(
 );
 
 const ratios: PaneVisibilityRatios = reactive({});
-const usesScrollEnd = typeof window !== "undefined" && "onscrollend" in window;
 
 let observer: IntersectionObserver | null = null;
 
@@ -124,11 +127,14 @@ const commitActivePane = () => {
   if (next !== activePane.value) setActivePane(next);
 };
 
-const onScrollEnd = () => commitActivePane();
+const onScrollEnd = () => settleTimer.ping();
 
-// Only actually used on the no-`scrollend` fallback path (see `onIntersect`)
-// — harmless to always create, since `ping()` is simply never called when
-// `usesScrollEnd` is true.
+// The settle timer is the one commit path for every browser (see the module
+// doc above for why `scrollend` itself can't be the commit point). `ping()`
+// is called on every observer callback — whenever the settled scroll
+// position differs from the current one, the timer fires `commitActivePane`
+// once the ratios have stabilised, and `settleMs` of continued movement
+// keeps pushing the commit out until the gesture truly stops.
 const settleTimer = createScrollSettleTimer(commitActivePane);
 
 const onIntersect: IntersectionObserverCallback = (entries) => {
@@ -138,14 +144,13 @@ const onIntersect: IntersectionObserverCallback = (entries) => {
     if (!pane) continue;
     ratios[pane] = entry.intersectionRatio;
   }
-  // Safari <17.4 fallback: no native `scrollend` to key off, so every
-  // observer callback (re)starts the settle timer instead of committing
-  // immediately — see the module doc above and `createScrollSettleTimer`.
-  if (!usesScrollEnd) settleTimer.ping();
+  settleTimer.ping();
 };
 
 const attachTrackListeners = () => {
   if (typeof IntersectionObserver === "undefined" || !trackRef.value) return;
+
+  detachTrackListeners();
 
   observer = new IntersectionObserver(onIntersect, {
     root: trackRef.value,
@@ -156,9 +161,7 @@ const attachTrackListeners = () => {
     if (el) observer.observe(el);
   }
 
-  if (usesScrollEnd) {
-    trackRef.value.addEventListener("scrollend", onScrollEnd);
-  }
+  trackRef.value.addEventListener("scrollend", onScrollEnd);
 };
 
 const detachTrackListeners = () => {
@@ -168,14 +171,27 @@ const detachTrackListeners = () => {
   settleTimer.cancel();
 };
 
-watch(
-  isNarrowViewport,
-  (narrow) => {
-    detachTrackListeners();
-    if (narrow) attachTrackListeners();
-  },
-  { immediate: true, flush: "post" },
-);
+// Not `immediate` + `flush: "post"`: it would run during the module's first
+// `setup`, a full render step before `trackRef` is bound, and
+// `attachTrackListeners`' `!trackRef.value` guard would silently no-op —
+// the observer (and with it, the entire swipe-to-pane sync) would never
+// attach. `onMounted` below is the guaranteed-`trackRef`-ready first
+// attach point; this watcher handles viewport changeovers after that.
+watch(isNarrowViewport, (narrow) => {
+  detachTrackListeners();
+  if (narrow) attachTrackListeners();
+});
+
+onMounted(() => {
+  if (isNarrowViewport.value) attachTrackListeners();
+
+  // Snaps instantly (no motion to reduce, there's no prior on-screen
+  // state to visibly transition away from) to whichever slide is already
+  // `activePane` (source, by default) instead of leaving the browser's own
+  // "first slide in DOM order" scroll position silently mismatched against
+  // it.
+  scrollToPane(activePane.value, true);
+});
 
 onUnmounted(detachTrackListeners);
 

--- a/app/components/reader/ReaderPane.vue
+++ b/app/components/reader/ReaderPane.vue
@@ -49,7 +49,7 @@ const containerRef = provideReaderPaneContainer();
 
     <div
       ref="containerRef"
-      class="min-h-0 flex-1 overflow-y-auto px-4 py-4"
+      class="min-h-0 flex-1 overflow-y-auto px-4 pt-4 pb-24 lg:pb-4"
       :dir="meta?.direction ?? 'ltr'"
       :lang="meta?.language"
     >

--- a/app/utils/mobilePaneSync.ts
+++ b/app/utils/mobilePaneSync.ts
@@ -55,15 +55,22 @@ export const resolveActivePane = (
 };
 
 /**
- * Minimal `scrollend` polyfill for the IntersectionObserver-only fallback
- * path (Safari <17.4 — see `MobileSwipePanes`): without this, every ratio
- * change from `IntersectionObserver` would commit `activePane` immediately,
- * which fights a live touch-drag (each in-between ratio update "wins"
- * briefly) and can mis-commit on a multi-slide programmatic jump (the
- * observer sees the skipped middle slide's ratio pass through on the way to
- * the real target). `ping()` on every observer callback; `onSettle` fires
- * once `settleMs` has passed with no further `ping()` — the same
+ * Minimal `scrollend` polyfill used as the single commit debounce for pane
+ * switching (see `MobileSwipePanes`): it fires `onSettle` once `settleMs`
+ * has passed with no further `ping()`, giving the same
  * gesture-has-ended semantics the native `scrollend` event gives for free.
+ *
+ * The native `scrollend` event itself cannot be the commit button: it fires
+ * the instant the gesture stops, one rendering step ahead of the final
+ * `IntersectionObserver` ratio batch, so resolving `activePane` at that
+ * moment would reuse the pre-swipe ratios and leave the pill stuck on the
+ * stale tab (there is no later scroll event to re-commit). Debouncing the
+ * observer callbacks instead means the commit always happens after the
+ * settled frame's ratios have been observed.
+ *
+ * `ping()` on every observer callback; also called from the `scrollend`
+ * listener (an extra early ping, harmless — it just restarts the same
+ * countdown).
  *
  * `hasSettled` is the pure piece (the threshold check itself); the timer
  * wrapper around it is a thin, conventional debounce — unit-tested with

--- a/content/toc.json
+++ b/content/toc.json
@@ -81,7 +81,7 @@
               "kind": "inner-observation",
               "number": 1,
               "title": {
-                "en": "Histaklut Penimit 1",
+                "en": "Histaklut Pnimit 1",
                 "he": "הסתכלות פנימית א׳"
               },
               "availableLayers": [
@@ -101,7 +101,7 @@
               "kind": "inner-observation",
               "number": 2,
               "title": {
-                "en": "Histaklut Penimit 2",
+                "en": "Histaklut Pnimit 2",
                 "he": "הסתכלות פנימית ב׳"
               },
               "availableLayers": [
@@ -121,7 +121,7 @@
               "kind": "inner-observation",
               "number": 3,
               "title": {
-                "en": "Histaklut Penimit 3",
+                "en": "Histaklut Pnimit 3",
                 "he": "הסתכלות פנימית ג׳"
               },
               "availableLayers": [
@@ -141,7 +141,7 @@
               "kind": "inner-observation",
               "number": 4,
               "title": {
-                "en": "Histaklut Penimit 4",
+                "en": "Histaklut Pnimit 4",
                 "he": "הסתכלות פנימית ד׳"
               },
               "availableLayers": [
@@ -161,7 +161,7 @@
               "kind": "inner-observation",
               "number": 5,
               "title": {
-                "en": "Histaklut Penimit 5",
+                "en": "Histaklut Pnimit 5",
                 "he": "הסתכלות פנימית ה׳"
               },
               "availableLayers": [
@@ -181,7 +181,7 @@
               "kind": "inner-observation",
               "number": 6,
               "title": {
-                "en": "Histaklut Penimit 6",
+                "en": "Histaklut Pnimit 6",
                 "he": "הסתכלות פנימית ו׳"
               },
               "availableLayers": [
@@ -201,7 +201,7 @@
               "kind": "inner-observation",
               "number": 7,
               "title": {
-                "en": "Histaklut Penimit 7",
+                "en": "Histaklut Pnimit 7",
                 "he": "הסתכלות פנימית ז׳"
               },
               "availableLayers": [
@@ -221,7 +221,7 @@
               "kind": "inner-observation",
               "number": 8,
               "title": {
-                "en": "Histaklut Penimit 8",
+                "en": "Histaklut Pnimit 8",
                 "he": "הסתכלות פנימית ח׳"
               },
               "availableLayers": [
@@ -241,7 +241,7 @@
               "kind": "inner-observation",
               "number": 9,
               "title": {
-                "en": "Histaklut Penimit 9",
+                "en": "Histaklut Pnimit 9",
                 "he": "הסתכלות פנימית ט׳"
               },
               "availableLayers": [
@@ -261,7 +261,7 @@
               "kind": "inner-observation",
               "number": 10,
               "title": {
-                "en": "Histaklut Penimit 10",
+                "en": "Histaklut Pnimit 10",
                 "he": "הסתכלות פנימית י׳"
               },
               "availableLayers": [
@@ -2480,7 +2480,7 @@
               "kind": "inner-observation",
               "number": 1,
               "title": {
-                "en": "Histaklut Penimit 1",
+                "en": "Histaklut Pnimit 1",
                 "he": "הסתכלות פנימית א׳"
               },
               "availableLayers": [
@@ -2500,7 +2500,7 @@
               "kind": "inner-observation",
               "number": 2,
               "title": {
-                "en": "Histaklut Penimit 2",
+                "en": "Histaklut Pnimit 2",
                 "he": "הסתכלות פנימית ב׳"
               },
               "availableLayers": [
@@ -2520,7 +2520,7 @@
               "kind": "inner-observation",
               "number": 3,
               "title": {
-                "en": "Histaklut Penimit 3",
+                "en": "Histaklut Pnimit 3",
                 "he": "הסתכלות פנימית ג׳"
               },
               "availableLayers": [
@@ -2540,7 +2540,7 @@
               "kind": "inner-observation",
               "number": 4,
               "title": {
-                "en": "Histaklut Penimit 4",
+                "en": "Histaklut Pnimit 4",
                 "he": "הסתכלות פנימית ד׳"
               },
               "availableLayers": [
@@ -2560,7 +2560,7 @@
               "kind": "inner-observation",
               "number": 5,
               "title": {
-                "en": "Histaklut Penimit 5",
+                "en": "Histaklut Pnimit 5",
                 "he": "הסתכלות פנימית ה׳"
               },
               "availableLayers": [
@@ -2580,7 +2580,7 @@
               "kind": "inner-observation",
               "number": 6,
               "title": {
-                "en": "Histaklut Penimit 6",
+                "en": "Histaklut Pnimit 6",
                 "he": "הסתכלות פנימית ו׳"
               },
               "availableLayers": [
@@ -2600,7 +2600,7 @@
               "kind": "inner-observation",
               "number": 7,
               "title": {
-                "en": "Histaklut Penimit 7",
+                "en": "Histaklut Pnimit 7",
                 "he": "הסתכלות פנימית ז׳"
               },
               "availableLayers": [
@@ -2620,7 +2620,7 @@
               "kind": "inner-observation",
               "number": 8,
               "title": {
-                "en": "Histaklut Penimit 8",
+                "en": "Histaklut Pnimit 8",
                 "he": "הסתכלות פנימית ח׳"
               },
               "availableLayers": [
@@ -2640,7 +2640,7 @@
               "kind": "inner-observation",
               "number": 9,
               "title": {
-                "en": "Histaklut Penimit 9",
+                "en": "Histaklut Pnimit 9",
                 "he": "הסתכלות פנימית ט׳"
               },
               "availableLayers": [
@@ -2660,7 +2660,7 @@
               "kind": "inner-observation",
               "number": 10,
               "title": {
-                "en": "Histaklut Penimit 10",
+                "en": "Histaklut Pnimit 10",
                 "he": "הסתכלות פנימית י׳"
               },
               "availableLayers": [
@@ -6531,7 +6531,7 @@
               "kind": "inner-observation",
               "number": 1,
               "title": {
-                "en": "Histaklut Penimit 1",
+                "en": "Histaklut Pnimit 1",
                 "he": "הסתכלות פנימית א׳"
               },
               "availableLayers": [
@@ -6551,7 +6551,7 @@
               "kind": "inner-observation",
               "number": 2,
               "title": {
-                "en": "Histaklut Penimit 2",
+                "en": "Histaklut Pnimit 2",
                 "he": "הסתכלות פנימית ב׳"
               },
               "availableLayers": [
@@ -6571,7 +6571,7 @@
               "kind": "inner-observation",
               "number": 3,
               "title": {
-                "en": "Histaklut Penimit 3",
+                "en": "Histaklut Pnimit 3",
                 "he": "הסתכלות פנימית ג׳"
               },
               "availableLayers": [
@@ -6591,7 +6591,7 @@
               "kind": "inner-observation",
               "number": 4,
               "title": {
-                "en": "Histaklut Penimit 4",
+                "en": "Histaklut Pnimit 4",
                 "he": "הסתכלות פנימית ד׳"
               },
               "availableLayers": [
@@ -6611,7 +6611,7 @@
               "kind": "inner-observation",
               "number": 5,
               "title": {
-                "en": "Histaklut Penimit 5",
+                "en": "Histaklut Pnimit 5",
                 "he": "הסתכלות פנימית ה׳"
               },
               "availableLayers": [
@@ -6631,7 +6631,7 @@
               "kind": "inner-observation",
               "number": 6,
               "title": {
-                "en": "Histaklut Penimit 6",
+                "en": "Histaklut Pnimit 6",
                 "he": "הסתכלות פנימית ו׳"
               },
               "availableLayers": [
@@ -6651,7 +6651,7 @@
               "kind": "inner-observation",
               "number": 7,
               "title": {
-                "en": "Histaklut Penimit 7",
+                "en": "Histaklut Pnimit 7",
                 "he": "הסתכלות פנימית ז׳"
               },
               "availableLayers": [
@@ -6671,7 +6671,7 @@
               "kind": "inner-observation",
               "number": 8,
               "title": {
-                "en": "Histaklut Penimit 8",
+                "en": "Histaklut Pnimit 8",
                 "he": "הסתכלות פנימית ח׳"
               },
               "availableLayers": [
@@ -6691,7 +6691,7 @@
               "kind": "inner-observation",
               "number": 9,
               "title": {
-                "en": "Histaklut Penimit 9",
+                "en": "Histaklut Pnimit 9",
                 "he": "הסתכלות פנימית ט׳"
               },
               "availableLayers": [
@@ -6711,7 +6711,7 @@
               "kind": "inner-observation",
               "number": 10,
               "title": {
-                "en": "Histaklut Penimit 10",
+                "en": "Histaklut Pnimit 10",
                 "he": "הסתכלות פנימית י׳"
               },
               "availableLayers": [
@@ -6731,7 +6731,7 @@
               "kind": "inner-observation",
               "number": 11,
               "title": {
-                "en": "Histaklut Penimit 11",
+                "en": "Histaklut Pnimit 11",
                 "he": "הסתכלות פנימית י״א"
               },
               "availableLayers": [
@@ -6751,7 +6751,7 @@
               "kind": "inner-observation",
               "number": 12,
               "title": {
-                "en": "Histaklut Penimit 12",
+                "en": "Histaklut Pnimit 12",
                 "he": "הסתכלות פנימית י״ב"
               },
               "availableLayers": [
@@ -6771,7 +6771,7 @@
               "kind": "inner-observation",
               "number": 13,
               "title": {
-                "en": "Histaklut Penimit 13",
+                "en": "Histaklut Pnimit 13",
                 "he": "הסתכלות פנימית י״ג"
               },
               "availableLayers": [
@@ -6791,7 +6791,7 @@
               "kind": "inner-observation",
               "number": 14,
               "title": {
-                "en": "Histaklut Penimit 14",
+                "en": "Histaklut Pnimit 14",
                 "he": "הסתכלות פנימית י״ד"
               },
               "availableLayers": [
@@ -6811,7 +6811,7 @@
               "kind": "inner-observation",
               "number": 15,
               "title": {
-                "en": "Histaklut Penimit 15",
+                "en": "Histaklut Pnimit 15",
                 "he": "הסתכלות פנימית ט״ו"
               },
               "availableLayers": [
@@ -11756,7 +11756,7 @@
               "kind": "inner-observation",
               "number": 1,
               "title": {
-                "en": "Histaklut Penimit 1",
+                "en": "Histaklut Pnimit 1",
                 "he": "הסתכלות פנימית א׳"
               },
               "availableLayers": [
@@ -11776,7 +11776,7 @@
               "kind": "inner-observation",
               "number": 2,
               "title": {
-                "en": "Histaklut Penimit 2",
+                "en": "Histaklut Pnimit 2",
                 "he": "הסתכלות פנימית ב׳"
               },
               "availableLayers": [
@@ -11796,7 +11796,7 @@
               "kind": "inner-observation",
               "number": 3,
               "title": {
-                "en": "Histaklut Penimit 3",
+                "en": "Histaklut Pnimit 3",
                 "he": "הסתכלות פנימית ג׳"
               },
               "availableLayers": [
@@ -11816,7 +11816,7 @@
               "kind": "inner-observation",
               "number": 4,
               "title": {
-                "en": "Histaklut Penimit 4",
+                "en": "Histaklut Pnimit 4",
                 "he": "הסתכלות פנימית ד׳"
               },
               "availableLayers": [
@@ -11836,7 +11836,7 @@
               "kind": "inner-observation",
               "number": 5,
               "title": {
-                "en": "Histaklut Penimit 5",
+                "en": "Histaklut Pnimit 5",
                 "he": "הסתכלות פנימית ה׳"
               },
               "availableLayers": [
@@ -11856,7 +11856,7 @@
               "kind": "inner-observation",
               "number": 6,
               "title": {
-                "en": "Histaklut Penimit 6",
+                "en": "Histaklut Pnimit 6",
                 "he": "הסתכלות פנימית ו׳"
               },
               "availableLayers": [
@@ -20798,7 +20798,7 @@
               "kind": "inner-observation",
               "number": 1,
               "title": {
-                "en": "Histaklut Penimit 1",
+                "en": "Histaklut Pnimit 1",
                 "he": "הסתכלות פנימית א׳"
               },
               "availableLayers": [
@@ -20818,7 +20818,7 @@
               "kind": "inner-observation",
               "number": 2,
               "title": {
-                "en": "Histaklut Penimit 2",
+                "en": "Histaklut Pnimit 2",
                 "he": "הסתכלות פנימית ב׳"
               },
               "availableLayers": [
@@ -25099,7 +25099,7 @@
               "kind": "inner-observation",
               "number": 1,
               "title": {
-                "en": "Histaklut Penimit 1",
+                "en": "Histaklut Pnimit 1",
                 "he": "הסתכלות פנימית א׳"
               },
               "availableLayers": [
@@ -25119,7 +25119,7 @@
               "kind": "inner-observation",
               "number": 2,
               "title": {
-                "en": "Histaklut Penimit 2",
+                "en": "Histaklut Pnimit 2",
                 "he": "הסתכלות פנימית ב׳"
               },
               "availableLayers": [
@@ -30150,7 +30150,7 @@
               "kind": "inner-observation",
               "number": 1,
               "title": {
-                "en": "Histaklut Penimit",
+                "en": "Histaklut Pnimit",
                 "he": "הסתכלות פנימית"
               },
               "availableLayers": [
@@ -35371,7 +35371,7 @@
               "kind": "inner-observation",
               "number": 1,
               "title": {
-                "en": "Histaklut Penimit",
+                "en": "Histaklut Pnimit",
                 "he": "הסתכלות פנימית"
               },
               "availableLayers": [
@@ -42282,7 +42282,7 @@
               "kind": "inner-observation",
               "number": 1,
               "title": {
-                "en": "Histaklut Penimit",
+                "en": "Histaklut Pnimit",
                 "he": "הסתכלות פנימית"
               },
               "availableLayers": [
@@ -58794,7 +58794,7 @@
               "kind": "inner-observation",
               "number": 1,
               "title": {
-                "en": "Histaklut Penimit",
+                "en": "Histaklut Pnimit",
                 "he": "הסתכלות פנימית"
               },
               "availableLayers": [
@@ -68445,7 +68445,7 @@
               "kind": "inner-observation",
               "number": 1,
               "title": {
-                "en": "Histaklut Penimit",
+                "en": "Histaklut Pnimit",
                 "he": "הסתכלות פנימית"
               },
               "availableLayers": [

--- a/content/toc.parts/part-01.json
+++ b/content/toc.parts/part-01.json
@@ -80,7 +80,7 @@
       "kind": "inner-observation",
       "number": 1,
       "title": {
-        "en": "Histaklut Penimit 1",
+        "en": "Histaklut Pnimit 1",
         "he": "הסתכלות פנימית א׳"
       },
       "availableLayers": [
@@ -100,7 +100,7 @@
       "kind": "inner-observation",
       "number": 2,
       "title": {
-        "en": "Histaklut Penimit 2",
+        "en": "Histaklut Pnimit 2",
         "he": "הסתכלות פנימית ב׳"
       },
       "availableLayers": [
@@ -120,7 +120,7 @@
       "kind": "inner-observation",
       "number": 3,
       "title": {
-        "en": "Histaklut Penimit 3",
+        "en": "Histaklut Pnimit 3",
         "he": "הסתכלות פנימית ג׳"
       },
       "availableLayers": [
@@ -140,7 +140,7 @@
       "kind": "inner-observation",
       "number": 4,
       "title": {
-        "en": "Histaklut Penimit 4",
+        "en": "Histaklut Pnimit 4",
         "he": "הסתכלות פנימית ד׳"
       },
       "availableLayers": [
@@ -160,7 +160,7 @@
       "kind": "inner-observation",
       "number": 5,
       "title": {
-        "en": "Histaklut Penimit 5",
+        "en": "Histaklut Pnimit 5",
         "he": "הסתכלות פנימית ה׳"
       },
       "availableLayers": [
@@ -180,7 +180,7 @@
       "kind": "inner-observation",
       "number": 6,
       "title": {
-        "en": "Histaklut Penimit 6",
+        "en": "Histaklut Pnimit 6",
         "he": "הסתכלות פנימית ו׳"
       },
       "availableLayers": [
@@ -200,7 +200,7 @@
       "kind": "inner-observation",
       "number": 7,
       "title": {
-        "en": "Histaklut Penimit 7",
+        "en": "Histaklut Pnimit 7",
         "he": "הסתכלות פנימית ז׳"
       },
       "availableLayers": [
@@ -220,7 +220,7 @@
       "kind": "inner-observation",
       "number": 8,
       "title": {
-        "en": "Histaklut Penimit 8",
+        "en": "Histaklut Pnimit 8",
         "he": "הסתכלות פנימית ח׳"
       },
       "availableLayers": [
@@ -240,7 +240,7 @@
       "kind": "inner-observation",
       "number": 9,
       "title": {
-        "en": "Histaklut Penimit 9",
+        "en": "Histaklut Pnimit 9",
         "he": "הסתכלות פנימית ט׳"
       },
       "availableLayers": [
@@ -260,7 +260,7 @@
       "kind": "inner-observation",
       "number": 10,
       "title": {
-        "en": "Histaklut Penimit 10",
+        "en": "Histaklut Pnimit 10",
         "he": "הסתכלות פנימית י׳"
       },
       "availableLayers": [

--- a/content/toc.parts/part-02.json
+++ b/content/toc.parts/part-02.json
@@ -69,7 +69,7 @@
       "kind": "inner-observation",
       "number": 1,
       "title": {
-        "en": "Histaklut Penimit 1",
+        "en": "Histaklut Pnimit 1",
         "he": "הסתכלות פנימית א׳"
       },
       "availableLayers": [
@@ -89,7 +89,7 @@
       "kind": "inner-observation",
       "number": 2,
       "title": {
-        "en": "Histaklut Penimit 2",
+        "en": "Histaklut Pnimit 2",
         "he": "הסתכלות פנימית ב׳"
       },
       "availableLayers": [
@@ -109,7 +109,7 @@
       "kind": "inner-observation",
       "number": 3,
       "title": {
-        "en": "Histaklut Penimit 3",
+        "en": "Histaklut Pnimit 3",
         "he": "הסתכלות פנימית ג׳"
       },
       "availableLayers": [
@@ -129,7 +129,7 @@
       "kind": "inner-observation",
       "number": 4,
       "title": {
-        "en": "Histaklut Penimit 4",
+        "en": "Histaklut Pnimit 4",
         "he": "הסתכלות פנימית ד׳"
       },
       "availableLayers": [
@@ -149,7 +149,7 @@
       "kind": "inner-observation",
       "number": 5,
       "title": {
-        "en": "Histaklut Penimit 5",
+        "en": "Histaklut Pnimit 5",
         "he": "הסתכלות פנימית ה׳"
       },
       "availableLayers": [
@@ -169,7 +169,7 @@
       "kind": "inner-observation",
       "number": 6,
       "title": {
-        "en": "Histaklut Penimit 6",
+        "en": "Histaklut Pnimit 6",
         "he": "הסתכלות פנימית ו׳"
       },
       "availableLayers": [
@@ -189,7 +189,7 @@
       "kind": "inner-observation",
       "number": 7,
       "title": {
-        "en": "Histaklut Penimit 7",
+        "en": "Histaklut Pnimit 7",
         "he": "הסתכלות פנימית ז׳"
       },
       "availableLayers": [
@@ -209,7 +209,7 @@
       "kind": "inner-observation",
       "number": 8,
       "title": {
-        "en": "Histaklut Penimit 8",
+        "en": "Histaklut Pnimit 8",
         "he": "הסתכלות פנימית ח׳"
       },
       "availableLayers": [
@@ -229,7 +229,7 @@
       "kind": "inner-observation",
       "number": 9,
       "title": {
-        "en": "Histaklut Penimit 9",
+        "en": "Histaklut Pnimit 9",
         "he": "הסתכלות פנימית ט׳"
       },
       "availableLayers": [
@@ -249,7 +249,7 @@
       "kind": "inner-observation",
       "number": 10,
       "title": {
-        "en": "Histaklut Penimit 10",
+        "en": "Histaklut Pnimit 10",
         "he": "הסתכלות פנימית י׳"
       },
       "availableLayers": [

--- a/content/toc.parts/part-03.json
+++ b/content/toc.parts/part-03.json
@@ -381,7 +381,7 @@
       "kind": "inner-observation",
       "number": 1,
       "title": {
-        "en": "Histaklut Penimit 1",
+        "en": "Histaklut Pnimit 1",
         "he": "הסתכלות פנימית א׳"
       },
       "availableLayers": [
@@ -401,7 +401,7 @@
       "kind": "inner-observation",
       "number": 2,
       "title": {
-        "en": "Histaklut Penimit 2",
+        "en": "Histaklut Pnimit 2",
         "he": "הסתכלות פנימית ב׳"
       },
       "availableLayers": [
@@ -421,7 +421,7 @@
       "kind": "inner-observation",
       "number": 3,
       "title": {
-        "en": "Histaklut Penimit 3",
+        "en": "Histaklut Pnimit 3",
         "he": "הסתכלות פנימית ג׳"
       },
       "availableLayers": [
@@ -441,7 +441,7 @@
       "kind": "inner-observation",
       "number": 4,
       "title": {
-        "en": "Histaklut Penimit 4",
+        "en": "Histaklut Pnimit 4",
         "he": "הסתכלות פנימית ד׳"
       },
       "availableLayers": [
@@ -461,7 +461,7 @@
       "kind": "inner-observation",
       "number": 5,
       "title": {
-        "en": "Histaklut Penimit 5",
+        "en": "Histaklut Pnimit 5",
         "he": "הסתכלות פנימית ה׳"
       },
       "availableLayers": [
@@ -481,7 +481,7 @@
       "kind": "inner-observation",
       "number": 6,
       "title": {
-        "en": "Histaklut Penimit 6",
+        "en": "Histaklut Pnimit 6",
         "he": "הסתכלות פנימית ו׳"
       },
       "availableLayers": [
@@ -501,7 +501,7 @@
       "kind": "inner-observation",
       "number": 7,
       "title": {
-        "en": "Histaklut Penimit 7",
+        "en": "Histaklut Pnimit 7",
         "he": "הסתכלות פנימית ז׳"
       },
       "availableLayers": [
@@ -521,7 +521,7 @@
       "kind": "inner-observation",
       "number": 8,
       "title": {
-        "en": "Histaklut Penimit 8",
+        "en": "Histaklut Pnimit 8",
         "he": "הסתכלות פנימית ח׳"
       },
       "availableLayers": [
@@ -541,7 +541,7 @@
       "kind": "inner-observation",
       "number": 9,
       "title": {
-        "en": "Histaklut Penimit 9",
+        "en": "Histaklut Pnimit 9",
         "he": "הסתכלות פנימית ט׳"
       },
       "availableLayers": [
@@ -561,7 +561,7 @@
       "kind": "inner-observation",
       "number": 10,
       "title": {
-        "en": "Histaklut Penimit 10",
+        "en": "Histaklut Pnimit 10",
         "he": "הסתכלות פנימית י׳"
       },
       "availableLayers": [
@@ -581,7 +581,7 @@
       "kind": "inner-observation",
       "number": 11,
       "title": {
-        "en": "Histaklut Penimit 11",
+        "en": "Histaklut Pnimit 11",
         "he": "הסתכלות פנימית י״א"
       },
       "availableLayers": [
@@ -601,7 +601,7 @@
       "kind": "inner-observation",
       "number": 12,
       "title": {
-        "en": "Histaklut Penimit 12",
+        "en": "Histaklut Pnimit 12",
         "he": "הסתכלות פנימית י״ב"
       },
       "availableLayers": [
@@ -621,7 +621,7 @@
       "kind": "inner-observation",
       "number": 13,
       "title": {
-        "en": "Histaklut Penimit 13",
+        "en": "Histaklut Pnimit 13",
         "he": "הסתכלות פנימית י״ג"
       },
       "availableLayers": [
@@ -641,7 +641,7 @@
       "kind": "inner-observation",
       "number": 14,
       "title": {
-        "en": "Histaklut Penimit 14",
+        "en": "Histaklut Pnimit 14",
         "he": "הסתכלות פנימית י״ד"
       },
       "availableLayers": [
@@ -661,7 +661,7 @@
       "kind": "inner-observation",
       "number": 15,
       "title": {
-        "en": "Histaklut Penimit 15",
+        "en": "Histaklut Pnimit 15",
         "he": "הסתכלות פנימית ט״ו"
       },
       "availableLayers": [

--- a/content/toc.parts/part-04.json
+++ b/content/toc.parts/part-04.json
@@ -165,7 +165,7 @@
       "kind": "inner-observation",
       "number": 1,
       "title": {
-        "en": "Histaklut Penimit 1",
+        "en": "Histaklut Pnimit 1",
         "he": "הסתכלות פנימית א׳"
       },
       "availableLayers": [
@@ -185,7 +185,7 @@
       "kind": "inner-observation",
       "number": 2,
       "title": {
-        "en": "Histaklut Penimit 2",
+        "en": "Histaklut Pnimit 2",
         "he": "הסתכלות פנימית ב׳"
       },
       "availableLayers": [
@@ -205,7 +205,7 @@
       "kind": "inner-observation",
       "number": 3,
       "title": {
-        "en": "Histaklut Penimit 3",
+        "en": "Histaklut Pnimit 3",
         "he": "הסתכלות פנימית ג׳"
       },
       "availableLayers": [
@@ -225,7 +225,7 @@
       "kind": "inner-observation",
       "number": 4,
       "title": {
-        "en": "Histaklut Penimit 4",
+        "en": "Histaklut Pnimit 4",
         "he": "הסתכלות פנימית ד׳"
       },
       "availableLayers": [
@@ -245,7 +245,7 @@
       "kind": "inner-observation",
       "number": 5,
       "title": {
-        "en": "Histaklut Penimit 5",
+        "en": "Histaklut Pnimit 5",
         "he": "הסתכלות פנימית ה׳"
       },
       "availableLayers": [
@@ -265,7 +265,7 @@
       "kind": "inner-observation",
       "number": 6,
       "title": {
-        "en": "Histaklut Penimit 6",
+        "en": "Histaklut Pnimit 6",
         "he": "הסתכלות פנימית ו׳"
       },
       "availableLayers": [

--- a/content/toc.parts/part-06.json
+++ b/content/toc.parts/part-06.json
@@ -1101,7 +1101,7 @@
       "kind": "inner-observation",
       "number": 1,
       "title": {
-        "en": "Histaklut Penimit 1",
+        "en": "Histaklut Pnimit 1",
         "he": "הסתכלות פנימית א׳"
       },
       "availableLayers": [
@@ -1121,7 +1121,7 @@
       "kind": "inner-observation",
       "number": 2,
       "title": {
-        "en": "Histaklut Penimit 2",
+        "en": "Histaklut Pnimit 2",
         "he": "הסתכלות פנימית ב׳"
       },
       "availableLayers": [

--- a/content/toc.parts/part-07.json
+++ b/content/toc.parts/part-07.json
@@ -1481,7 +1481,7 @@
       "kind": "inner-observation",
       "number": 1,
       "title": {
-        "en": "Histaklut Penimit 1",
+        "en": "Histaklut Pnimit 1",
         "he": "הסתכלות פנימית א׳"
       },
       "availableLayers": [
@@ -1501,7 +1501,7 @@
       "kind": "inner-observation",
       "number": 2,
       "title": {
-        "en": "Histaklut Penimit 2",
+        "en": "Histaklut Pnimit 2",
         "he": "הסתכלות פנימית ב׳"
       },
       "availableLayers": [

--- a/content/toc.parts/part-08.json
+++ b/content/toc.parts/part-08.json
@@ -1901,7 +1901,7 @@
       "kind": "inner-observation",
       "number": 1,
       "title": {
-        "en": "Histaklut Penimit",
+        "en": "Histaklut Pnimit",
         "he": "הסתכלות פנימית"
       },
       "availableLayers": [

--- a/content/toc.parts/part-09.json
+++ b/content/toc.parts/part-09.json
@@ -2201,7 +2201,7 @@
       "kind": "inner-observation",
       "number": 1,
       "title": {
-        "en": "Histaklut Penimit",
+        "en": "Histaklut Pnimit",
         "he": "הסתכלות פנימית"
       },
       "availableLayers": [

--- a/content/toc.parts/part-10.json
+++ b/content/toc.parts/part-10.json
@@ -3201,7 +3201,7 @@
       "kind": "inner-observation",
       "number": 1,
       "title": {
-        "en": "Histaklut Penimit",
+        "en": "Histaklut Pnimit",
         "he": "הסתכלות פנימית"
       },
       "availableLayers": [

--- a/content/toc.parts/part-12.json
+++ b/content/toc.parts/part-12.json
@@ -5881,7 +5881,7 @@
       "kind": "inner-observation",
       "number": 1,
       "title": {
-        "en": "Histaklut Penimit",
+        "en": "Histaklut Pnimit",
         "he": "הסתכלות פנימית"
       },
       "availableLayers": [

--- a/content/toc.parts/part-13.json
+++ b/content/toc.parts/part-13.json
@@ -4421,7 +4421,7 @@
       "kind": "inner-observation",
       "number": 1,
       "title": {
-        "en": "Histaklut Penimit",
+        "en": "Histaklut Pnimit",
         "he": "הסתכלות פנימית"
       },
       "availableLayers": [

--- a/public/sitemap-style.xsl
+++ b/public/sitemap-style.xsl
@@ -1,0 +1,371 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsl:stylesheet version="2.0"
+                xmlns:html="http://www.w3.org/TR/REC-html40"
+                xmlns:image="http://www.google.com/schemas/sitemap-image/1.1"
+                xmlns:sitemap="http://www.sitemaps.org/schemas/sitemap/0.9"
+                xmlns:xhtml="http://www.w3.org/1999/xhtml"
+                xmlns:news="http://www.google.com/schemas/sitemap-news/0.9"
+                xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+  <xsl:output method="html" version="1.0" encoding="UTF-8" indent="yes"/>
+  <xsl:template match="/">
+    <html xmlns="http://www.w3.org/1999/xhtml">
+      <head>
+        <title>XML Sitemap</title>
+        <meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
+        <style type="text/css">
+          :root {
+            --accent: #00dc82;
+            --accent-hover: #00b86b;
+            --bg: #0a0a0a;
+            --bg-elevated: #141414;
+            --bg-subtle: #1a1a1a;
+            --border: #262626;
+            --border-subtle: #1f1f1f;
+            --text: #e5e5e5;
+            --text-muted: #737373;
+            --text-faint: #525252;
+            --error: #ef4444;
+            --error-bg: rgba(239,68,68,0.1);
+            --warning: #f59e0b;
+          }
+          * { box-sizing: border-box; }
+          body {
+            font-family: ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, monospace;
+            font-size: 13px;
+            color: var(--text);
+            background: var(--bg);
+            margin: 0;
+            padding: 0;
+            line-height: 1.6;
+            -webkit-font-smoothing: antialiased;
+          }
+          a { color: inherit; transition: color 0.15s; }
+          a:hover { color: var(--accent); }
+
+          /* Debug bar (dev only) */
+          .debug-bar {
+            position: fixed;
+            bottom: 0.75rem;
+            left: 50%;
+            transform: translateX(-50%);
+            width: 80%;
+            background: var(--bg-elevated);
+            border: 1px solid var(--border);
+            border-radius: 10px;
+            padding: 0 1rem;
+            height: 2.5rem;
+            display: flex;
+            align-items: center;
+            gap: 0.75rem;
+            z-index: 100;
+            font-size: 11px;
+          }
+          .debug-bar-brand {
+            display: flex;
+            align-items: center;
+            gap: 0.5rem;
+            color: var(--text-muted);
+            text-decoration: none;
+          }
+          .debug-bar-brand:hover { color: var(--text); }
+          .debug-bar-brand svg { flex-shrink: 0; }
+          .debug-bar-hint {
+            color: var(--text-faint);
+            margin-right: auto;
+            white-space: nowrap;
+            overflow: hidden;
+            text-overflow: ellipsis;
+          }
+          .debug-bar-hint code {
+            background: var(--bg-subtle);
+            padding: 0.1rem 0.3rem;
+            border-radius: 3px;
+            font-size: 10px;
+          }
+          .mode-badge {
+            font-size: 9px;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.04em;
+            padding: 0.2rem 0.4rem;
+            border-radius: 3px;
+          }
+          .mode-dev { background: rgba(245,158,11,0.15); color: var(--warning); }
+          .mode-prod { background: rgba(0,220,130,0.12); color: var(--accent); }
+          .mode-toggle {
+            display: inline-flex;
+            border-radius: 4px;
+            overflow: hidden;
+            background: var(--bg-subtle);
+            padding: 2px;
+            gap: 1px;
+          }
+          .mode-toggle a {
+            padding: 0.2rem 0.4rem;
+            font-size: 9px;
+            font-weight: 500;
+            text-decoration: none;
+            color: var(--text-muted);
+            border-radius: 2px;
+            transition: all 0.15s;
+          }
+          .mode-toggle a:hover { color: var(--text); }
+          .mode-toggle a.active {
+            background: var(--accent);
+            color: #0a0a0a;
+          }
+          .btn {
+            display: inline-flex;
+            align-items: center;
+            gap: 0.25rem;
+            padding: 0.25rem 0.5rem;
+            border-radius: 4px;
+            text-decoration: none;
+            font-size: 10px;
+            font-weight: 500;
+            transition: all 0.15s;
+          }
+          .btn-primary {
+            background: var(--accent);
+            color: #0a0a0a;
+          }
+          .btn-primary:hover { background: var(--accent-hover); color: #0a0a0a; }
+          .btn svg { width: 12px; height: 12px; }
+
+          /* Error banner */
+          .error-banner {
+            background: var(--error-bg);
+            border-bottom: 1px solid rgba(239,68,68,0.2);
+            padding: 0.75rem 1.5rem;
+            color: #fca5a5;
+            font-size: 12px;
+          }
+          .error-banner strong { color: var(--error); }
+          .error-item { display: block; margin-top: 0.375rem; color: #fca5a5; }
+          .error-debug-link {
+            display: inline-flex;
+            align-items: center;
+            gap: 0.25rem;
+            margin-top: 0.625rem;
+            padding: 0.25rem 0.5rem;
+            background: var(--error);
+            color: #fff;
+            border-radius: 4px;
+            font-size: 11px;
+            font-weight: 500;
+            text-decoration: none;
+            transition: background 0.15s;
+          }
+          .error-debug-link:hover { background: #dc2626; color: #fff; }
+
+          /* Main content */
+          .container {
+            max-width: 1200px;
+            margin: 0 auto;
+            padding: 1.5rem;
+          }
+          .header {
+            margin-bottom: 1.25rem;
+          }
+          .header h1 {
+            font-size: 1rem;
+            font-weight: 600;
+            margin: 0 0 0.25rem 0;
+            color: var(--text);
+          }
+          .header-meta {
+            color: var(--text-muted);
+            font-size: 12px;
+          }
+          .header-meta a {
+            color: var(--text-muted);
+            text-decoration: underline;
+            text-decoration-color: var(--border);
+            text-underline-offset: 2px;
+          }
+          .header-meta a:hover { color: var(--accent); text-decoration-color: var(--accent); }
+
+          /* Table */
+          .table-wrap {
+            border: 1px solid var(--border);
+            border-radius: 8px;
+            overflow: hidden;
+            background: var(--bg-elevated);
+          }
+          table {
+            width: 100%;
+            border-collapse: collapse;
+          }
+          th {
+            text-align: left;
+            padding: 0.625rem 1rem;
+            font-size: 10px;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.05em;
+            color: var(--text-muted);
+            background: var(--bg-subtle);
+            border-bottom: 1px solid var(--border);
+          }
+          td {
+            padding: 0.5rem 1rem;
+            border-bottom: 1px solid var(--border-subtle);
+            font-size: 12px;
+            color: var(--text);
+          }
+          tr:last-child td { border-bottom: none; }
+          tr:hover td { background: rgba(255,255,255,0.02); }
+          td a {
+            text-decoration: none;
+            word-break: break-all;
+            color: var(--text);
+          }
+          td a:hover { color: var(--accent); }
+          .inline-warning {
+            font-size: 11px;
+            color: var(--warning);
+            margin-top: 0.25rem;
+            line-height: 1.4;
+          }
+          .inline-warning::before {
+            content: "⚠ ";
+          }
+          .count {
+            display: inline-block;
+            min-width: 1.25rem;
+            padding: 0.125rem 0.375rem;
+            background: var(--bg-subtle);
+            border-radius: 4px;
+            text-align: center;
+            font-size: 11px;
+            color: var(--text-muted);
+            font-variant-numeric: tabular-nums;
+          }
+          .count:empty::before { content: "0"; }
+
+          /* Light mode */
+          @media (prefers-color-scheme: light) {
+            :root {
+              --accent: #00a963;
+              --accent-hover: #008f54;
+              --bg: #ffffff;
+              --bg-elevated: #f5f5f5;
+              --bg-subtle: #ebebeb;
+              --border: #d4d4d4;
+              --border-subtle: #e5e5e5;
+              --text: #171717;
+              --text-muted: #525252;
+              --text-faint: #737373;
+              --error: #dc2626;
+              --error-bg: rgba(220,38,38,0.08);
+              --warning: #b45309;
+            }
+            tr:hover td { background: rgba(0,0,0,0.02); }
+            .btn-primary { color: #fff; }
+            .btn-primary:hover { color: #fff; }
+            .mode-toggle a.active { color: #fff; }
+            .error-banner { color: #991b1b; }
+            .error-item { color: #b91c1c; }
+            .error-debug-link { color: #fff; }
+            .error-debug-link:hover { color: #fff; }
+          }
+
+          .debug-bar-version {
+            color: var(--text-faint);
+            font-size: 10px;
+          }
+
+          /* Responsive */
+          @media (max-width: 640px) {
+            .debug-bar { padding: 0 0.75rem; gap: 0.5rem; width: 95%; }
+            .debug-bar-brand span { display: none; }
+            .debug-bar-hint { display: none; }
+            .debug-bar-version { display: none; }
+            .mode-badge { display: none; }
+            .container { padding: 1rem; }
+            th, td { padding: 0.5rem 0.75rem; }
+          }
+          
+        </style>
+      </head>
+      <body>
+        
+        <div class="container">
+          <div class="header">
+            <h1>Read TES</h1>
+            <div class="header-meta">
+              
+              <xsl:if test="count(sitemap:sitemapindex/sitemap:sitemap) &gt; 0">
+                <xsl:value-of select="count(sitemap:sitemapindex/sitemap:sitemap)"/> sitemaps
+              </xsl:if>
+              <xsl:if test="count(sitemap:sitemapindex/sitemap:sitemap) &lt; 1">
+                <xsl:value-of select="count(sitemap:urlset/sitemap:url)"/> URLs
+              </xsl:if>
+            </div>
+          </div>
+          <xsl:if test="count(sitemap:sitemapindex/sitemap:sitemap) &gt; 0">
+            <div class="table-wrap">
+              <table>
+                <thead>
+                  <tr>
+                    <th style="width:70%">Sitemap</th>
+                    <th style="width:30%">Last Modified</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  <xsl:for-each select="sitemap:sitemapindex/sitemap:sitemap">
+                    <xsl:variable name="sitemapURL">
+                      <xsl:value-of select="sitemap:loc"/>
+                    </xsl:variable>
+                    <tr>
+                      <td>
+                        <a href="{$sitemapURL}">
+                          <xsl:value-of select="sitemap:loc"/>
+                        </a>
+                      </td>
+                      <td>
+                        <xsl:value-of
+                          select="concat(substring(sitemap:lastmod,0,11),concat(' ', substring(sitemap:lastmod,12,5)),concat(' ', substring(sitemap:lastmod,20,6)))"/>
+                      </td>
+                    </tr>
+                  </xsl:for-each>
+                </tbody>
+              </table>
+            </div>
+          </xsl:if>
+          <xsl:if test="count(sitemap:sitemapindex/sitemap:sitemap) &lt; 1">
+            <div class="table-wrap">
+              <table>
+                <thead>
+                  <tr>
+                    <th style="width:50%">URL</th>
+<th style="width:25%">Images</th>
+<th style="width:25%">Last Updated</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  <xsl:for-each select="sitemap:urlset/sitemap:url">
+                    <tr>
+                      <td>
+                        <xsl:variable name="itemURL">
+                          <xsl:value-of select="sitemap:loc"/>
+                        </xsl:variable>
+                        <a href="{$itemURL}">
+                          <xsl:value-of select="sitemap:loc"/>
+                        </a>
+                        
+                      </td>
+                      <td><span class="count"><xsl:value-of select="count(image:image)"/></span></td>
+<td><span class="count"><xsl:value-of select="concat(substring(sitemap:lastmod,0,11),concat(' ', substring(sitemap:lastmod,12,5)),concat(' ', substring(sitemap:lastmod,20,6)))"/></span></td>
+                    </tr>
+                  </xsl:for-each>
+                </tbody>
+              </table>
+            </div>
+          </xsl:if>
+        </div>
+        
+      </body>
+    </html>
+  </xsl:template>
+</xsl:stylesheet>

--- a/scripts/lib/toc-builder.ts
+++ b/scripts/lib/toc-builder.ts
@@ -15,6 +15,16 @@ import type { SefariaIndexNode } from "./sefaria-api-types.ts";
 
 type LocalizedTitle = Record<string, string>;
 
+/**
+ * Sefaria's own index titles spell the inner-observation layer "Histaklut
+ * Penimit"; this site's transliteration is "Pnimit" (matching the
+ * `histaklut-pnimit` section id everywhere else). Normalize display
+ * titles on write so re-imports can never drift the corpus back to the
+ * Sefaria spelling — refs and provenance keep Sefaria's original strings.
+ */
+const normalizeEnTitle = (title: string): string =>
+  title.replace(/Penimit/g, "Pnimit");
+
 /** Stable display/sort order for chapter kinds within a part. */
 const KIND_ORDER: ChapterKind[] = [
   "chapter",
@@ -68,7 +78,7 @@ export const mainChapterTitle = (number: number): LocalizedTitle => ({
 /**
  * Title for a sibling-node chapter. When a node produces exactly one
  * chapter (e.g. a flat "List of Questions..." node), its own index title
- * is used verbatim; when it produces several (e.g. 10 Histaklut Penimit
+ * is used verbatim; when it produces several (e.g. 10 Histaklut Pnimit
  * chapters), each is numbered off the node's title.
  */
 export const siblingChapterTitle = (
@@ -77,9 +87,9 @@ export const siblingChapterTitle = (
   totalInKind: number,
 ): LocalizedTitle =>
   totalInKind === 1
-    ? { en: node.title, he: node.heTitle }
+    ? { en: normalizeEnTitle(node.title), he: node.heTitle }
     : {
-        en: `${node.title} ${number}`,
+        en: `${normalizeEnTitle(node.title)} ${number}`,
         he: `${node.heTitle} ${hebrewNumeral(number)}`,
       };
 

--- a/shared/utils/sitemap.ts
+++ b/shared/utils/sitemap.ts
@@ -97,6 +97,7 @@ export const renderSitemapXml = (entries: SitemapEntry[]): string => {
 
   return [
     '<?xml version="1.0" encoding="UTF-8"?>',
+    '<?xml-stylesheet type="text/xsl" href="/sitemap-style.xsl"?>',
     '<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:xhtml="http://www.w3.org/1999/xhtml">',
     ...urls,
     "</urlset>",

--- a/tests/unit/chapter-row.spec.ts
+++ b/tests/unit/chapter-row.spec.ts
@@ -28,7 +28,7 @@ const aiTranslatedChapter: TocChapter = {
   id: "part-01/inner-observation-01",
   kind: "inner-observation",
   number: 1,
-  title: { en: "Histaklut Penimit 1", he: "הסתכלות פנימית א׳" },
+  title: { en: "Histaklut Pnimit 1", he: "הסתכלות פנימית א׳" },
   availableLayers: ["source"],
   availableVersions: {
     summary: [],

--- a/tests/unit/import-sefaria.spec.ts
+++ b/tests/unit/import-sefaria.spec.ts
@@ -551,8 +551,20 @@ describe("toc-builder", () => {
       10,
     );
     expect(title).toEqual({
-      en: "Histaklut Penimit 3",
+      en: "Histaklut Pnimit 3",
       he: "הסתכלות פנימית ג׳",
+    });
+  });
+
+  it("siblingChapterTitle normalizes Sefaria's 'Penimit' transliteration to 'Pnimit'", () => {
+    const title = siblingChapterTitle(
+      { title: "Histaklut Penimit", heTitle: "הסתכלות פנימית" },
+      1,
+      1,
+    );
+    expect(title).toEqual({
+      en: "Histaklut Pnimit",
+      he: "הסתכלות פנימית",
     });
   });
 

--- a/tests/unit/inner-observation-pane.spec.ts
+++ b/tests/unit/inner-observation-pane.spec.ts
@@ -9,14 +9,14 @@ describe("InnerObservationPane", () => {
     const sections: InnerObservationSectionView[] = [
       {
         chapterId: "part-01/inner-observation-01",
-        title: { en: "Histaklut Penimit 1", he: "הסתכלות פנימית א׳" },
+        title: { en: "Histaklut Pnimit 1", he: "הסתכלות פנימית א׳" },
         items: [
           { n: 1, sefariaRef: "x 1", html: "First section.", anchors: [] },
         ],
       },
       {
         chapterId: "part-01/inner-observation-02",
-        title: { en: "Histaklut Penimit 2", he: "הסתכלות פנימית ב׳" },
+        title: { en: "Histaklut Pnimit 2", he: "הסתכלות פנימית ב׳" },
         items: [
           { n: 1, sefariaRef: "x 2", html: "Second section.", anchors: [] },
         ],
@@ -28,12 +28,12 @@ describe("InnerObservationPane", () => {
     });
 
     const text = wrapper.text();
-    expect(text).toContain("Histaklut Penimit 1");
+    expect(text).toContain("Histaklut Pnimit 1");
     expect(text).toContain("First section.");
-    expect(text).toContain("Histaklut Penimit 2");
+    expect(text).toContain("Histaklut Pnimit 2");
     expect(text).toContain("Second section.");
     expect(text.indexOf("First section.")).toBeLessThan(
-      text.indexOf("Histaklut Penimit 2"),
+      text.indexOf("Histaklut Pnimit 2"),
     );
   });
 
@@ -41,7 +41,7 @@ describe("InnerObservationPane", () => {
     const sections: InnerObservationSectionView[] = [
       {
         chapterId: "part-01/inner-observation-01",
-        title: { en: "Histaklut Penimit 1", he: "א" },
+        title: { en: "Histaklut Pnimit 1", he: "א" },
         items: [{ n: 1, sefariaRef: "x 1", html: "Text.", anchors: [] }],
       },
     ];

--- a/tests/unit/sitemap.spec.ts
+++ b/tests/unit/sitemap.spec.ts
@@ -80,6 +80,11 @@ describe("sitemap URL builder", () => {
     const xml = renderSitemapXml(entries);
 
     expect(xml).toContain('<?xml version="1.0" encoding="UTF-8"?>');
+    // The stylesheet PI comes straight after the declaration so browsers
+    // render the sitemap as a styled table instead of raw XML.
+    expect(xml).toContain(
+      '<?xml version="1.0" encoding="UTF-8"?>\n<?xml-stylesheet type="text/xsl" href="/sitemap-style.xsl"?>',
+    );
     expect(xml).toContain(
       '<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:xhtml="http://www.w3.org/1999/xhtml">',
     );


### PR DESCRIPTION
Four fixes riding together from the mobile-panes debug session:

- **fix(reader)**: swipe-to-pane pill sync — commit from the settle debounce instead of the native scrollend (which fires a rendering step ahead of the observer's final ratio batch and left the pill stuck on the stale tab); attach the observer in onMounted (the immediate watcher ran before trackRef was bound and silently no-op'd); extra bottom padding so the floating pill never covers the last text line.
- **fix(library)**: whole VolumeCard clickable via stretched link.
- **fix(content)**: toc-builder normalizes Sefaria's 'Histaklut Penimit' to the site's 'Pnimit' transliteration on write, regenerated toc.json + per-part ToCs.
- **feat(seo)**: sitemap.xml now renders as a styled table in browsers via a vendored MIT XSL stylesheet; crawler output unchanged.

Verified: touch-swipe repro on the built artifact (pill follows slide, pane scroll preserved), full gate (lint/typecheck/validate/unit/generate 10,320 routes/e2e 4/4).