### PR TITLE
fix(reader): pill tap scrolls the panes track directly (drop scrollIntoView)

### DIFF
--- a/app/components/reader/MobileSwipePanes.vue
+++ b/app/components/reader/MobileSwipePanes.vue
@@ -41,13 +41,13 @@
 // instead fires once ~`settleMs` after the last ratio change, by which
 // point the final (settled) frame has been observed, so the commit always
 // resolves the post-swipe layout. Tab/pill taps and cross-pane anchor
-// jumps both just set `activePane`; the `watch` below is the only thing
-// that turns that into an actual `scrollIntoView` (via `inline: "start"`,
-// a logical value, so it's RTL-correct without a `dir` check) — including
-// on mount, so a fresh load lands snapped to whichever pane is already
-// `activePane` (source, by default) instead of sitting on the DOM-first
-// slide the browser scrolls to by default with nothing else to say
-// otherwise.
+// jumps both just set `activePane`; the `watch` on it is the only thing
+// that turns that into an actual track scroll (`scrollToPane` — a direct
+// `track.scrollTo`, see its own comment for why not `scrollIntoView`),
+// including on mount, so a fresh load lands snapped to whichever pane is
+// already `activePane` (source, by default) instead of sitting on the
+// DOM-first slide the browser scrolls to by default with nothing else to
+// say otherwise.
 //
 // `[contain:layout]` on the track + `min-w-0` on every slide (mobile-only —
 // both reset back to none/auto at `lg:`) are load-bearing, not decoration:
@@ -197,26 +197,27 @@ onUnmounted(detachTrackListeners);
 
 const scrollToPane = (pane: PaneId, instant: boolean) => {
   if (!isNarrowViewport.value) return;
-  slideRefs[pane].value?.scrollIntoView({
+  const track = trackRef.value;
+  const slide = slideRefs[pane].value;
+  if (!track || !slide) return;
+
+  // Scroll the track directly instead of `slide.scrollIntoView()`: the
+  // track is a `contain: layout` scroll-snap container (see the module doc
+  // above — both properties are load-bearing on real mobile browsers), and
+  // WebKit's `scrollIntoView` resolution through that combination is
+  // unreliable — on touch devices a pill tap can end up scrolling nothing
+  // at all. Computing the target ourselves is geometry, so it behaves
+  // identically in every engine and RTL is handled by the fact that
+  // `getBoundingClientRect().left` is already a physical coordinate.
+  const target =
+    Math.round(
+      slide.getBoundingClientRect().left - track.getBoundingClientRect().left,
+    ) + track.scrollLeft;
+  track.scrollTo({
+    left: target,
     behavior: instant || prefersReducedMotion() ? "auto" : "smooth",
-    inline: "start",
-    block: "nearest",
   });
 };
-
-// `onMounted`, not an `immediate` watch: template refs are only guaranteed
-// populated once the component has actually mounted, and (unlike
-// `useFocusTrap`'s own `immediate`+`flush: "post"` watch, which reacts to a
-// *prop* flipping true after this component already exists) this needs to
-// run for the very state this component is born into — this *is* the
-// mount. Snaps instantly (no motion to reduce, there's no prior on-screen
-// state to visibly transition away from) to whichever slide is already
-// `activePane` (source, by default) instead of leaving the browser's own
-// "first slide in DOM order" scroll position silently mismatched against
-// it.
-onMounted(() => {
-  scrollToPane(activePane.value, true);
-});
 
 watch(activePane, (pane) => {
   scrollToPane(pane, false);

--- a/tests/e2e/reader.spec.ts
+++ b/tests/e2e/reader.spec.ts
@@ -127,10 +127,36 @@ test.describe("mobile reader", () => {
     await modes.getByRole("button", { name: "Panes" }).click();
     const paneTabs = page.getByRole("tablist", { name: "Reader pane" });
     await expect(paneTabs).toBeVisible();
+    const trackScrollLeft = () =>
+      page.evaluate(
+        () =>
+          document.querySelector("#reader-source-pane")?.parentElement
+            ?.scrollLeft ?? 0,
+      );
+
+    // Pill tap moves the track (regression: a tap used to flip
+    // aria-selected without scrolling the track at all on some engines).
     await paneTabs.getByRole("tab", { name: "Inner Light" }).click();
     await expect(
       paneTabs.getByRole("tab", { name: "Inner Light" }),
     ).toHaveAttribute("aria-selected", "true");
     await expect(page.locator("#reader-commentary-pane")).toBeInViewport();
+    await expect.poll(trackScrollLeft).toBeGreaterThan(0);
+
+    // Swipe to the last slide, then tap back — the tap must scroll the
+    // track even while the swipe's settle timer is still pending.
+    await page.evaluate(() => {
+      const track = document.querySelector(
+        "#reader-source-pane",
+      )?.parentElement;
+      track?.scrollTo({ left: track.scrollWidth, behavior: "smooth" });
+    });
+    await expect.poll(trackScrollLeft).toBeGreaterThan(0);
+    await paneTabs.getByRole("tab", { name: "The Ari's Text" }).click();
+    await expect(
+      paneTabs.getByRole("tab", { name: "The Ari's Text" }),
+    ).toHaveAttribute("aria-selected", "true");
+    await expect(page.locator("#reader-source-pane")).toBeInViewport();
+    await expect.poll(trackScrollLeft).toBe(0);
   });
 });

--- a/tests/unit/mobile-swipe-panes.spec.ts
+++ b/tests/unit/mobile-swipe-panes.spec.ts
@@ -1,7 +1,8 @@
 // Thin wiring coverage for `MobileSwipePanes` over the tested pure
 // `resolveActivePane` (`mobile-pane-sync.spec.ts`): renders the slides
 // with their `data-pane` markers, and confirms `activePane` changes drive a
-// `scrollIntoView` call on the matching slide once the narrow-viewport
+// direct `scrollTo` on the track (not the slide's `scrollIntoView` — see
+// the component's `scrollToPane` comment for why) once the narrow-viewport
 // media query matches. The reverse direction — a real swipe gesture
 // settling on a slide via `IntersectionObserver`/`scrollend` — needs a
 // manual pass on an actual device/browser: happy-dom's `IntersectionObserver`
@@ -57,7 +58,7 @@ const Host = defineComponent({
 describe("MobileSwipePanes", () => {
   beforeEach(() => {
     vi.unstubAllGlobals();
-    Element.prototype.scrollIntoView = vi.fn();
+    Element.prototype.scrollTo = vi.fn();
   });
 
   it("renders all three slides with their data-pane marker, always mounted", async () => {
@@ -115,7 +116,7 @@ describe("MobileSwipePanes", () => {
     expect(wrapper.vm.state.activePane.value).toBe("source");
   });
 
-  it("scrolls the matching slide into view when activePane changes on a narrow viewport", async () => {
+  it("scrolls the track to the matching slide when activePane changes on a narrow viewport", async () => {
     stubMatchMedia(true);
     const wrapper = await mountSuspended(Host);
     await nextTick();
@@ -123,7 +124,7 @@ describe("MobileSwipePanes", () => {
     wrapper.vm.state.setActivePane("commentary");
     await nextTick();
 
-    expect(Element.prototype.scrollIntoView).toHaveBeenCalled();
+    expect(Element.prototype.scrollTo).toHaveBeenCalled();
   });
 
   it("never auto-scrolls on a wide (desktop grid) viewport", async () => {
@@ -134,6 +135,6 @@ describe("MobileSwipePanes", () => {
     wrapper.vm.state.setActivePane("commentary");
     await nextTick();
 
-    expect(Element.prototype.scrollIntoView).not.toHaveBeenCalled();
+    expect(Element.prototype.scrollTo).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
The swipe-to-pill sync works, but tapping the pill could flip aria-selected without moving the track at all on some engines.

Root cause: scrollToPane relied on `slide.scrollIntoView()`, which walks the engine's scroll chain through the track's `contain: layout` scroll-snap container — reliable in Chromium, unreliable on touch devices in WebKit (resolves to no scroll at all).

Fix: compute the target offset from `getBoundingClientRect()` and `track.scrollTo()` directly — geometry, engine-agnostic, RTL-safe. Also removed a leftover duplicate onMounted.

Regression coverage: e2e mobile test now asserts the track's actual scrollLeft moves on pill taps (both directions, including while the swipe settle timer is pending); unit spec pins `scrollTo` on the track instead of `scrollIntoView` on the slide.

Verified: full gate passes locally (504 unit, 10,320 prerendered routes, 4/4 e2e).