### PR TITLE
fix(reader): draw disclosure chevrons with the mask icon, drop the duplicate mini-toc heading

### DIFF
--- a/app/assets/css/main.css
+++ b/app/assets/css/main.css
@@ -547,6 +547,11 @@ html {
   @apply flex cursor-pointer list-none items-center justify-between gap-2 px-4 py-3 [&::-webkit-details-marker]:hidden focus-visible:outline focus-visible:outline-2 focus-visible:outline-teal;
 }
 
+/* Pairs with `.tes-icon .tes-icon-chevron-down` at the call site, not a
+   typographic glyph: `⌄` (U+2304) renders at wildly different weights and
+   baselines across the font stack — heavy and low next to the eyebrow it
+   sits beside. `color` here is what the mask paints with, since `.tes-icon`
+   sets `background-color: currentColor`. */
 .tes-disclosure-chevron {
   @apply text-(--text-muted) transition-transform group-open:rotate-180;
 }

--- a/app/components/reader/ChapterIntro.vue
+++ b/app/components/reader/ChapterIntro.vue
@@ -23,7 +23,10 @@ const { t } = useI18n();
       <span class="tes-eyebrow">
         {{ t("reader.chapterIntro.title") }}
       </span>
-      <span aria-hidden="true" class="tes-disclosure-chevron">⌄</span>
+      <span
+        aria-hidden="true"
+        class="tes-icon tes-icon-chevron-down tes-disclosure-chevron h-4 w-4"
+      />
     </summary>
 
     <div class="px-4 pb-4">

--- a/app/components/reader/ReaderSummaryBody.vue
+++ b/app/components/reader/ReaderSummaryBody.vue
@@ -4,9 +4,14 @@
 // extracted from its source segments as a mini table-of-contents, so this
 // is never an empty box. Each mini-toc entry jumps to that seif (`seif-N`).
 //
-// Used by both `ChapterIntro` (study mode's collapsible intro card, above
-// the reading stream) and `SourcePane` (panes mode's own collapsible
-// `<details>`, above its segment list) — always rendered in the same
+// Rendered only by `ChapterIntro`, which both study mode (above the reading
+// stream) and `SourcePane` (above its segment list) mount. That host's
+// `<summary>` already shows "In this chapter", so the mini-toc carries NO
+// visible heading of its own — it would render directly beneath an
+// identical one. The name survives as the `<nav>`'s `aria-label`, which is
+// what a screen reader announces for the landmark anyway.
+//
+// It is always rendered in the same
 // container as the `seif-N` targets it jumps to, so a plain local
 // `scrollIntoView` + highlight flash is all a mini-toc click needs; unlike
 // a real cross-pane anchor activation, there's no other pane's
@@ -66,10 +71,7 @@ const onMiniTocEntryClick = (anchorId: string) => {
     v-else-if="miniToc.entries.length > 0"
     :aria-label="t('reader.miniTocTitle')"
   >
-    <h3 class="tes-eyebrow">
-      {{ t("reader.miniTocTitle") }}
-    </h3>
-    <ol class="mt-3 flex flex-col gap-1">
+    <ol class="flex flex-col gap-1">
       <li v-for="entry in miniToc.entries" :key="entry.anchorId">
         <button
           type="button"

--- a/app/components/reader/StudyStream.vue
+++ b/app/components/reader/StudyStream.vue
@@ -243,7 +243,10 @@ const goToFullCommentary = async () => {
         <span class="tes-eyebrow">
           {{ t("reader.studyMode.unalignedCommentaryTitle") }}
         </span>
-        <span aria-hidden="true" class="tes-disclosure-chevron">⌄</span>
+        <span
+          aria-hidden="true"
+          class="tes-icon tes-icon-chevron-down tes-disclosure-chevron h-4 w-4"
+        />
       </summary>
 
       <div class="flex flex-col gap-6 px-4 pb-4">

--- a/tests/unit/reader-summary-body.spec.ts
+++ b/tests/unit/reader-summary-body.spec.ts
@@ -35,7 +35,7 @@ describe("ReaderSummaryBody", () => {
 
     expect(wrapper.text()).toContain("Before restriction: the simple light");
     // The mini-toc must not also render alongside a real summary.
-    expect(wrapper.text()).not.toContain("In this chapter");
+    expect(wrapper.find("nav").exists()).toBe(false);
   });
 
   it("falls back to a heading mini-toc when there's no summary layer", async () => {
@@ -43,7 +43,14 @@ describe("ReaderSummaryBody", () => {
       props: { summaryItems: [], sourceSegments },
     });
 
-    expect(wrapper.text()).toContain("In this chapter");
+    // The name is the `<nav>`'s accessible label, never visible text: the
+    // only host (`ChapterIntro`) already prints "In this chapter" in its
+    // `<summary>`, directly above this. Rendering it again produced the
+    // heading twice, one line apart.
+    expect(wrapper.find("nav").attributes("aria-label")).toBe(
+      "In this chapter",
+    );
+    expect(wrapper.text()).not.toContain("In this chapter");
     expect(wrapper.text()).toContain("Before restriction");
     // Segment 2 has no `heading` — falls back to a generic seif label so the
     // mini-toc entry count still matches the segment count.


### PR DESCRIPTION
## Summary
- The literal `⌄` (U+2304) glyph used for the `<details><summary>` disclosure chevron rendered at inconsistent weight/baseline across the font stack; swap in the same masked chevron-down icon `ReaderBreadcrumbMenu.vue` already uses.
- `ReaderSummaryBody`'s mini-toc `<h3>` duplicated the "In this chapter" text that its only host, `ChapterIntro`, already prints in its `<summary>` one line above. The name now lives solely on the `<nav>`'s `aria-label`.

## Test plan
- [x] `task check` (lint, format:check, typecheck, validate:content, test, generate, test:e2e) — all green