### PR TITLE
fix(reader): label notes with the marker the source text prints, and open collapsed groups on anchor activation

### DIFF
--- a/app/assets/css/main.css
+++ b/app/assets/css/main.css
@@ -453,18 +453,26 @@ html {
  * load-bearing, not decoration: a transparent sticky heading has the list's
  * own text sliding visibly under it.
  */
+/* The transparent inline-start border is reserved on EVERY heading, not just
+   the current one, so `.is-current` colouring it in shifts nothing. */
 .tes-commentary-seif-heading {
-  @apply sticky top-0 z-10 flex cursor-pointer list-none items-center justify-between gap-2 border-b border-(--border) bg-(--surface) py-2 text-sm font-semibold tabular-nums text-(--text-primary) [&::-webkit-details-marker]:hidden focus-visible:outline focus-visible:outline-2 focus-visible:outline-teal;
+  @apply sticky top-0 z-10 flex cursor-pointer list-none items-center justify-between gap-2 border-b border-(--border) border-s-[3px] border-s-transparent bg-(--surface) py-2 ps-2 text-sm font-semibold tabular-nums text-(--text-primary) [&::-webkit-details-marker]:hidden focus-visible:outline focus-visible:outline-2 focus-visible:outline-teal;
 }
 
 /*
- * The seif the reader is currently on in the source pane (`useCurrentSeif`).
- * Colour only — no movement, no scrolling, no hiding: the whole chapter's
- * commentary is always rendered, and this is the quiet cross-pane link
- * between the two columns' numbers, not a mode.
+ * The seif the source pane is currently scrolled to (`useCurrentSeif`).
+ *
+ * An edge bar, not just coloured text: colour alone read as "selected" —
+ * with every group collapsed and the source pane at the top, a lone teal
+ * "Seif 1" looks like a choice the reader made rather than a report of
+ * where the other column is. A margin rule is the conventional shape for
+ * "you are here", and it survives being the only one lit.
+ *
+ * Never moves or hides anything: the whole chapter's commentary is always
+ * rendered, and this is a quiet cross-pane link, not a mode.
  */
 .tes-commentary-seif-heading.is-current {
-  @apply border-b-teal text-(--accent-text);
+  @apply border-s-teal text-(--accent-text);
 }
 
 /*

--- a/app/components/reader/CommentaryPane.vue
+++ b/app/components/reader/CommentaryPane.vue
@@ -46,13 +46,31 @@
 // own trailing group under their own heading rather than being dropped.
 import type { CommentaryItem } from "~~/shared/types/content";
 
-const props = defineProps<{ items: CommentaryItem[] }>();
+const props = defineProps<{
+  items: CommentaryItem[];
+  /**
+   * `anchorId` -> the marker the source version on screen prints for it
+   * (`anchorMarkersFromSegments`). Preferred over the item's own `label`,
+   * because the two disagree and both are faithful to the printed edition:
+   * Bnei Baruch's English marks the Ari's text with the Hebrew letters'
+   * gematria values ("20") while numbering the notes sequentially ("11") —
+   * see issue #96. Taking the marker from the text means the number the
+   * reader clicks is the number they land on. Optional so the component
+   * still renders standalone (tests, any caller without segments).
+   */
+  anchorMarkers?: ReadonlyMap<string, string>;
+}>();
 
 const { locale, t } = useI18n();
 const { activateAnchor } = useReaderState();
 const { currentSeif } = useCurrentSeif();
 const containerRef = useReaderPaneContainer();
 useHighlightedAnchor("commentary", containerRef);
+
+/** The marker to print for an item: the source's own, else its stored label. */
+const markerFor = (item: CommentaryItem): string =>
+  props.anchorMarkers?.get(item.anchorId) ??
+  localizedText(item.label, locale.value);
 
 const sections = computed(() =>
   groupCommentaryBySection(props.items).map((section) => ({
@@ -137,10 +155,10 @@ const isSectionHeadingUseful = computed(
               class="tes-anchor tes-commentary-marker"
               @click="activateAnchor(item.anchorId, 'commentary')"
             >
-              {{ localizedText(item.label, locale) }}
+              {{ markerFor(item) }}
             </button>
             <span v-else class="tes-commentary-marker is-plain">
-              {{ localizedText(item.label, locale) }}
+              {{ markerFor(item) }}
             </span>
             <span class="tes-commentary-body" v-html="item.html" />
           </li>

--- a/app/components/reader/CommentarySheet.vue
+++ b/app/components/reader/CommentarySheet.vue
@@ -24,6 +24,8 @@ const props = defineProps<{
   open: boolean;
   seif: number | null;
   items: CommentaryItem[];
+  /** `anchorId` -> the marker the source text prints — see `anchorMarkersFromSegments` (issue #96). */
+  anchorMarkers?: ReadonlyMap<string, string>;
 }>();
 
 const emit = defineEmits<{ close: [] }>();
@@ -168,7 +170,10 @@ const transitionDuration = computed(() =>
               class="rounded-card border border-(--border) p-3"
             >
               <p class="mb-1 text-xs font-semibold text-(--accent-text)">
-                {{ localizedText(item.label, locale) }}
+                {{
+                  props.anchorMarkers?.get(item.anchorId) ??
+                  localizedText(item.label, locale)
+                }}
               </p>
               <div
                 class="text-sm leading-relaxed text-(--text-primary)"

--- a/app/components/reader/InlineCommentary.vue
+++ b/app/components/reader/InlineCommentary.vue
@@ -14,6 +14,8 @@ const props = defineProps<{
   items: CommentaryItem[];
   meta: ContentVersion | null;
   canSwitchToHebrew: boolean;
+  /** `anchorId` -> the marker the source text prints — see `anchorMarkersFromSegments` (issue #96). */
+  anchorMarkers?: ReadonlyMap<string, string>;
 }>();
 
 const emit = defineEmits<{ "switch-to-hebrew": [] }>();
@@ -72,6 +74,7 @@ const fold = () => toggleInline(props.anchorId);
         class="text-[length:calc(1rem*var(--reading-scale))] leading-relaxed text-(--text-primary)"
       >
         <span class="me-1.5 text-xs font-semibold text-(--accent-text)">{{
+          props.anchorMarkers?.get(item.anchorId) ??
           localizedText(item.label, locale)
         }}</span>
         <span v-html="item.html" />

--- a/app/components/reader/OriginalStream.vue
+++ b/app/components/reader/OriginalStream.vue
@@ -33,6 +33,18 @@ const props = defineProps<{
 const { t, locale } = useI18n();
 
 const hasCommentary = computed(() => props.commentaryItems.length > 0);
+
+// Label each note with the marker the source text above it actually prints,
+// falling back to the item's stored label — the two disagree in the English
+// editions and both are faithful (issue #96). This mode shows both texts on
+// one page, so a disagreement is at its most visible here.
+const anchorMarkers = computed(() =>
+  anchorMarkersFromSegments(props.sourceSegments),
+);
+
+const markerFor = (item: CommentaryItem): string =>
+  anchorMarkers.value.get(item.anchorId) ??
+  localizedText(item.label, locale.value);
 </script>
 
 <template>
@@ -97,9 +109,7 @@ const hasCommentary = computed(() => props.commentaryItems.length > 0);
           :key="item.anchorId"
           class="text-[length:calc(1rem*var(--reading-scale))] leading-relaxed text-(--text-primary)"
         >
-          <span class="font-medium"
-            >{{ localizedText(item.label, locale) }}.</span
-          >
+          <span class="font-medium">{{ markerFor(item) }}.</span>
           <span v-html="item.html" />
         </li>
       </ol>

--- a/app/components/reader/StudyStream.vue
+++ b/app/components/reader/StudyStream.vue
@@ -137,6 +137,14 @@ const hasCommentaryLayer = computed(
   () => props.commentaryLanguageOptions.length > 0,
 );
 
+// The marker each anchor is printed with in the source text these
+// disclosures unfold beneath — see `anchorMarkersFromSegments` (issue #96).
+// Study mode puts note and marker within a line of each other, so a
+// disagreement between them is unmissable here.
+const anchorMarkers = computed(() =>
+  anchorMarkersFromSegments(props.sourceSegments),
+);
+
 /** Switches to panes mode and scrolls straight to its commentary column — see `ReaderShell`'s `#reader-commentary-pane`. */
 const goToFullCommentary = async () => {
   setMode("panes");
@@ -223,6 +231,7 @@ const goToFullCommentary = async () => {
                   :items="commentaryItemsForAnchor(anchorId)"
                   :meta="commentaryMeta"
                   :can-switch-to-hebrew="canSwitchToHebrewFor(anchorId)"
+                  :anchor-markers="anchorMarkers"
                   @switch-to-hebrew="switchToHebrew"
                 />
               </div>

--- a/app/composables/useHighlightedAnchor.ts
+++ b/app/composables/useHighlightedAnchor.ts
@@ -38,6 +38,31 @@ const findAnchorElement = (
   );
 };
 
+/**
+ * Opens every collapsed `<details>` between `target` and `container`.
+ *
+ * Without this, a cross-pane activation into a folded group silently does
+ * nothing that the reader can see: the element is still in the document (it
+ * is found above, and in-page find can still reach it), but a closed
+ * `<details>` renders its contents `display: none`, so `scrollIntoView` has
+ * no box to scroll to and the highlight flashes where nobody is looking.
+ * Clicking `(20)` in the Ari's text must open the seif group holding note
+ * 20, not appear to do nothing.
+ *
+ * Stops at the pane container so this can never reach out and open chrome
+ * that happens to wrap the pane.
+ */
+const revealInsideCollapsedGroups = (
+  target: HTMLElement,
+  container: HTMLElement,
+): void => {
+  let node: HTMLElement | null = target.parentElement;
+  while (node && node !== container) {
+    if (node instanceof HTMLDetailsElement && !node.open) node.open = true;
+    node = node.parentElement;
+  }
+};
+
 export const useHighlightedAnchor = (
   paneId: PaneId,
   containerRef: Ref<HTMLElement | null | undefined>,
@@ -63,6 +88,8 @@ export const useHighlightedAnchor = (
 
       const target = findAnchorElement(container, anchorId);
       if (!target) return;
+
+      revealInsideCollapsedGroups(target, container);
 
       setActivePane(paneId);
       target.scrollIntoView({

--- a/app/pages/read/[part]/[chapter].vue
+++ b/app/pages/read/[part]/[chapter].vue
@@ -298,6 +298,17 @@ const commentarySheetItems = computed(() =>
     : commentaryItemsForSeif(commentaryItems.value, commentarySheetSeif.value),
 );
 
+// The marker each anchor is printed with in the source version currently on
+// screen. Every surface that labels a commentary item uses this in
+// preference to the item's own `label`, so the number the reader clicks in
+// the Ari's text is the number they land on — see `anchorMarkersFromSegments`
+// for why the two differ in the first place (issue #96: Bnei Baruch's own
+// printed English marks the text with gematria values but numbers the notes
+// sequentially, and the corpus reproduces both faithfully).
+const anchorMarkers = computed(() =>
+  anchorMarkersFromSegments(sourceSegments.value),
+);
+
 // `useCurrentSeif`: the source pane measures which seif the reader is on and
 // the commentary pane's followed view reads it. Called here, ahead of
 // `ReaderShell`, so this page is the provider both panes inject — neither
@@ -387,7 +398,10 @@ useLocalizedSeo({
               </button>
             </p>
           </template>
-          <ReaderCommentaryPane :items="commentaryItems" />
+          <ReaderCommentaryPane
+            :items="commentaryItems"
+            :anchor-markers="anchorMarkers"
+          />
         </ReaderPane>
       </template>
 
@@ -466,6 +480,7 @@ useLocalizedSeo({
       :open="commentarySheetSeif !== null"
       :seif="commentarySheetSeif"
       :items="commentarySheetItems"
+      :anchor-markers="anchorMarkers"
       @close="closeCommentarySheet"
     />
   </div>

--- a/app/utils/anchorMarkers.ts
+++ b/app/utils/anchorMarkers.ts
@@ -1,0 +1,56 @@
+/**
+ * The marker text the CURRENTLY DISPLAYED source version prints for each of
+ * its anchors — so the commentary pane can label a note with the very
+ * characters the reader just clicked in the Ari's text.
+ *
+ * Why this is needed rather than trusting `CommentaryItem.label`: the two
+ * disagree, and both are faithful. Fetched from Bnei Baruch's own English
+ * document for Part 1 Chapter 1 (KabbalahMedia `doc2html/vYyXn9gY`,
+ * 2026-08-13), their printed edition marks the Ari's text
+ * `(1)…(10) (20) (30) … (400)` — the gematria values of the Hebrew letters —
+ * while numbering the Inner Light notes themselves `1. 2. 3.` in plain
+ * running order. Our corpus reproduces both sides exactly: `en-bb`'s source
+ * html carries "20", its `label.en` carries "11". The printed edition is
+ * internally inconsistent; the import is not (see issue #96).
+ *
+ * The reader can do better than the page without falsifying either file.
+ * Taking the marker from whichever source version is on screen means the
+ * two panes can never disagree — and it stays right when the panes are in
+ * different languages, since a Hebrew source pane yields "כ" and the
+ * commentary pane then shows "כ" too.
+ *
+ * Anchors are normalized at import time (`app/utils/anchors.ts`) to
+ * `<a class="tes-anchor" data-anchor="op-N">MARKER</a>`, so a regex over the
+ * committed html is sufficient and — unlike `DOMParser` — works unchanged
+ * during prerender.
+ */
+import type { SourceSegment } from "~~/shared/types/content";
+
+const ANCHOR_RE = /<a\b[^>]*\bdata-anchor="([^"]+)"[^>]*>([\s\S]*?)<\/a>/g;
+
+const TAG_RE = /<[^>]+>/g;
+
+/**
+ * `anchorId` -> printed marker, for every anchor in these segments.
+ *
+ * An anchor whose marker text is empty is skipped rather than mapped to ""
+ * — callers fall back to the item's own `label`, and an empty string would
+ * silently render a note with no marker at all.
+ */
+export const anchorMarkersFromSegments = (
+  segments: SourceSegment[],
+): Map<string, string> => {
+  const markers = new Map<string, string>();
+
+  for (const segment of segments) {
+    for (const match of segment.html.matchAll(ANCHOR_RE)) {
+      const [, anchorId, rawMarker] = match;
+      if (!anchorId || markers.has(anchorId)) continue;
+
+      const marker = (rawMarker ?? "").replace(TAG_RE, "").trim();
+      if (marker.length > 0) markers.set(anchorId, marker);
+    }
+  }
+
+  return markers;
+};

--- a/tests/unit/anchor-markers.spec.ts
+++ b/tests/unit/anchor-markers.spec.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from "vitest";
+import type { SourceSegment } from "~~/shared/types/content";
+
+const segment = (n: number, html: string): SourceSegment => ({
+  n,
+  sefariaRef: `x ${n}`,
+  html,
+  anchors: [],
+});
+
+const anchor = (id: string, marker: string) =>
+  `<a class="tes-anchor" href="#${id}" data-anchor="${id}">${marker}</a>`;
+
+describe("anchorMarkersFromSegments", () => {
+  it("maps each anchor id to the marker the source text prints", () => {
+    const markers = anchorMarkersFromSegments([
+      segment(
+        1,
+        `Know that ${anchor("op-1", "1")} before ${anchor("op-2", "2")}`,
+      ),
+      segment(2, `When it arose ${anchor("op-12", "30")}`),
+    ]);
+
+    expect([...markers]).toEqual([
+      ["op-1", "1"],
+      ["op-2", "2"],
+      ["op-12", "30"],
+    ]);
+  });
+
+  it("captures the gematria markers the English edition prints (issue #96)", () => {
+    // Bnei Baruch's own English document marks the 11th note "(20)" — the
+    // gematria of כ — while its commentary list numbers that note "11".
+    const markers = anchorMarkersFromSegments([
+      segment(1, `light of Ein Sof ${anchor("op-11", "20")}`),
+      segment(3, `the triangle ${anchor("op-16", "400")}`),
+    ]);
+
+    expect(markers.get("op-11")).toBe("20");
+    expect(markers.get("op-16")).toBe("400");
+  });
+
+  it("keeps Hebrew letter markers exactly as printed", () => {
+    const markers = anchorMarkersFromSegments([
+      segment(1, `דע כי ${anchor("op-1", "א")}טרם ${anchor("op-11", "כ")}`),
+    ]);
+
+    expect(markers.get("op-1")).toBe("א");
+    expect(markers.get("op-11")).toBe("כ");
+  });
+
+  it("strips inline markup inside a marker rather than emitting tags", () => {
+    const markers = anchorMarkersFromSegments([
+      segment(1, `x <a class="tes-anchor" data-anchor="op-1"><b>7</b></a>`),
+    ]);
+
+    expect(markers.get("op-1")).toBe("7");
+  });
+
+  it("skips an empty marker so the caller falls back to the stored label", () => {
+    const markers = anchorMarkersFromSegments([
+      segment(1, `x ${anchor("op-1", "")} y ${anchor("op-2", "  ")}`),
+    ]);
+
+    expect(markers.has("op-1")).toBe(false);
+    expect(markers.has("op-2")).toBe(false);
+  });
+
+  it("keeps the first occurrence when an anchor id repeats", () => {
+    const markers = anchorMarkersFromSegments([
+      segment(1, anchor("op-1", "1")),
+      segment(2, anchor("op-1", "999")),
+    ]);
+
+    expect(markers.get("op-1")).toBe("1");
+  });
+
+  it("returns an empty map for segments with no anchors at all", () => {
+    expect(anchorMarkersFromSegments([segment(1, "plain text")]).size).toBe(0);
+    expect(anchorMarkersFromSegments([]).size).toBe(0);
+  });
+});

--- a/tests/unit/commentary-pane.spec.ts
+++ b/tests/unit/commentary-pane.spec.ts
@@ -275,4 +275,53 @@ describe("CommentaryPane", () => {
       expect(wrapper.find("#op-1").exists()).toBe(true);
     });
   });
+  describe("marker text (issue #96)", () => {
+    it("prints the marker the source text shows, not the item's stored label", async () => {
+      // Bnei Baruch's English marks the 11th note "(20)" in the Ari's text
+      // while numbering it "11" in the commentary list. The reader clicks
+      // "20", so "20" is what they must land on.
+      const wrapper = await mountSuspended(PaneContainerStub, {
+        slots: {
+          default: () =>
+            h(CommentaryPane, {
+              items,
+              anchorMarkers: new Map([
+                ["op-1", "20"],
+                ["op-2", "30"],
+              ]),
+            }),
+        },
+      });
+
+      expect(
+        wrapper.findAll(".tes-commentary-marker").map((m) => m.text()),
+      ).toEqual(["20", "30"]);
+    });
+
+    it("falls back to the stored label for an anchor the source does not print", async () => {
+      const wrapper = await mountSuspended(PaneContainerStub, {
+        slots: {
+          default: () =>
+            h(CommentaryPane, {
+              items,
+              anchorMarkers: new Map([["op-1", "20"]]),
+            }),
+        },
+      });
+
+      expect(
+        wrapper.findAll(".tes-commentary-marker").map((m) => m.text()),
+      ).toEqual(["20", "2"]);
+    });
+
+    it("uses the stored label throughout when given no markers at all", async () => {
+      const wrapper = await mountSuspended(PaneContainerStub, {
+        slots: { default: () => h(CommentaryPane, { items }) },
+      });
+
+      expect(
+        wrapper.findAll(".tes-commentary-marker").map((m) => m.text()),
+      ).toEqual(["1", "2"]);
+    });
+  });
 });


### PR DESCRIPTION
Two reader-reported problems, one root cause each.

**Clicking `(40)` in the Ari's text landed on a note labelled `13`.** Fetched
Bnei Baruch's own English document for part 1 chapter 1 (KabbalahMedia
`doc2html/vYyXn9gY`): their printed edition marks the Ari's text
`(1)…(10) (20) (30) … (400)` — the gematria values of א…ת — while numbering the
Inner Light notes themselves `1. 2. 3.` in running order. Our corpus
transcribes both faithfully; the printed edition is what disagrees with
itself, so this is **not** an import bug (#96 updated with the evidence, and
unblocked from #81).

Nothing in `content/` is changed. Instead every surface that labels a
commentary item takes its marker from whichever source version is currently on
screen (`anchorMarkersFromSegments`), falling back to the stored `label` when
the source prints none. The two panes can no longer disagree, and it stays
correct when they are in different languages — a Hebrew source pane yields
"כ" and the commentary shows "כ". Applied to `CommentaryPane`,
`InlineCommentary`, `CommentarySheet` and `OriginalStream`.

**Clicking an anchor into a folded group appeared to do nothing** — a
regression from the collapsible groups in #97. A closed `<details>` renders
its contents `display: none`, so `useHighlightedAnchor` found its target,
scrolled to a zero-height box and flashed a highlight nobody could see. It now
opens every collapsed `<details>` between the target and the pane container
before scrolling.

**Also:** the current-seif accent is now an inline-start bar, not coloured
text alone. With every group folded and the source pane at the top, a lone
teal "Seif 1" read as a selection the reader had made rather than a report of
where the other column is.

## Verification

`task check` green: 840 unit tests (up from 830, 73 files), content
validation, full generate, 5/5 e2e.

Browser, `part-01/chapter-01` at 1440px:
- 22 anchors compared source-text marker vs commentary-pane marker —
  **0 disagreements** (op-11 `20`/`20`, op-13 `40`/`40`, op-14 `50`/`50`).
- All 5 groups collapsed, then clicked `(40)` in seif 3: the Seif 3 group
  opened, the target rendered visible, the other 4 groups stayed closed.

Refs #96