### PR TITLE
fix(content): label commentary notes with the marker their own source prints

### DIFF
--- a/app/utils/anchorMarkers.ts
+++ b/app/utils/anchorMarkers.ts
@@ -1,56 +1,26 @@
 /**
  * The marker text the CURRENTLY DISPLAYED source version prints for each of
- * its anchors — so the commentary pane can label a note with the very
- * characters the reader just clicked in the Ari's text.
+ * its anchors — so every surface that labels a commentary note can use the
+ * very characters the reader sees and clicks in the Ari's text.
  *
- * Why this is needed rather than trusting `CommentaryItem.label`: the two
- * disagree, and both are faithful. Fetched from Bnei Baruch's own English
- * document for Part 1 Chapter 1 (KabbalahMedia `doc2html/vYyXn9gY`,
- * 2026-08-13), their printed edition marks the Ari's text
- * `(1)…(10) (20) (30) … (400)` — the gematria values of the Hebrew letters —
- * while numbering the Inner Light notes themselves `1. 2. 3.` in plain
- * running order. Our corpus reproduces both sides exactly: `en-bb`'s source
- * html carries "20", its `label.en` carries "11". The printed edition is
- * internally inconsistent; the import is not (see issue #96).
+ * The stored `CommentaryItem.label` now agrees with these markers —
+ * `scripts/migrate-commentary-labels.ts` corrected the committed files from
+ * this same source and `validate-content.ts`'s
+ * `checkCommentaryLabelMatchesSourceMarker` keeps them in step (issue #96).
+ * So this is no longer compensating for bad data.
  *
- * The reader can do better than the page without falsifying either file.
- * Taking the marker from whichever source version is on screen means the
- * two panes can never disagree — and it stays right when the panes are in
- * different languages, since a Hebrew source pane yields "כ" and the
- * commentary pane then shows "כ" too.
- *
- * Anchors are normalized at import time (`app/utils/anchors.ts`) to
- * `<a class="tes-anchor" data-anchor="op-N">MARKER</a>`, so a regex over the
- * committed html is sufficient and — unlike `DOMParser` — works unchanged
- * during prerender.
+ * It stays the right rule on its own terms: the marker belongs to a source
+ * VERSION, and the two panes can each be showing a different language. Taking
+ * it from whichever source is on screen means a Hebrew source pane yields
+ * "כ" and the commentary pane shows "כ" beside it, while an English source
+ * pane yields "20" and the commentary shows "20" — always the characters the
+ * reader can actually see and click.
  */
 import type { SourceSegment } from "~~/shared/types/content";
+import { anchorMarkersFromHtml } from "~~/shared/utils/anchorMarkers";
 
-const ANCHOR_RE = /<a\b[^>]*\bdata-anchor="([^"]+)"[^>]*>([\s\S]*?)<\/a>/g;
-
-const TAG_RE = /<[^>]+>/g;
-
-/**
- * `anchorId` -> printed marker, for every anchor in these segments.
- *
- * An anchor whose marker text is empty is skipped rather than mapped to ""
- * — callers fall back to the item's own `label`, and an empty string would
- * silently render a note with no marker at all.
- */
+/** `anchorId` -> the marker these segments print for it. */
 export const anchorMarkersFromSegments = (
   segments: SourceSegment[],
-): Map<string, string> => {
-  const markers = new Map<string, string>();
-
-  for (const segment of segments) {
-    for (const match of segment.html.matchAll(ANCHOR_RE)) {
-      const [, anchorId, rawMarker] = match;
-      if (!anchorId || markers.has(anchorId)) continue;
-
-      const marker = (rawMarker ?? "").replace(TAG_RE, "").trim();
-      if (marker.length > 0) markers.set(anchorId, marker);
-    }
-  }
-
-  return markers;
-};
+): Map<string, string> =>
+  anchorMarkersFromHtml(segments.map((segment) => segment.html));

--- a/content/parts/part-01/chapters/chapter-01/commentary.en-bb.json
+++ b/content/parts/part-01/chapters/chapter-01/commentary.en-bb.json
@@ -1,8 +1,8 @@
 {
   "chapterId": "part-01/chapter-01",
-  "layer": "commentary",
   "versionId": "en-bb",
   "sefariaRef": "Ohr Penimi on Talmud Eser HaSefirot 1:1",
+  "layer": "commentary",
   "items": [
     {
       "anchorId": "op-1",
@@ -129,7 +129,7 @@
       "order": 11,
       "label": {
         "he": "כ",
-        "en": "11"
+        "en": "20"
       },
       "sefariaRef": "Ohr Penimi on Talmud Eser HaSefirot 1:1:11",
       "targetSeif": 1,
@@ -141,7 +141,7 @@
       "order": 12,
       "label": {
         "he": "ל",
-        "en": "12"
+        "en": "30"
       },
       "sefariaRef": "Ohr Penimi on Talmud Eser HaSefirot 1:1:12",
       "targetSeif": 2,
@@ -153,7 +153,7 @@
       "order": 13,
       "label": {
         "he": "מ",
-        "en": "13"
+        "en": "40"
       },
       "sefariaRef": "Ohr Penimi on Talmud Eser HaSefirot 1:1:13",
       "targetSeif": 3,
@@ -165,7 +165,7 @@
       "order": 14,
       "label": {
         "he": "נ",
-        "en": "14"
+        "en": "50"
       },
       "sefariaRef": "Ohr Penimi on Talmud Eser HaSefirot 1:1:14",
       "targetSeif": 3,
@@ -177,7 +177,7 @@
       "order": 15,
       "label": {
         "he": "ס",
-        "en": "15"
+        "en": "60"
       },
       "sefariaRef": "Ohr Penimi on Talmud Eser HaSefirot 1:1:15",
       "targetSeif": 3,
@@ -189,7 +189,7 @@
       "order": 16,
       "label": {
         "he": "ע",
-        "en": "16"
+        "en": "70"
       },
       "sefariaRef": "Ohr Penimi on Talmud Eser HaSefirot 1:1:16",
       "targetSeif": 3,
@@ -201,7 +201,7 @@
       "order": 17,
       "label": {
         "he": "פ",
-        "en": "17"
+        "en": "80"
       },
       "sefariaRef": "Ohr Penimi on Talmud Eser HaSefirot 1:1:17",
       "targetSeif": 4,
@@ -213,7 +213,7 @@
       "order": 18,
       "label": {
         "he": "צ",
-        "en": "18"
+        "en": "90"
       },
       "sefariaRef": "Ohr Penimi on Talmud Eser HaSefirot 1:1:18",
       "targetSeif": 4,
@@ -225,7 +225,7 @@
       "order": 19,
       "label": {
         "he": "ק",
-        "en": "19"
+        "en": "100"
       },
       "sefariaRef": "Ohr Penimi on Talmud Eser HaSefirot 1:1:19",
       "targetSeif": 4,
@@ -237,7 +237,7 @@
       "order": 20,
       "label": {
         "he": "ר",
-        "en": "20"
+        "en": "200"
       },
       "sefariaRef": "Ohr Penimi on Talmud Eser HaSefirot 1:1:20",
       "targetSeif": 5,
@@ -249,7 +249,7 @@
       "order": 21,
       "label": {
         "he": "ש",
-        "en": "21"
+        "en": "300"
       },
       "sefariaRef": "Ohr Penimi on Talmud Eser HaSefirot 1:1:21",
       "targetSeif": 5,
@@ -261,7 +261,7 @@
       "order": 22,
       "label": {
         "he": "ת",
-        "en": "22"
+        "en": "400"
       },
       "sefariaRef": "Ohr Penimi on Talmud Eser HaSefirot 1:1:22",
       "targetSeif": 5,

--- a/content/parts/part-01/chapters/chapter-02/commentary.en-bb.json
+++ b/content/parts/part-01/chapters/chapter-02/commentary.en-bb.json
@@ -1,8 +1,8 @@
 {
   "chapterId": "part-01/chapter-02",
-  "layer": "commentary",
   "versionId": "en-bb",
   "sefariaRef": "Ohr Penimi on Talmud Eser HaSefirot 1:2",
+  "layer": "commentary",
   "items": [
     {
       "anchorId": "op-1",
@@ -129,7 +129,7 @@
       "order": 11,
       "label": {
         "he": "כ",
-        "en": "11"
+        "en": "20"
       },
       "sefariaRef": "Ohr Penimi on Talmud Eser HaSefirot 1:2:11",
       "targetSeif": 5,
@@ -141,7 +141,7 @@
       "order": 12,
       "label": {
         "he": "ל",
-        "en": "12"
+        "en": "30"
       },
       "sefariaRef": "Ohr Penimi on Talmud Eser HaSefirot 1:2:12",
       "targetSeif": 5,

--- a/content/parts/part-02/chapters/chapter-01/commentary.en-ai.json
+++ b/content/parts/part-02/chapters/chapter-01/commentary.en-ai.json
@@ -1,8 +1,8 @@
 {
   "chapterId": "part-02/chapter-01",
-  "layer": "commentary",
   "versionId": "en-ai",
   "sefariaRef": "Ohr Penimi on Talmud Eser HaSefirot 2:1",
+  "layer": "commentary",
   "items": [
     {
       "anchorId": "op-1",
@@ -249,7 +249,7 @@
       "order": 21,
       "label": {
         "he": "ת",
-        "en": "21"
+        "en": "400"
       },
       "sefariaRef": "Ohr Penimi on Talmud Eser HaSefirot 2:1:21",
       "targetSeif": 5,
@@ -261,7 +261,7 @@
       "order": 22,
       "label": {
         "he": "א",
-        "en": "22"
+        "en": "1"
       },
       "sefariaRef": "Ohr Penimi on Talmud Eser HaSefirot 2:1:22",
       "targetSeif": 5,
@@ -273,7 +273,7 @@
       "order": 23,
       "label": {
         "he": "ב",
-        "en": "23"
+        "en": "2"
       },
       "sefariaRef": "Ohr Penimi on Talmud Eser HaSefirot 2:1:23",
       "targetSeif": 5,
@@ -285,7 +285,7 @@
       "order": 24,
       "label": {
         "he": "ג",
-        "en": "24"
+        "en": "3"
       },
       "sefariaRef": "Ohr Penimi on Talmud Eser HaSefirot 2:1:24",
       "targetSeif": 6,
@@ -297,7 +297,7 @@
       "order": 25,
       "label": {
         "he": "ד",
-        "en": "25"
+        "en": "4"
       },
       "sefariaRef": "Ohr Penimi on Talmud Eser HaSefirot 2:1:25",
       "targetSeif": 6,
@@ -309,7 +309,7 @@
       "order": 26,
       "label": {
         "he": "ה",
-        "en": "26"
+        "en": "5"
       },
       "sefariaRef": "Ohr Penimi on Talmud Eser HaSefirot 2:1:26",
       "targetSeif": 6,
@@ -321,7 +321,7 @@
       "order": 27,
       "label": {
         "he": "ו",
-        "en": "27"
+        "en": "6"
       },
       "sefariaRef": "Ohr Penimi on Talmud Eser HaSefirot 2:1:27",
       "targetSeif": 6,
@@ -333,7 +333,7 @@
       "order": 28,
       "label": {
         "he": "ז",
-        "en": "28"
+        "en": "7"
       },
       "sefariaRef": "Ohr Penimi on Talmud Eser HaSefirot 2:1:28",
       "targetSeif": 6,
@@ -345,7 +345,7 @@
       "order": 29,
       "label": {
         "he": "ח",
-        "en": "29"
+        "en": "8"
       },
       "sefariaRef": "Ohr Penimi on Talmud Eser HaSefirot 2:1:29",
       "targetSeif": 7,
@@ -357,7 +357,7 @@
       "order": 30,
       "label": {
         "he": "ט",
-        "en": "30"
+        "en": "9"
       },
       "sefariaRef": "Ohr Penimi on Talmud Eser HaSefirot 2:1:30",
       "targetSeif": 7,
@@ -369,7 +369,7 @@
       "order": 31,
       "label": {
         "he": "י",
-        "en": "31"
+        "en": "10"
       },
       "sefariaRef": "Ohr Penimi on Talmud Eser HaSefirot 2:1:31",
       "targetSeif": 8,

--- a/content/parts/part-02/chapters/chapter-02/commentary.en-ai.json
+++ b/content/parts/part-02/chapters/chapter-02/commentary.en-ai.json
@@ -1,8 +1,8 @@
 {
   "chapterId": "part-02/chapter-02",
-  "layer": "commentary",
   "versionId": "en-ai",
   "sefariaRef": "Ohr Penimi on Talmud Eser HaSefirot 2:2",
+  "layer": "commentary",
   "items": [
     {
       "anchorId": "op-1",
@@ -261,7 +261,7 @@
       "order": 22,
       "label": {
         "he": "ת",
-        "en": "22"
+        "en": "400"
       },
       "sefariaRef": "Ohr Penimi on Talmud Eser HaSefirot 2:2:22",
       "targetSeif": 6,
@@ -273,7 +273,7 @@
       "order": 23,
       "label": {
         "he": "א",
-        "en": "23"
+        "en": "1"
       },
       "sefariaRef": "Ohr Penimi on Talmud Eser HaSefirot 2:2:23",
       "targetSeif": 6,
@@ -285,7 +285,7 @@
       "order": 24,
       "label": {
         "he": "ב",
-        "en": "24"
+        "en": "2"
       },
       "sefariaRef": "Ohr Penimi on Talmud Eser HaSefirot 2:2:24",
       "targetSeif": 6,
@@ -297,7 +297,7 @@
       "order": 25,
       "label": {
         "he": "ג",
-        "en": "25"
+        "en": "3"
       },
       "sefariaRef": "Ohr Penimi on Talmud Eser HaSefirot 2:2:25",
       "targetSeif": 7,
@@ -309,7 +309,7 @@
       "order": 26,
       "label": {
         "he": "ד",
-        "en": "26"
+        "en": "4"
       },
       "sefariaRef": "Ohr Penimi on Talmud Eser HaSefirot 2:2:26",
       "targetSeif": 7,
@@ -321,7 +321,7 @@
       "order": 27,
       "label": {
         "he": "ה",
-        "en": "27"
+        "en": "5"
       },
       "sefariaRef": "Ohr Penimi on Talmud Eser HaSefirot 2:2:27",
       "targetSeif": 7,

--- a/content/parts/part-03/chapters/chapter-01/commentary.en-ai.json
+++ b/content/parts/part-03/chapters/chapter-01/commentary.en-ai.json
@@ -1,8 +1,8 @@
 {
   "chapterId": "part-03/chapter-01",
-  "layer": "commentary",
   "versionId": "en-ai",
   "sefariaRef": "Ohr Penimi on Talmud Eser HaSefirot 3:1",
+  "layer": "commentary",
   "items": [
     {
       "anchorId": "op-1",
@@ -129,7 +129,7 @@
       "order": 11,
       "label": {
         "he": "כ",
-        "en": "11"
+        "en": "20"
       },
       "sefariaRef": "Ohr Penimi on Talmud Eser HaSefirot 3:1:11",
       "targetSeif": 2,
@@ -141,7 +141,7 @@
       "order": 12,
       "label": {
         "he": "ל",
-        "en": "12"
+        "en": "30"
       },
       "sefariaRef": "Ohr Penimi on Talmud Eser HaSefirot 3:1:12",
       "targetSeif": 2,
@@ -153,7 +153,7 @@
       "order": 13,
       "label": {
         "he": "מ",
-        "en": "13"
+        "en": "40"
       },
       "sefariaRef": "Ohr Penimi on Talmud Eser HaSefirot 3:1:13",
       "targetSeif": 2,
@@ -165,7 +165,7 @@
       "order": 14,
       "label": {
         "he": "נ",
-        "en": "14"
+        "en": "50"
       },
       "sefariaRef": "Ohr Penimi on Talmud Eser HaSefirot 3:1:14",
       "targetSeif": 2,
@@ -177,7 +177,7 @@
       "order": 15,
       "label": {
         "he": "ס",
-        "en": "15"
+        "en": "60"
       },
       "sefariaRef": "Ohr Penimi on Talmud Eser HaSefirot 3:1:15",
       "targetSeif": 2,
@@ -189,7 +189,7 @@
       "order": 16,
       "label": {
         "he": "ע",
-        "en": "16"
+        "en": "70"
       },
       "sefariaRef": "Ohr Penimi on Talmud Eser HaSefirot 3:1:16",
       "targetSeif": 3,
@@ -201,7 +201,7 @@
       "order": 17,
       "label": {
         "he": "פ",
-        "en": "17"
+        "en": "80"
       },
       "sefariaRef": "Ohr Penimi on Talmud Eser HaSefirot 3:1:17",
       "targetSeif": 3,
@@ -213,7 +213,7 @@
       "order": 18,
       "label": {
         "he": "צ",
-        "en": "18"
+        "en": "90"
       },
       "sefariaRef": "Ohr Penimi on Talmud Eser HaSefirot 3:1:18",
       "targetSeif": 3,
@@ -225,7 +225,7 @@
       "order": 19,
       "label": {
         "he": "ק",
-        "en": "19"
+        "en": "100"
       },
       "sefariaRef": "Ohr Penimi on Talmud Eser HaSefirot 3:1:19",
       "targetSeif": 3,
@@ -237,7 +237,7 @@
       "order": 20,
       "label": {
         "he": "ר",
-        "en": "20"
+        "en": "200"
       },
       "sefariaRef": "Ohr Penimi on Talmud Eser HaSefirot 3:1:20",
       "targetSeif": 3,
@@ -249,7 +249,7 @@
       "order": 21,
       "label": {
         "he": "ש",
-        "en": "21"
+        "en": "300"
       },
       "sefariaRef": "Ohr Penimi on Talmud Eser HaSefirot 3:1:21",
       "targetSeif": 3,
@@ -261,7 +261,7 @@
       "order": 22,
       "label": {
         "he": "ת",
-        "en": "22"
+        "en": "400"
       },
       "sefariaRef": "Ohr Penimi on Talmud Eser HaSefirot 3:1:22",
       "targetSeif": 3,
@@ -273,7 +273,7 @@
       "order": 23,
       "label": {
         "he": "א",
-        "en": "23"
+        "en": "1"
       },
       "sefariaRef": "Ohr Penimi on Talmud Eser HaSefirot 3:1:23",
       "targetSeif": 4,
@@ -285,7 +285,7 @@
       "order": 24,
       "label": {
         "he": "ב",
-        "en": "24"
+        "en": "2"
       },
       "sefariaRef": "Ohr Penimi on Talmud Eser HaSefirot 3:1:24",
       "targetSeif": 4,
@@ -297,7 +297,7 @@
       "order": 25,
       "label": {
         "he": "ג",
-        "en": "25"
+        "en": "3"
       },
       "sefariaRef": "Ohr Penimi on Talmud Eser HaSefirot 3:1:25",
       "targetSeif": 4,
@@ -309,7 +309,7 @@
       "order": 26,
       "label": {
         "he": "ד",
-        "en": "26"
+        "en": "4"
       },
       "sefariaRef": "Ohr Penimi on Talmud Eser HaSefirot 3:1:26",
       "targetSeif": 4,
@@ -321,7 +321,7 @@
       "order": 27,
       "label": {
         "he": "ה",
-        "en": "27"
+        "en": "5"
       },
       "sefariaRef": "Ohr Penimi on Talmud Eser HaSefirot 3:1:27",
       "targetSeif": 4,
@@ -333,7 +333,7 @@
       "order": 28,
       "label": {
         "he": "ו",
-        "en": "28"
+        "en": "6"
       },
       "sefariaRef": "Ohr Penimi on Talmud Eser HaSefirot 3:1:28",
       "targetSeif": 4,
@@ -345,7 +345,7 @@
       "order": 29,
       "label": {
         "he": "ז",
-        "en": "29"
+        "en": "7"
       },
       "sefariaRef": "Ohr Penimi on Talmud Eser HaSefirot 3:1:29",
       "targetSeif": 4,
@@ -357,7 +357,7 @@
       "order": 30,
       "label": {
         "he": "ח",
-        "en": "30"
+        "en": "8"
       },
       "sefariaRef": "Ohr Penimi on Talmud Eser HaSefirot 3:1:30",
       "targetSeif": 4,
@@ -369,7 +369,7 @@
       "order": 31,
       "label": {
         "he": "ט",
-        "en": "31"
+        "en": "9"
       },
       "sefariaRef": "Ohr Penimi on Talmud Eser HaSefirot 3:1:31",
       "targetSeif": 4,

--- a/content/parts/part-03/chapters/chapter-04/commentary.en-ai.json
+++ b/content/parts/part-03/chapters/chapter-04/commentary.en-ai.json
@@ -1,8 +1,8 @@
 {
   "chapterId": "part-03/chapter-04",
-  "layer": "commentary",
   "versionId": "en-ai",
   "sefariaRef": "Ohr Penimi on Talmud Eser HaSefirot 3:4",
+  "layer": "commentary",
   "items": [
     {
       "anchorId": "op-1",
@@ -129,7 +129,7 @@
       "order": 11,
       "label": {
         "he": "כ",
-        "en": "11"
+        "en": "20"
       },
       "sefariaRef": "Ohr Penimi on Talmud Eser HaSefirot 3:4:11",
       "targetSeif": 4,
@@ -141,7 +141,7 @@
       "order": 12,
       "label": {
         "he": "ל",
-        "en": "12"
+        "en": "30"
       },
       "sefariaRef": "Ohr Penimi on Talmud Eser HaSefirot 3:4:12",
       "targetSeif": 4,
@@ -153,7 +153,7 @@
       "order": 13,
       "label": {
         "he": "מ",
-        "en": "13"
+        "en": "40"
       },
       "sefariaRef": "Ohr Penimi on Talmud Eser HaSefirot 3:4:13",
       "targetSeif": 4,
@@ -165,7 +165,7 @@
       "order": 14,
       "label": {
         "he": "נ",
-        "en": "14"
+        "en": "50"
       },
       "sefariaRef": "Ohr Penimi on Talmud Eser HaSefirot 3:4:14",
       "targetSeif": 6,
@@ -177,7 +177,7 @@
       "order": 15,
       "label": {
         "he": "ס",
-        "en": "15"
+        "en": "60"
       },
       "sefariaRef": "Ohr Penimi on Talmud Eser HaSefirot 3:4:15",
       "targetSeif": 6,
@@ -189,7 +189,7 @@
       "order": 16,
       "label": {
         "he": "ע",
-        "en": "16"
+        "en": "70"
       },
       "sefariaRef": "Ohr Penimi on Talmud Eser HaSefirot 3:4:16",
       "targetSeif": 7,
@@ -201,7 +201,7 @@
       "order": 17,
       "label": {
         "he": "פ",
-        "en": "17"
+        "en": "80"
       },
       "sefariaRef": "Ohr Penimi on Talmud Eser HaSefirot 3:4:17",
       "targetSeif": 7,
@@ -213,7 +213,7 @@
       "order": 18,
       "label": {
         "he": "צ",
-        "en": "18"
+        "en": "90"
       },
       "sefariaRef": "Ohr Penimi on Talmud Eser HaSefirot 3:4:18",
       "targetSeif": 7,
@@ -225,7 +225,7 @@
       "order": 19,
       "label": {
         "he": "ק",
-        "en": "19"
+        "en": "100"
       },
       "sefariaRef": "Ohr Penimi on Talmud Eser HaSefirot 3:4:19",
       "targetSeif": 8,
@@ -237,7 +237,7 @@
       "order": 20,
       "label": {
         "he": "ר",
-        "en": "20"
+        "en": "200"
       },
       "sefariaRef": "Ohr Penimi on Talmud Eser HaSefirot 3:4:20",
       "targetSeif": 8,
@@ -249,7 +249,7 @@
       "order": 21,
       "label": {
         "he": "ש",
-        "en": "21"
+        "en": "300"
       },
       "sefariaRef": "Ohr Penimi on Talmud Eser HaSefirot 3:4:21",
       "targetSeif": 9,

--- a/content/parts/part-03/chapters/chapter-05/commentary.en-ai.json
+++ b/content/parts/part-03/chapters/chapter-05/commentary.en-ai.json
@@ -1,8 +1,8 @@
 {
   "chapterId": "part-03/chapter-05",
-  "layer": "commentary",
   "versionId": "en-ai",
   "sefariaRef": "Ohr Penimi on Talmud Eser HaSefirot 3:5",
+  "layer": "commentary",
   "items": [
     {
       "anchorId": "op-1",
@@ -129,7 +129,7 @@
       "order": 11,
       "label": {
         "he": "כ",
-        "en": "11"
+        "en": "20"
       },
       "sefariaRef": "Ohr Penimi on Talmud Eser HaSefirot 3:5:11",
       "targetSeif": 5,
@@ -141,7 +141,7 @@
       "order": 12,
       "label": {
         "he": "ל",
-        "en": "12"
+        "en": "30"
       },
       "sefariaRef": "Ohr Penimi on Talmud Eser HaSefirot 3:5:12",
       "targetSeif": 5,
@@ -153,7 +153,7 @@
       "order": 13,
       "label": {
         "he": "מ",
-        "en": "13"
+        "en": "40"
       },
       "sefariaRef": "Ohr Penimi on Talmud Eser HaSefirot 3:5:13",
       "targetSeif": 5,
@@ -165,7 +165,7 @@
       "order": 14,
       "label": {
         "he": "נ",
-        "en": "14"
+        "en": "50"
       },
       "sefariaRef": "Ohr Penimi on Talmud Eser HaSefirot 3:5:14",
       "targetSeif": 6,

--- a/content/parts/part-03/chapters/chapter-11/commentary.en-ai.json
+++ b/content/parts/part-03/chapters/chapter-11/commentary.en-ai.json
@@ -1,8 +1,8 @@
 {
   "chapterId": "part-03/chapter-11",
-  "layer": "commentary",
   "versionId": "en-ai",
   "sefariaRef": "Ohr Penimi on Talmud Eser HaSefirot 3:11",
+  "layer": "commentary",
   "items": [
     {
       "anchorId": "op-1",
@@ -129,7 +129,7 @@
       "order": 11,
       "label": {
         "he": "כ",
-        "en": "11"
+        "en": "20"
       },
       "sefariaRef": "Ohr Penimi on Talmud Eser HaSefirot 3:11:11",
       "targetSeif": 8,

--- a/content/parts/part-03/chapters/chapter-12/commentary.en-ai.json
+++ b/content/parts/part-03/chapters/chapter-12/commentary.en-ai.json
@@ -1,8 +1,8 @@
 {
   "chapterId": "part-03/chapter-12",
-  "layer": "commentary",
   "versionId": "en-ai",
   "sefariaRef": "Ohr Penimi on Talmud Eser HaSefirot 3:12",
+  "layer": "commentary",
   "items": [
     {
       "anchorId": "op-1",
@@ -129,7 +129,7 @@
       "order": 11,
       "label": {
         "he": "כ",
-        "en": "11"
+        "en": "20"
       },
       "sefariaRef": "Ohr Penimi on Talmud Eser HaSefirot 3:12:11",
       "targetSeif": 7,
@@ -141,7 +141,7 @@
       "order": 12,
       "label": {
         "he": "ל",
-        "en": "12"
+        "en": "30"
       },
       "sefariaRef": "Ohr Penimi on Talmud Eser HaSefirot 3:12:12",
       "targetSeif": 7,
@@ -153,7 +153,7 @@
       "order": 13,
       "label": {
         "he": "מ",
-        "en": "13"
+        "en": "40"
       },
       "sefariaRef": "Ohr Penimi on Talmud Eser HaSefirot 3:12:13",
       "targetSeif": 7,
@@ -165,7 +165,7 @@
       "order": 14,
       "label": {
         "he": "נ",
-        "en": "14"
+        "en": "50"
       },
       "sefariaRef": "Ohr Penimi on Talmud Eser HaSefirot 3:12:14",
       "targetSeif": 7,
@@ -177,7 +177,7 @@
       "order": 15,
       "label": {
         "he": "ס",
-        "en": "15"
+        "en": "60"
       },
       "sefariaRef": "Ohr Penimi on Talmud Eser HaSefirot 3:12:15",
       "targetSeif": 7,
@@ -189,7 +189,7 @@
       "order": 16,
       "label": {
         "he": "ע",
-        "en": "16"
+        "en": "70"
       },
       "sefariaRef": "Ohr Penimi on Talmud Eser HaSefirot 3:12:16",
       "targetSeif": 7,

--- a/content/parts/part-04/chapters/chapter-01/commentary.en-ai.json
+++ b/content/parts/part-04/chapters/chapter-01/commentary.en-ai.json
@@ -1,8 +1,8 @@
 {
   "chapterId": "part-04/chapter-01",
-  "layer": "commentary",
   "versionId": "en-ai",
   "sefariaRef": "Ohr Penimi on Talmud Eser HaSefirot 4:1",
+  "layer": "commentary",
   "items": [
     {
       "anchorId": "op-1",
@@ -129,7 +129,7 @@
       "order": 11,
       "label": {
         "he": "כ",
-        "en": "11"
+        "en": "20"
       },
       "sefariaRef": "Ohr Penimi on Talmud Eser HaSefirot 4:1:11",
       "targetSeif": 5,
@@ -141,7 +141,7 @@
       "order": 12,
       "label": {
         "he": "ל",
-        "en": "12"
+        "en": "30"
       },
       "sefariaRef": "Ohr Penimi on Talmud Eser HaSefirot 4:1:12",
       "targetSeif": 5,
@@ -153,7 +153,7 @@
       "order": 13,
       "label": {
         "he": "מ",
-        "en": "13"
+        "en": "40"
       },
       "sefariaRef": "Ohr Penimi on Talmud Eser HaSefirot 4:1:13",
       "targetSeif": 7,
@@ -165,7 +165,7 @@
       "order": 14,
       "label": {
         "he": "נ",
-        "en": "14"
+        "en": "50"
       },
       "sefariaRef": "Ohr Penimi on Talmud Eser HaSefirot 4:1:14",
       "targetSeif": 7,
@@ -177,7 +177,7 @@
       "order": 15,
       "label": {
         "he": "ס",
-        "en": "15"
+        "en": "60"
       },
       "sefariaRef": "Ohr Penimi on Talmud Eser HaSefirot 4:1:15",
       "targetSeif": 7,
@@ -189,7 +189,7 @@
       "order": 16,
       "label": {
         "he": "ע",
-        "en": "16"
+        "en": "70"
       },
       "sefariaRef": "Ohr Penimi on Talmud Eser HaSefirot 4:1:16",
       "targetSeif": 7,
@@ -201,7 +201,7 @@
       "order": 17,
       "label": {
         "he": "פ",
-        "en": "17"
+        "en": "80"
       },
       "sefariaRef": "Ohr Penimi on Talmud Eser HaSefirot 4:1:17",
       "targetSeif": 8,
@@ -213,7 +213,7 @@
       "order": 18,
       "label": {
         "he": "צ",
-        "en": "18"
+        "en": "90"
       },
       "sefariaRef": "Ohr Penimi on Talmud Eser HaSefirot 4:1:18",
       "targetSeif": 8,
@@ -225,7 +225,7 @@
       "order": 19,
       "label": {
         "he": "ק",
-        "en": "19"
+        "en": "100"
       },
       "sefariaRef": "Ohr Penimi on Talmud Eser HaSefirot 4:1:19",
       "targetSeif": 8,
@@ -237,7 +237,7 @@
       "order": 20,
       "label": {
         "he": "ר",
-        "en": "20"
+        "en": "200"
       },
       "sefariaRef": "Ohr Penimi on Talmud Eser HaSefirot 4:1:20",
       "targetSeif": 9,
@@ -249,7 +249,7 @@
       "order": 21,
       "label": {
         "he": "ש",
-        "en": "21"
+        "en": "300"
       },
       "sefariaRef": "Ohr Penimi on Talmud Eser HaSefirot 4:1:21",
       "targetSeif": 10,
@@ -261,7 +261,7 @@
       "order": 22,
       "label": {
         "he": "ת",
-        "en": "22"
+        "en": "400"
       },
       "sefariaRef": "Ohr Penimi on Talmud Eser HaSefirot 4:1:22",
       "targetSeif": 11,

--- a/content/parts/part-04/chapters/chapter-02/commentary.en-ai.json
+++ b/content/parts/part-04/chapters/chapter-02/commentary.en-ai.json
@@ -1,8 +1,8 @@
 {
   "chapterId": "part-04/chapter-02",
-  "layer": "commentary",
   "versionId": "en-ai",
   "sefariaRef": "Ohr Penimi on Talmud Eser HaSefirot 4:2",
+  "layer": "commentary",
   "items": [
     {
       "anchorId": "op-1",
@@ -129,7 +129,7 @@
       "order": 11,
       "label": {
         "he": "כ",
-        "en": "11"
+        "en": "20"
       },
       "sefariaRef": "Ohr Penimi on Talmud Eser HaSefirot 4:2:11",
       "targetSeif": 10,

--- a/content/parts/part-04/chapters/chapter-03/commentary.en-ai.json
+++ b/content/parts/part-04/chapters/chapter-03/commentary.en-ai.json
@@ -1,8 +1,8 @@
 {
   "chapterId": "part-04/chapter-03",
-  "layer": "commentary",
   "versionId": "en-ai",
   "sefariaRef": "Ohr Penimi on Talmud Eser HaSefirot 4:3",
+  "layer": "commentary",
   "items": [
     {
       "anchorId": "op-1",
@@ -129,7 +129,7 @@
       "order": 11,
       "label": {
         "he": "כ",
-        "en": "11"
+        "en": "20"
       },
       "sefariaRef": "Ohr Penimi on Talmud Eser HaSefirot 4:3:11",
       "targetSeif": 9,
@@ -141,7 +141,7 @@
       "order": 12,
       "label": {
         "he": "ל",
-        "en": "12"
+        "en": "30"
       },
       "sefariaRef": "Ohr Penimi on Talmud Eser HaSefirot 4:3:12",
       "targetSeif": 9,
@@ -153,7 +153,7 @@
       "order": 13,
       "label": {
         "he": "מ",
-        "en": "13"
+        "en": "40"
       },
       "sefariaRef": "Ohr Penimi on Talmud Eser HaSefirot 4:3:13",
       "targetSeif": 9,
@@ -165,7 +165,7 @@
       "order": 14,
       "label": {
         "he": "נ",
-        "en": "14"
+        "en": "50"
       },
       "sefariaRef": "Ohr Penimi on Talmud Eser HaSefirot 4:3:14",
       "targetSeif": 10,
@@ -177,7 +177,7 @@
       "order": 15,
       "label": {
         "he": "ס",
-        "en": "15"
+        "en": "60"
       },
       "sefariaRef": "Ohr Penimi on Talmud Eser HaSefirot 4:3:15",
       "targetSeif": 10,
@@ -189,7 +189,7 @@
       "order": 16,
       "label": {
         "he": "ע",
-        "en": "16"
+        "en": "70"
       },
       "sefariaRef": "Ohr Penimi on Talmud Eser HaSefirot 4:3:16",
       "targetSeif": 10,
@@ -201,7 +201,7 @@
       "order": 17,
       "label": {
         "he": "פ",
-        "en": "17"
+        "en": "80"
       },
       "sefariaRef": "Ohr Penimi on Talmud Eser HaSefirot 4:3:17",
       "targetSeif": 10,
@@ -213,7 +213,7 @@
       "order": 18,
       "label": {
         "he": "צ",
-        "en": "18"
+        "en": "90"
       },
       "sefariaRef": "Ohr Penimi on Talmud Eser HaSefirot 4:3:18",
       "targetSeif": 12,
@@ -225,7 +225,7 @@
       "order": 19,
       "label": {
         "he": "ק",
-        "en": "19"
+        "en": "100"
       },
       "sefariaRef": "Ohr Penimi on Talmud Eser HaSefirot 4:3:19",
       "targetSeif": 13,
@@ -237,7 +237,7 @@
       "order": 20,
       "label": {
         "he": "ר",
-        "en": "20"
+        "en": "200"
       },
       "sefariaRef": "Ohr Penimi on Talmud Eser HaSefirot 4:3:20",
       "targetSeif": 13,

--- a/content/parts/part-04/chapters/chapter-04/commentary.en-ai.json
+++ b/content/parts/part-04/chapters/chapter-04/commentary.en-ai.json
@@ -1,8 +1,8 @@
 {
   "chapterId": "part-04/chapter-04",
-  "layer": "commentary",
   "versionId": "en-ai",
   "sefariaRef": "Ohr Penimi on Talmud Eser HaSefirot 4:4",
+  "layer": "commentary",
   "items": [
     {
       "anchorId": "op-1",
@@ -129,7 +129,7 @@
       "order": 11,
       "label": {
         "he": "כ",
-        "en": "11"
+        "en": "20"
       },
       "sefariaRef": "Ohr Penimi on Talmud Eser HaSefirot 4:4:11",
       "targetSeif": 5,
@@ -141,7 +141,7 @@
       "order": 12,
       "label": {
         "he": "ל",
-        "en": "12"
+        "en": "30"
       },
       "sefariaRef": "Ohr Penimi on Talmud Eser HaSefirot 4:4:12",
       "targetSeif": 5,
@@ -153,7 +153,7 @@
       "order": 13,
       "label": {
         "he": "מ",
-        "en": "13"
+        "en": "40"
       },
       "sefariaRef": "Ohr Penimi on Talmud Eser HaSefirot 4:4:13",
       "targetSeif": 5,
@@ -165,7 +165,7 @@
       "order": 14,
       "label": {
         "he": "נ",
-        "en": "14"
+        "en": "50"
       },
       "sefariaRef": "Ohr Penimi on Talmud Eser HaSefirot 4:4:14",
       "targetSeif": 6,
@@ -177,7 +177,7 @@
       "order": 15,
       "label": {
         "he": "ס",
-        "en": "15"
+        "en": "60"
       },
       "sefariaRef": "Ohr Penimi on Talmud Eser HaSefirot 4:4:15",
       "targetSeif": 6,
@@ -189,7 +189,7 @@
       "order": 16,
       "label": {
         "he": "ע",
-        "en": "16"
+        "en": "70"
       },
       "sefariaRef": "Ohr Penimi on Talmud Eser HaSefirot 4:4:16",
       "targetSeif": 6,
@@ -201,7 +201,7 @@
       "order": 17,
       "label": {
         "he": "פ",
-        "en": "17"
+        "en": "80"
       },
       "sefariaRef": "Ohr Penimi on Talmud Eser HaSefirot 4:4:17",
       "targetSeif": 6,
@@ -213,7 +213,7 @@
       "order": 18,
       "label": {
         "he": "צ",
-        "en": "18"
+        "en": "90"
       },
       "sefariaRef": "Ohr Penimi on Talmud Eser HaSefirot 4:4:18",
       "targetSeif": 6,
@@ -225,7 +225,7 @@
       "order": 19,
       "label": {
         "he": "ק",
-        "en": "19"
+        "en": "100"
       },
       "sefariaRef": "Ohr Penimi on Talmud Eser HaSefirot 4:4:19",
       "targetSeif": 6,
@@ -237,7 +237,7 @@
       "order": 20,
       "label": {
         "he": "ר",
-        "en": "20"
+        "en": "200"
       },
       "sefariaRef": "Ohr Penimi on Talmud Eser HaSefirot 4:4:20",
       "targetSeif": 6,
@@ -249,7 +249,7 @@
       "order": 21,
       "label": {
         "he": "ש",
-        "en": "21"
+        "en": "300"
       },
       "sefariaRef": "Ohr Penimi on Talmud Eser HaSefirot 4:4:21",
       "targetSeif": 7,
@@ -261,7 +261,7 @@
       "order": 22,
       "label": {
         "he": "ת",
-        "en": "22"
+        "en": "400"
       },
       "sefariaRef": "Ohr Penimi on Talmud Eser HaSefirot 4:4:22",
       "targetSeif": 8,

--- a/content/parts/part-04/chapters/chapter-05/commentary.en-ai.json
+++ b/content/parts/part-04/chapters/chapter-05/commentary.en-ai.json
@@ -1,8 +1,8 @@
 {
   "chapterId": "part-04/chapter-05",
-  "layer": "commentary",
   "versionId": "en-ai",
   "sefariaRef": "Ohr Penimi on Talmud Eser HaSefirot 4:5",
+  "layer": "commentary",
   "items": [
     {
       "anchorId": "op-1",
@@ -129,7 +129,7 @@
       "order": 11,
       "label": {
         "he": "כ",
-        "en": "11"
+        "en": "20"
       },
       "sefariaRef": "Ohr Penimi on Talmud Eser HaSefirot 4:5:11",
       "targetSeif": 4,
@@ -141,7 +141,7 @@
       "order": 12,
       "label": {
         "he": "ל",
-        "en": "12"
+        "en": "30"
       },
       "sefariaRef": "Ohr Penimi on Talmud Eser HaSefirot 4:5:12",
       "targetSeif": 5,
@@ -153,7 +153,7 @@
       "order": 13,
       "label": {
         "he": "מ",
-        "en": "13"
+        "en": "40"
       },
       "sefariaRef": "Ohr Penimi on Talmud Eser HaSefirot 4:5:13",
       "targetSeif": 5,
@@ -165,7 +165,7 @@
       "order": 14,
       "label": {
         "he": "נ",
-        "en": "14"
+        "en": "50"
       },
       "sefariaRef": "Ohr Penimi on Talmud Eser HaSefirot 4:5:14",
       "targetSeif": 6,
@@ -177,7 +177,7 @@
       "order": 15,
       "label": {
         "he": "ס",
-        "en": "15"
+        "en": "60"
       },
       "sefariaRef": "Ohr Penimi on Talmud Eser HaSefirot 4:5:15",
       "targetSeif": 6,
@@ -189,7 +189,7 @@
       "order": 16,
       "label": {
         "he": "ע",
-        "en": "16"
+        "en": "70"
       },
       "sefariaRef": "Ohr Penimi on Talmud Eser HaSefirot 4:5:16",
       "targetSeif": 6,
@@ -201,7 +201,7 @@
       "order": 17,
       "label": {
         "he": "פ",
-        "en": "17"
+        "en": "80"
       },
       "sefariaRef": "Ohr Penimi on Talmud Eser HaSefirot 4:5:17",
       "targetSeif": 7,
@@ -213,7 +213,7 @@
       "order": 18,
       "label": {
         "he": "צ",
-        "en": "18"
+        "en": "90"
       },
       "sefariaRef": "Ohr Penimi on Talmud Eser HaSefirot 4:5:18",
       "targetSeif": 7,
@@ -225,7 +225,7 @@
       "order": 19,
       "label": {
         "he": "ק",
-        "en": "19"
+        "en": "100"
       },
       "sefariaRef": "Ohr Penimi on Talmud Eser HaSefirot 4:5:19",
       "targetSeif": 8,
@@ -237,7 +237,7 @@
       "order": 20,
       "label": {
         "he": "ר",
-        "en": "20"
+        "en": "200"
       },
       "sefariaRef": "Ohr Penimi on Talmud Eser HaSefirot 4:5:20",
       "targetSeif": 8,

--- a/content/parts/part-04/chapters/chapter-06/commentary.en-ai.json
+++ b/content/parts/part-04/chapters/chapter-06/commentary.en-ai.json
@@ -1,8 +1,8 @@
 {
   "chapterId": "part-04/chapter-06",
-  "layer": "commentary",
   "versionId": "en-ai",
   "sefariaRef": "Ohr Penimi on Talmud Eser HaSefirot 4:6",
+  "layer": "commentary",
   "items": [
     {
       "anchorId": "op-1",
@@ -129,7 +129,7 @@
       "order": 11,
       "label": {
         "he": "כ",
-        "en": "11"
+        "en": "20"
       },
       "sefariaRef": "Ohr Penimi on Talmud Eser HaSefirot 4:6:11",
       "targetSeif": 3,
@@ -141,7 +141,7 @@
       "order": 12,
       "label": {
         "he": "ל",
-        "en": "12"
+        "en": "30"
       },
       "sefariaRef": "Ohr Penimi on Talmud Eser HaSefirot 4:6:12",
       "targetSeif": 4,
@@ -153,7 +153,7 @@
       "order": 13,
       "label": {
         "he": "מ",
-        "en": "13"
+        "en": "40"
       },
       "sefariaRef": "Ohr Penimi on Talmud Eser HaSefirot 4:6:13",
       "targetSeif": 6,
@@ -165,7 +165,7 @@
       "order": 14,
       "label": {
         "he": "נ",
-        "en": "14"
+        "en": "50"
       },
       "sefariaRef": "Ohr Penimi on Talmud Eser HaSefirot 4:6:14",
       "targetSeif": 6,
@@ -177,7 +177,7 @@
       "order": 15,
       "label": {
         "he": "ס",
-        "en": "15"
+        "en": "60"
       },
       "sefariaRef": "Ohr Penimi on Talmud Eser HaSefirot 4:6:15",
       "targetSeif": 6,
@@ -189,7 +189,7 @@
       "order": 16,
       "label": {
         "he": "ע",
-        "en": "16"
+        "en": "70"
       },
       "sefariaRef": "Ohr Penimi on Talmud Eser HaSefirot 4:6:16",
       "targetSeif": 7,
@@ -201,7 +201,7 @@
       "order": 17,
       "label": {
         "he": "פ",
-        "en": "17"
+        "en": "80"
       },
       "sefariaRef": "Ohr Penimi on Talmud Eser HaSefirot 4:6:17",
       "targetSeif": 8,
@@ -213,7 +213,7 @@
       "order": 18,
       "label": {
         "he": "צ",
-        "en": "18"
+        "en": "90"
       },
       "sefariaRef": "Ohr Penimi on Talmud Eser HaSefirot 4:6:18",
       "targetSeif": 8,
@@ -225,7 +225,7 @@
       "order": 19,
       "label": {
         "he": "ק",
-        "en": "19"
+        "en": "100"
       },
       "sefariaRef": "Ohr Penimi on Talmud Eser HaSefirot 4:6:19",
       "targetSeif": 10,
@@ -237,7 +237,7 @@
       "order": 20,
       "label": {
         "he": "ר",
-        "en": "20"
+        "en": "200"
       },
       "sefariaRef": "Ohr Penimi on Talmud Eser HaSefirot 4:6:20",
       "targetSeif": 11,
@@ -249,7 +249,7 @@
       "order": 21,
       "label": {
         "he": "ש",
-        "en": "21"
+        "en": "300"
       },
       "sefariaRef": "Ohr Penimi on Talmud Eser HaSefirot 4:6:21",
       "targetSeif": 12,
@@ -261,7 +261,7 @@
       "order": 22,
       "label": {
         "he": "ת",
-        "en": "22"
+        "en": "400"
       },
       "sefariaRef": "Ohr Penimi on Talmud Eser HaSefirot 4:6:22",
       "targetSeif": 14,
@@ -273,7 +273,7 @@
       "order": 23,
       "label": {
         "he": "א",
-        "en": "23"
+        "en": "1"
       },
       "sefariaRef": "Ohr Penimi on Talmud Eser HaSefirot 4:6:23",
       "targetSeif": 14,
@@ -285,7 +285,7 @@
       "order": 24,
       "label": {
         "he": "ב",
-        "en": "24"
+        "en": "2"
       },
       "sefariaRef": "Ohr Penimi on Talmud Eser HaSefirot 4:6:24",
       "targetSeif": 15,
@@ -297,7 +297,7 @@
       "order": 25,
       "label": {
         "he": "ג",
-        "en": "25"
+        "en": "3"
       },
       "sefariaRef": "Ohr Penimi on Talmud Eser HaSefirot 4:6:25",
       "targetSeif": 15,
@@ -309,7 +309,7 @@
       "order": 26,
       "label": {
         "he": "ד",
-        "en": "26"
+        "en": "4"
       },
       "sefariaRef": "Ohr Penimi on Talmud Eser HaSefirot 4:6:26",
       "targetSeif": 15,
@@ -321,7 +321,7 @@
       "order": 27,
       "label": {
         "he": "ה",
-        "en": "27"
+        "en": "5"
       },
       "sefariaRef": "Ohr Penimi on Talmud Eser HaSefirot 4:6:27",
       "targetSeif": 15,
@@ -333,7 +333,7 @@
       "order": 28,
       "label": {
         "he": "ו",
-        "en": "28"
+        "en": "6"
       },
       "sefariaRef": "Ohr Penimi on Talmud Eser HaSefirot 4:6:28",
       "targetSeif": 15,
@@ -345,7 +345,7 @@
       "order": 29,
       "label": {
         "he": "ז",
-        "en": "29"
+        "en": "7"
       },
       "sefariaRef": "Ohr Penimi on Talmud Eser HaSefirot 4:6:29",
       "targetSeif": 16,
@@ -357,7 +357,7 @@
       "order": 30,
       "label": {
         "he": "ח",
-        "en": "30"
+        "en": "8"
       },
       "sefariaRef": "Ohr Penimi on Talmud Eser HaSefirot 4:6:30",
       "targetSeif": 16,
@@ -369,7 +369,7 @@
       "order": 31,
       "label": {
         "he": "ט",
-        "en": "31"
+        "en": "9"
       },
       "sefariaRef": "Ohr Penimi on Talmud Eser HaSefirot 4:6:31",
       "targetSeif": 16,
@@ -381,7 +381,7 @@
       "order": 32,
       "label": {
         "he": "י",
-        "en": "32"
+        "en": "10"
       },
       "sefariaRef": "Ohr Penimi on Talmud Eser HaSefirot 4:6:32",
       "targetSeif": 17,
@@ -393,7 +393,7 @@
       "order": 33,
       "label": {
         "he": "כ",
-        "en": "33"
+        "en": "20"
       },
       "sefariaRef": "Ohr Penimi on Talmud Eser HaSefirot 4:6:33",
       "targetSeif": 17,
@@ -405,7 +405,7 @@
       "order": 34,
       "label": {
         "he": "ל",
-        "en": "34"
+        "en": "30"
       },
       "sefariaRef": "Ohr Penimi on Talmud Eser HaSefirot 4:6:34",
       "targetSeif": 17,
@@ -417,7 +417,7 @@
       "order": 35,
       "label": {
         "he": "מ",
-        "en": "35"
+        "en": "40"
       },
       "sefariaRef": "Ohr Penimi on Talmud Eser HaSefirot 4:6:35",
       "targetSeif": 18,
@@ -429,7 +429,7 @@
       "order": 36,
       "label": {
         "he": "נ",
-        "en": "36"
+        "en": "50"
       },
       "sefariaRef": "Ohr Penimi on Talmud Eser HaSefirot 4:6:36",
       "targetSeif": 19,
@@ -441,7 +441,7 @@
       "order": 37,
       "label": {
         "he": "ס",
-        "en": "37"
+        "en": "60"
       },
       "sefariaRef": "Ohr Penimi on Talmud Eser HaSefirot 4:6:37",
       "targetSeif": 19,
@@ -453,7 +453,7 @@
       "order": 38,
       "label": {
         "he": "ע",
-        "en": "38"
+        "en": "70"
       },
       "sefariaRef": "Ohr Penimi on Talmud Eser HaSefirot 4:6:38",
       "targetSeif": 20,
@@ -465,7 +465,7 @@
       "order": 39,
       "label": {
         "he": "פ",
-        "en": "39"
+        "en": "80"
       },
       "sefariaRef": "Ohr Penimi on Talmud Eser HaSefirot 4:6:39",
       "targetSeif": 20,
@@ -477,7 +477,7 @@
       "order": 40,
       "label": {
         "he": "צ",
-        "en": "40"
+        "en": "90"
       },
       "sefariaRef": "Ohr Penimi on Talmud Eser HaSefirot 4:6:40",
       "targetSeif": 21,
@@ -489,7 +489,7 @@
       "order": 41,
       "label": {
         "he": "ק",
-        "en": "41"
+        "en": "100"
       },
       "sefariaRef": "Ohr Penimi on Talmud Eser HaSefirot 4:6:41",
       "targetSeif": 21,
@@ -501,7 +501,7 @@
       "order": 42,
       "label": {
         "he": "ר",
-        "en": "42"
+        "en": "200"
       },
       "sefariaRef": "Ohr Penimi on Talmud Eser HaSefirot 4:6:42",
       "targetSeif": 21,
@@ -513,7 +513,7 @@
       "order": 43,
       "label": {
         "he": "ש",
-        "en": "43"
+        "en": "300"
       },
       "sefariaRef": "Ohr Penimi on Talmud Eser HaSefirot 4:6:43",
       "targetSeif": 22,

--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
     "emit:glossary-splits": "tsx scripts/emit-glossary-splits.ts",
     "import:sefaria": "tsx scripts/import-sefaria.ts",
     "import:kabbalahmedia": "tsx scripts/import-kabbalahmedia.ts",
-    "migrate:consolidate-qa": "tsx scripts/migrate-consolidate-qa.ts"
+    "migrate:consolidate-qa": "tsx scripts/migrate-consolidate-qa.ts",
+    "migrate:commentary-labels": "tsx scripts/migrate-commentary-labels.ts"
   },
   "dependencies": {
     "@nuxtjs/i18n": "^10.6.0",

--- a/scripts/lib/hebrew-numerals.ts
+++ b/scripts/lib/hebrew-numerals.ts
@@ -128,3 +128,29 @@ export const hebrewGematriaValue = (label: string): number => {
   }
   return total;
 };
+
+/**
+ * The number a printed English edition marks a commentary anchor with, given
+ * the Hebrew letter the Hebrew edition marks it with.
+ *
+ * Bnei Baruch's English marks both the Ari's text and its Inner Light list
+ * with the letters' gematria values — `1 2 3 … 10 20 30 … 400` — verified
+ * against their own document for `part-01/chapter-01` (KabbalahMedia
+ * `doc2html/vYyXn9gY`). So the 12th note is printed "30" (ל), not "12".
+ *
+ * The FIRST recognized letter decides it, unlike `hebrewGematriaValue` which
+ * sums every letter to read a multi-letter numeral like "יא" (11). A label
+ * can name more than one marker — `part-02/chapter-01` op-20 is "ר וש", one
+ * note covering two letters — and the text prints only the first, so summing
+ * would produce 500, a number in no edition.
+ *
+ * Returns `null` when the label holds no recognized Hebrew letter, leaving
+ * the caller to decide (import paths warn and fall back rather than crash).
+ */
+export const printedMarkerForHebrewLabel = (label: string): string | null => {
+  for (const char of label) {
+    const value = GEMATRIA_LETTER_VALUES[char];
+    if (value !== undefined) return String(value);
+  }
+  return null;
+};

--- a/scripts/lib/km-he-whole-part-parser.ts
+++ b/scripts/lib/km-he-whole-part-parser.ts
@@ -70,7 +70,11 @@ import type {
   CommentaryItem,
   SourceSegment,
 } from "../../shared/types/content.ts";
-import { bareHebrewOrdinal, hebrewGematriaValue } from "./hebrew-numerals.ts";
+import {
+  bareHebrewOrdinal,
+  hebrewGematriaValue,
+  printedMarkerForHebrewLabel,
+} from "./hebrew-numerals.ts";
 
 // ---------------------------------------------------------------------------
 // Block tokenizing — this dialect additionally needs `<blockquote>` blocks
@@ -595,7 +599,12 @@ export const buildHeChapterContent = (
     items.push({
       anchorId: `op-${anchor.order}`,
       order: anchor.order,
-      label: { he: anchor.letter, en: String(anchor.order) },
+      // See `printedMarkerForHebrewLabel` (issue #96): the English marker is
+      // the letter's gematria value, not the item's running order.
+      label: {
+        he: anchor.letter,
+        en: printedMarkerForHebrewLabel(anchor.letter) ?? String(anchor.order),
+      },
       targetSeif: anchor.seif,
       section: "ohr-pnimi",
       html: sanitizeHtml(collapseSpaces(pieces.join(" "))),

--- a/scripts/lib/transform.ts
+++ b/scripts/lib/transform.ts
@@ -15,6 +15,7 @@ import type {
   SourceSegment,
 } from "../../shared/types/content.ts";
 import { extractLeadingHeading } from "./heading.ts";
+import { printedMarkerForHebrewLabel } from "./hebrew-numerals.ts";
 import type { JaggedNodeShape } from "./jagged-array.ts";
 import type { SefariaLink } from "./sefaria-api-types.ts";
 import { ohrPenimiItemRef, segmentRefFor } from "./sefaria-refs.ts";
@@ -241,10 +242,23 @@ export const buildCommentaryItems = (
       return;
     }
 
+    // The English marker is the letter's gematria value, not the running
+    // order — that is what the printed English edition marks both the text
+    // and its note list with (see `printedMarkerForHebrewLabel`, issue #96).
+    // `String(order)` here was the source of the invented labels that
+    // `validate-content.ts`'s `checkCommentaryLabelMatchesSourceMarker` now
+    // rejects.
+    const enLabel = printedMarkerForHebrewLabel(link.heLabel);
+    if (enLabel === null) {
+      warnings.push(
+        `${chapterRef}: commentary item order ${order} has label "${link.heLabel}" with no recognized Hebrew letter — falling back to the order digits`,
+      );
+    }
+
     items.push({
       anchorId: `op-${order}`,
       order,
-      label: { he: link.heLabel, en: String(order) },
+      label: { he: link.heLabel, en: enLabel ?? String(order) },
       sefariaRef,
       targetSeif: link.targetSeif,
       section: "ohr-pnimi",

--- a/scripts/migrate-commentary-labels.ts
+++ b/scripts/migrate-commentary-labels.ts
@@ -1,0 +1,165 @@
+/**
+ * One-off migration for issue #96: replaces every anchored commentary item's
+ * `label` with the marker its OWN version's source text actually prints.
+ *
+ * The defect. Both Sefaria and KabbalahMedia import paths set the English
+ * label to `String(order)` — the item's running position in the chapter
+ * (`transform.ts`, `km-he-whole-part-parser.ts`). That number appears
+ * nowhere in the printed book. Bnei Baruch's English edition (verified
+ * against their own document, KabbalahMedia `doc2html/vYyXn9gY`, for
+ * `part-01/chapter-01`) marks BOTH the Ari's text and its Inner Light list
+ * with the gematria values of the Hebrew letters:
+ *
+ *   1 2 3 4 5 6 7 8 9 10 20 30 40 50 60 70 80 90 100 200 300 400
+ *
+ * So the 12th note is printed "30" (ל), not "12". The source html we import
+ * carries the right value; only the label was invented. Below order 11 the
+ * two coincide (א=1 … י=10), which is why it went unnoticed.
+ *
+ * The rule. For an anchored item, the source html of the SAME version is
+ * ground truth — it is the marker the reader sees and clicks. So this
+ * derives, never computes: no gematria arithmetic, no assumption about
+ * where the sequence restarts. A version with no source file, an item with
+ * no marker in it, and every unanchored item (no marker exists to derive
+ * from — see `commentaryItemSchema`) are all left untouched.
+ *
+ * Only the key for the version's own language is rewritten: `en-bb`'s
+ * `label.en`, `he-jerusalem-1956`'s `label.he`. The other key is left as
+ * imported.
+ *
+ * `pnpm migrate:commentary-labels [--dry-run]`. Deterministic and
+ * idempotent: a second run against unchanged input writes nothing and
+ * leaves `git diff` empty. `checkCommentaryLabelMatchesSourceMarker` in
+ * `validate-content.ts` enforces the result from here on, so a future
+ * import that regresses fails `task check` loudly instead of silently
+ * reintroducing invented numbers.
+ */
+import { readdirSync, readFileSync, statSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+import {
+  chapterLayerFileSchema,
+  versionsFileSchema,
+  type CommentaryItem,
+} from "../shared/types/content.ts";
+import {
+  anchorMarkersFromHtml,
+  labelNamesMarker,
+} from "../shared/utils/anchorMarkers.ts";
+
+const CONTENT_ROOT = fileURLToPath(new URL("../content", import.meta.url));
+const PARTS_ROOT = join(CONTENT_ROOT, "parts");
+
+const isDryRun = process.argv.includes("--dry-run");
+
+/** Every directory holding chapter layer files: `content/parts/<part>/chapters/<chapter>`. */
+const chapterDirs = (): string[] => {
+  const dirs: string[] = [];
+  for (const part of readdirSync(PARTS_ROOT)) {
+    const chaptersRoot = join(PARTS_ROOT, part, "chapters");
+    if (!statSync(chaptersRoot, { throwIfNoEntry: false })?.isDirectory()) {
+      continue;
+    }
+    for (const chapter of readdirSync(chaptersRoot)) {
+      dirs.push(join(chaptersRoot, chapter));
+    }
+  }
+  return dirs.sort();
+};
+
+const versionLanguages = new Map(
+  versionsFileSchema
+    .parse(
+      JSON.parse(readFileSync(join(CONTENT_ROOT, "versions.json"), "utf8")),
+    )
+    .map((version) => [version.id, version.language]),
+);
+
+let filesRewritten = 0;
+let labelsChanged = 0;
+const skipped: string[] = [];
+
+for (const dir of chapterDirs()) {
+  for (const fileName of readdirSync(dir).sort()) {
+    const match = /^commentary\.(.+)\.json$/.exec(fileName);
+    if (!match) continue;
+
+    const versionId = match[1] as string;
+    const language = versionLanguages.get(versionId);
+    if (!language) {
+      skipped.push(
+        `${dir}/${fileName}: version "${versionId}" not in versions.json`,
+      );
+      continue;
+    }
+
+    const sourcePath = join(dir, `source.${versionId}.json`);
+    const sourceRaw = (() => {
+      try {
+        return readFileSync(sourcePath, "utf8");
+      } catch {
+        return null;
+      }
+    })();
+    // No same-version source file means no printed marker to derive from —
+    // the commentary is carried in a language whose source text we do not
+    // have. Leaving the label alone is the only honest option.
+    if (sourceRaw === null) continue;
+
+    const sourceFile = chapterLayerFileSchema.parse(JSON.parse(sourceRaw));
+    if (sourceFile.layer !== "source") continue;
+
+    const markers = anchorMarkersFromHtml(
+      sourceFile.items.map((segment) => segment.html),
+    );
+    if (markers.size === 0) continue;
+
+    const commentaryPath = join(dir, fileName);
+    const commentaryFile = chapterLayerFileSchema.parse(
+      JSON.parse(readFileSync(commentaryPath, "utf8")),
+    );
+    if (commentaryFile.layer !== "commentary") continue;
+
+    let changedHere = 0;
+    for (const item of commentaryFile.items as CommentaryItem[]) {
+      if (item.targetSeif === undefined) continue;
+
+      const marker = markers.get(item.anchorId);
+      if (marker === undefined) continue;
+      // A label that already NAMES the marker is left alone, even when it
+      // isn't equal to it: `part-02/chapter-01` op-20 carries `"ר וש"` —
+      // one note covering two printed letters, where the source prints only
+      // the first. Overwriting that with "ר" would delete real information
+      // to satisfy a string comparison. Only labels with no relationship to
+      // the marker at all (the invented running ordinals) are replaced.
+      if (labelNamesMarker(item.label[language], marker)) continue;
+
+      item.label[language] = marker;
+      changedHere++;
+    }
+
+    if (changedHere === 0) continue;
+
+    labelsChanged += changedHere;
+    filesRewritten++;
+
+    const relative = commentaryPath.slice(CONTENT_ROOT.length + 1);
+    console.log(
+      `${isDryRun ? "would rewrite" : "rewrote"} ${relative} (${changedHere} labels)`,
+    );
+
+    if (!isDryRun) {
+      writeFileSync(
+        commentaryPath,
+        `${JSON.stringify(commentaryFile, null, 2)}\n`,
+        "utf8",
+      );
+    }
+  }
+}
+
+for (const note of skipped) console.warn(`skipped: ${note}`);
+
+console.log(
+  `\n${isDryRun ? "[dry run] " : ""}${labelsChanged} labels in ${filesRewritten} files`,
+);

--- a/scripts/validate-content.ts
+++ b/scripts/validate-content.ts
@@ -24,6 +24,10 @@ import {
   type Toc,
 } from "../shared/types/content.ts";
 import {
+  anchorMarkersFromHtml,
+  labelNamesMarker,
+} from "../shared/utils/anchorMarkers.ts";
+import {
   deriveGlossaryCitationsFile,
   deriveGlossaryIndexFile,
   GLOSSARY_CITATIONS_FILE_NAME,
@@ -506,6 +510,75 @@ const checkCommentaryItemBasics = (
   }
 };
 
+/**
+ * An anchored commentary item's label must name the marker its OWN version's
+ * source text prints for that anchor (issue #96).
+ *
+ * The two are the same thing seen from either side of the page: the marker
+ * is what the reader sees inset in the Ari's text and clicks; the label is
+ * what the note beside it is called. They drifted because both import paths
+ * set the English label to `String(order)` — the item's running position —
+ * and Bnei Baruch's edition marks the text with the gematria values of the
+ * Hebrew letters instead (`… 10, 20, 30 … 400`), so the 12th note is printed
+ * "30", not "12". `scripts/migrate-commentary-labels.ts` corrected the
+ * committed files; this keeps a future import from silently undoing it.
+ *
+ * Deliberately checked per VERSION, never across versions: only
+ * `commentary.en-bb.json` against `source.en-bb.json`. A chapter's Hebrew
+ * source prints letters and its English source prints numbers, and neither
+ * is wrong.
+ *
+ * Uses `labelNamesMarker` rather than equality so a label may stay richer
+ * than its marker where the data genuinely is — `part-02/chapter-01` op-20
+ * is `"ר וש"`, one note covering two printed letters, against a source that
+ * prints only the first.
+ *
+ * Unanchored items are exempt: no marker exists anywhere for them, so
+ * `label` stays the plain `order` digits the schema documents.
+ */
+const checkCommentaryLabelMatchesSourceMarker = (
+  loaded: LoadedChapterFile[],
+  versions: ContentVersion[],
+  errors: string[],
+): void => {
+  const languageOf = new Map(versions.map((v) => [v.id, v.language]));
+
+  const sourceMarkers = new Map<string, Map<string, string>>();
+  for (const entry of loaded) {
+    if (entry.file.layer !== "source") continue;
+    sourceMarkers.set(
+      `${entry.chapterDirId}::${entry.file.versionId}`,
+      anchorMarkersFromHtml(entry.file.items.map((segment) => segment.html)),
+    );
+  }
+
+  for (const entry of loaded) {
+    if (entry.file.layer !== "commentary") continue;
+
+    const language = languageOf.get(entry.file.versionId);
+    if (language === undefined) continue;
+
+    const markers = sourceMarkers.get(
+      `${entry.chapterDirId}::${entry.file.versionId}`,
+    );
+    // No same-version source text in this chapter: nothing prints a marker
+    // to check against, which is a coverage gap, not a label defect.
+    if (!markers) continue;
+
+    for (const item of entry.file.items) {
+      if (item.targetSeif === undefined) continue;
+
+      const marker = markers.get(item.anchorId);
+      if (marker === undefined) continue;
+      if (labelNamesMarker(item.label[language], marker)) continue;
+
+      errors.push(
+        `${entry.relativePath}: anchor "${item.anchorId}" is labelled "${item.label[language] ?? ""}" (${language}) but its own source version prints "${marker}" — run \`pnpm migrate:commentary-labels\``,
+      );
+    }
+  }
+};
+
 const checkTocFileCrossReferences = (
   toc: Toc,
   loaded: LoadedChapterFile[],
@@ -827,6 +900,11 @@ export const validateContent = (contentDir: string): ValidationResult => {
   checkAnchorCommentaryIntegrity(loaded, errors);
   checkCommentaryItemBasics(loaded, errors);
   if (versionsParsed.success) {
+    checkCommentaryLabelMatchesSourceMarker(
+      loaded,
+      versionsParsed.data,
+      errors,
+    );
     checkTranslatedVersionIntegrity(
       versionsParsed.data,
       loaded,

--- a/shared/utils/anchorMarkers.ts
+++ b/shared/utils/anchorMarkers.ts
@@ -1,0 +1,63 @@
+/**
+ * Extracts the marker text a source version prints for each of its commentary
+ * anchors.
+ *
+ * Shared because two very different callers need the identical answer, and a
+ * second implementation would be a second thing to drift: the reader
+ * (`app/utils/anchorMarkers.ts`, labelling notes with the marker on screen)
+ * and the content tooling (`scripts/migrate-commentary-labels.ts` +
+ * `validate-content.ts`, issue #96).
+ *
+ * Anchors are normalized at import time (`app/utils/anchors.ts`) to
+ * `<a class="tes-anchor" data-anchor="op-N">MARKER</a>`, so a regex over the
+ * committed html is sufficient — and unlike `DOMParser` it works unchanged
+ * during prerender and under `tsx` in a script.
+ *
+ * Contains no `zod` and no Nuxt imports, so app code may import it as a
+ * value rather than `import type`.
+ */
+
+const ANCHOR_RE = /<a\b[^>]*\bdata-anchor="([^"]+)"[^>]*>([\s\S]*?)<\/a>/g;
+const TAG_RE = /<[^>]+>/g;
+
+/**
+ * `anchorId` -> printed marker, over a sequence of source html strings, in
+ * order. The FIRST occurrence of an id wins.
+ *
+ * An anchor whose marker text is empty is omitted rather than mapped to `""`:
+ * callers fall back to the item's stored label, and an empty string would
+ * silently render a note with no marker at all.
+ */
+export const anchorMarkersFromHtml = (
+  htmlStrings: Iterable<string>,
+): Map<string, string> => {
+  const markers = new Map<string, string>();
+
+  for (const html of htmlStrings) {
+    for (const match of html.matchAll(ANCHOR_RE)) {
+      const [, anchorId, rawMarker] = match;
+      if (!anchorId || markers.has(anchorId)) continue;
+
+      const marker = (rawMarker ?? "").replace(TAG_RE, "").trim();
+      if (marker.length > 0) markers.set(anchorId, marker);
+    }
+  }
+
+  return markers;
+};
+
+/**
+ * Whether `label` already names `marker` — equal to it, or listing it among
+ * several whitespace-separated markers.
+ *
+ * The looser test exists because a label may legitimately be richer than the
+ * marker beside it: `part-02/chapter-01` op-20 is labelled `"ר וש"`, one
+ * note covering two printed letters, while the source text prints only the
+ * first. That is correct data, not drift. Token equality (never substring)
+ * so "30" is not considered named by "300".
+ */
+export const labelNamesMarker = (
+  label: string | undefined,
+  marker: string,
+): boolean =>
+  label !== undefined && label.split(/\s+/).some((token) => token === marker);

--- a/tests/fixtures/content-integrity/label-marker-mismatch/parts/part-01/chapters/chapter-01/commentary.v1.json
+++ b/tests/fixtures/content-integrity/label-marker-mismatch/parts/part-01/chapters/chapter-01/commentary.v1.json
@@ -7,8 +7,8 @@
       "anchorId": "op-1",
       "order": 1,
       "label": {
-        "en": "a",
-        "he": "a"
+        "en": "1",
+        "he": "1"
       },
       "targetSeif": 1,
       "section": "ohr-pnimi",

--- a/tests/fixtures/content-integrity/label-marker-mismatch/parts/part-01/chapters/chapter-01/source.v1.json
+++ b/tests/fixtures/content-integrity/label-marker-mismatch/parts/part-01/chapters/chapter-01/source.v1.json
@@ -1,0 +1,19 @@
+{
+  "chapterId": "part-01/chapter-01",
+  "layer": "source",
+  "versionId": "v1",
+  "items": [
+    {
+      "n": 1,
+      "sefariaRef": "Fixture 1:1",
+      "html": "<p>Text <a class=\"tes-anchor\" href=\"#op-1\" data-anchor=\"op-1\">a</a></p>",
+      "anchors": ["op-1"]
+    },
+    {
+      "n": 2,
+      "sefariaRef": "Fixture 1:2",
+      "html": "<p>No inline markers here.</p>",
+      "anchors": []
+    }
+  ]
+}

--- a/tests/fixtures/content-integrity/label-marker-mismatch/toc.json
+++ b/tests/fixtures/content-integrity/label-marker-mismatch/toc.json
@@ -1,0 +1,31 @@
+{
+  "volumes": [
+    {
+      "id": "volume-01",
+      "number": 1,
+      "title": { "en": "Volume 1" },
+      "parts": [
+        {
+          "id": "part-01",
+          "number": 1,
+          "sefariaNode": "Fixture Node",
+          "title": { "en": "Part 1" },
+          "chapters": [
+            {
+              "id": "part-01/chapter-01",
+              "kind": "chapter",
+              "number": 1,
+              "title": { "en": "Chapter 1" },
+              "availableLayers": ["source", "commentary"],
+              "availableVersions": {
+                "summary": [],
+                "source": ["v1"],
+                "commentary": ["v1"]
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tests/fixtures/content-integrity/label-marker-mismatch/versions.json
+++ b/tests/fixtures/content-integrity/label-marker-mismatch/versions.json
@@ -1,0 +1,10 @@
+[
+  {
+    "id": "v1",
+    "language": "en",
+    "direction": "ltr",
+    "title": "Fixture Version",
+    "license": "Public Domain",
+    "source": "curated"
+  }
+]

--- a/tests/unit/anchor-markers.spec.ts
+++ b/tests/unit/anchor-markers.spec.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import type { SourceSegment } from "~~/shared/types/content";
+import { labelNamesMarker } from "~~/shared/utils/anchorMarkers";
 
 const segment = (n: number, html: string): SourceSegment => ({
   n,
@@ -78,5 +79,30 @@ describe("anchorMarkersFromSegments", () => {
   it("returns an empty map for segments with no anchors at all", () => {
     expect(anchorMarkersFromSegments([segment(1, "plain text")]).size).toBe(0);
     expect(anchorMarkersFromSegments([]).size).toBe(0);
+  });
+});
+
+describe("labelNamesMarker", () => {
+  it("accepts a label equal to the marker", () => {
+    expect(labelNamesMarker("30", "30")).toBe(true);
+  });
+
+  it("accepts a label that lists the marker among several", () => {
+    // `part-02/chapter-01` op-20 is labelled "ר וש" — one note covering two
+    // printed letters — against a source that prints only the first.
+    expect(labelNamesMarker("ר וש", "ר")).toBe(true);
+  });
+
+  it("rejects an invented ordinal that has no relation to the marker", () => {
+    expect(labelNamesMarker("12", "30")).toBe(false);
+  });
+
+  it("compares whole tokens, never substrings", () => {
+    expect(labelNamesMarker("300", "30")).toBe(false);
+    expect(labelNamesMarker("30", "300")).toBe(false);
+  });
+
+  it("rejects a missing label rather than throwing", () => {
+    expect(labelNamesMarker(undefined, "30")).toBe(false);
   });
 });

--- a/tests/unit/content-integrity.spec.ts
+++ b/tests/unit/content-integrity.spec.ts
@@ -85,6 +85,25 @@ describe("content integrity — unanchored commentary items", () => {
     expect(nonBoilerplateErrors(errors)).toEqual([]);
   });
 
+  it("fires when a label bears no relation to the marker its own source prints (issue #96)", () => {
+    // The English import paths used to label a note with its running order
+    // ("12") while the source text printed the letter's gematria value
+    // ("30"), so clicking a marker landed on a differently-numbered note.
+    const { errors } = validateContent(
+      join(fixturesDir, "label-marker-mismatch"),
+    );
+
+    expect(nonBoilerplateErrors(errors)).toEqual([
+      'parts/part-01/chapters/chapter-01/commentary.v1.json: anchor "op-1" is labelled "1" (en) but its own source version prints "a" — run `pnpm migrate:commentary-labels`',
+    ]);
+  });
+
+  it("accepts a label that names its marker among several (a note covering two printed letters)", () => {
+    // `part-02/chapter-01` op-20 is labelled "ר וש" against a source that
+    // prints only "ר" — richer data, not drift, so it must not fire.
+    expect(labelNamesMarker("ר וש", "ר")).toBe(true);
+  });
+
   it("fires when two unanchored items in the same file duplicate an order", () => {
     const { errors } = validateContent(
       join(fixturesDir, "unanchored-duplicate-order"),

--- a/tests/unit/import-kabbalahmedia.spec.ts
+++ b/tests/unit/import-kabbalahmedia.spec.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from "vitest";
-import { hebrewGematriaValue } from "../../scripts/lib/hebrew-numerals.ts";
+import {
+  hebrewGematriaValue,
+  printedMarkerForHebrewLabel,
+} from "../../scripts/lib/hebrew-numerals.ts";
 import { convertAnchorMarkers } from "../../scripts/lib/km-anchor-markers.ts";
 import {
   dedupeKmDocumentCandidates,
@@ -1344,5 +1347,41 @@ describe("isSupportedKmStructure", () => {
     expect(
       isSupportedKmStructure(parseDocBlocks("<h5>1. Know that.</h5>")),
     ).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// printedMarkerForHebrewLabel (issue #96)
+// ---------------------------------------------------------------------------
+
+describe("printedMarkerForHebrewLabel", () => {
+  it.each([
+    ["א", "1"],
+    ["י", "10"],
+    ["כ", "20"],
+    ["ל", "30"],
+    ["ר", "200"],
+    ["ת", "400"],
+  ])(
+    "marks %s as %s, the value the English edition prints",
+    (letter, expected) => {
+      expect(printedMarkerForHebrewLabel(letter)).toBe(expected);
+    },
+  );
+
+  it("takes the FIRST letter of a label naming several markers, not their sum", () => {
+    // `part-02/chapter-01` op-20 is labelled "ר וש" — one note covering two
+    // printed letters — and the source text prints only "ר". Summing would
+    // give 500, a number in no edition.
+    expect(printedMarkerForHebrewLabel("ר וש")).toBe("200");
+  });
+
+  it("ignores geresh/gershayim and surrounding punctuation", () => {
+    expect(printedMarkerForHebrewLabel('"כ"')).toBe("20");
+  });
+
+  it("returns null when there is no Hebrew letter to read", () => {
+    expect(printedMarkerForHebrewLabel("12")).toBeNull();
+    expect(printedMarkerForHebrewLabel("")).toBeNull();
   });
 });


### PR DESCRIPTION
Closes the content half of #96. The reader already showed the right number
(#98); the files still held the wrong one, which mattered for anything
reading them directly — search, export, citation, and every future
translation copied from them.

## Correcting my own finding

I previously concluded on #96 that Bnei Baruch's edition numbers the Ari's
text and its note list differently, and that our corpus faithfully reproduced
that. **That was wrong.** I read only the first three notes of their
commentary list, saw `1. 2. 3.`, and generalised — from precisely the range
(orders 1-10, where א=1 … י=10) that cannot distinguish the two systems.

The full list from the same document (`doc2html/vYyXn9gY`):

```
1 2 3 4 5 6 7 8 9 10 20 30 40 50 60 70 80 90 100 200 300 400
```

Identical to the text markers. BB is internally consistent. Our `label.en`
was the invented side, set to `String(order)` at import.

## What changed

- **`pnpm migrate:commentary-labels`** derives each anchored item's label
  from the marker its **own version's** source html prints. Derived, never
  computed — no gematria arithmetic, no assumption about where the sequence
  restarts. **152 labels across 15 files** (`en-bb`, `en-ai`). Hebrew
  untouched. Idempotent: a second run writes nothing.
- A label that already **names** its marker is left alone, so
  `part-02/chapter-01` op-20 keeps `"ר וש"` — one note covering two printed
  letters against a source printing only the first. Overwriting it to satisfy
  a string comparison would delete real information.
- **`checkCommentaryLabelMatchesSourceMarker`** in `validate-content.ts`
  holds the line, per version and never across versions (a chapter's Hebrew
  source prints letters and its English source prints numbers; neither is
  wrong). I regressed a label deliberately and confirmed it fails with an
  actionable message before trusting it.
- **Both import paths fixed at the root** — `transform.ts` and
  `km-he-whole-part-parser.ts` now set the English label from
  `printedMarkerForHebrewLabel` rather than `String(order)`, warning instead
  of crashing on a label with no Hebrew letter. Without this a re-import
  would quietly undo the migration.
- `anchorMarkersFromHtml` moved to `shared/utils/` so the reader, the
  migration and the validator all read markers through one implementation.

## Fixture note

`mixed-chapter-valid` printed `"a"` in its source while labelling the item
`"1"` — an unrelated inconsistency the new check correctly caught. I made the
fixture self-consistent (it exists to test anchored/unanchored mixing, not
labels) rather than exempting it, and added `label-marker-mismatch` to cover
the new check itself.

## Verification

`task check` exit 0 — **856 unit tests** (up from 840), content validation,
full generate, 5/5 e2e.

Spot check, `part-01/chapter-01` `en-bb`:

```
order=10  label.en="10"   label.he="י"
order=11  label.en="20"   label.he="כ"
order=12  label.en="30"   label.he="ל"
order=20  label.en="200"  label.he="ר"
order=22  label.en="400"  label.he="ת"
```

Refs #96