### PR TITLE
feat(app): credit Bnei Baruch's source library in the footer, thin the scrollbars

### DIFF
--- a/app/assets/css/main.css
+++ b/app/assets/css/main.css
@@ -199,6 +199,47 @@ html {
   color-scheme: light;
 }
 
+/*
+ * Thin, theme-coloured scrollbars.
+ *
+ * The reader is three independently scrolling columns plus the page itself,
+ * so default-width bars are up to four heavy stripes of chrome competing
+ * with the text. `scrollbar-color` uses the `--border` token, so each theme
+ * gets its own without a per-theme rule; `transparent` for the track keeps
+ * the gutter reading as part of the column rather than a channel beside it.
+ *
+ * `scrollbar-width`/`scrollbar-color` are the standard properties (Firefox,
+ * and Chromium since 121); the `::-webkit-` block below is the fallback for
+ * older WebKit/Chromium, which ignores them. Both are declared because
+ * neither covers every browser this ships to on its own.
+ *
+ * Deliberately not `scrollbar-width: none`: a scrollable column with no
+ * visible bar gives no indication there is more text below it, which is
+ * exactly the "where am I" problem the reader panes already had.
+ */
+* {
+  scrollbar-width: thin;
+  scrollbar-color: var(--border) transparent;
+}
+
+*::-webkit-scrollbar {
+  width: 8px;
+  height: 8px;
+}
+
+*::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+*::-webkit-scrollbar-thumb {
+  background-color: var(--border);
+  border-radius: 4px;
+}
+
+*::-webkit-scrollbar-thumb:hover {
+  background-color: var(--text-muted);
+}
+
 .dark {
   color-scheme: dark;
 }

--- a/app/components/app/AppFooter.vue
+++ b/app/components/app/AppFooter.vue
@@ -1,11 +1,59 @@
 <script setup lang="ts">
-const { t } = useI18n();
+// The attribution credits Bnei Baruch, so the academy's name links to their
+// own source library rather than leaving the reader to go looking for it.
+//
+// The name is a separate message from the sentence around it, and the
+// sentence is split on a placeholder rather than stored as two half-
+// sentences: Hebrew puts the name in a different position, and asking a
+// translator to hand-place an `<a>` inside a translated string (or to keep
+// two fragments in the right order) is how attribution ends up mangled in
+// the languages nobody on the team reads.
+//
+// Split rather than `<i18n-t>`: that component resolved the message but
+// dropped the slot's markup here, rendering the name as plain text.
+const { t, locale } = useI18n();
+
+/**
+ * Placeholder we split the sentence on. Never rendered, so it only has to be
+ * a string no translation would contain — plain ASCII on purpose, since a
+ * control character here is invisible in review and trips the template
+ * parser.
+ */
+const NAME_SLOT = "@@ACADEMY@@";
+
+/** KabbalahMedia serves these; the other target languages fall back to English. */
+const KM_SOURCES_LOCALES = new Set(["en", "he"]);
+
+const sourcesUrl = computed(
+  () =>
+    `https://kabbalahmedia.info/${
+      KM_SOURCES_LOCALES.has(locale.value) ? locale.value : "en"
+    }/sources/`,
+);
+
+/** The sentence either side of the academy's name, in the translation's own order. */
+const attribution = computed(() => {
+  const [before = "", after = ""] = t("footer.attribution", {
+    academy: NAME_SLOT,
+  }).split(NAME_SLOT);
+  return { before, after };
+});
 </script>
 
 <template>
   <footer
     class="border-t border-(--border) bg-(--surface) px-4 py-6 text-center text-sm text-(--text-muted) sm:px-6"
   >
-    <p>{{ t("footer.attribution") }}</p>
+    <p>
+      {{ attribution.before
+      }}<a
+        :href="sourcesUrl"
+        :title="t('footer.sourcesLinkTitle')"
+        target="_blank"
+        rel="noopener noreferrer"
+        class="rounded-button underline underline-offset-2 hover:text-teal focus-visible:outline focus-visible:outline-2 focus-visible:outline-teal"
+        >{{ t("footer.academy") }}</a
+      >{{ attribution.after }}
+    </p>
   </footer>
 </template>

--- a/i18n/locales/en.json
+++ b/i18n/locales/en.json
@@ -23,7 +23,9 @@
     "breadcrumbLabel": "Breadcrumb"
   },
   "footer": {
-    "attribution": "Made by students of Bnei Baruch Kabbalah Academy"
+    "attribution": "Made by students of {academy}",
+    "academy": "Bnei Baruch Kabbalah Academy",
+    "sourcesLinkTitle": "Bnei Baruch's source library on Kabbalah Media"
   },
   "reader": {
     "aiTranslated": "AI translated",

--- a/i18n/locales/he.json
+++ b/i18n/locales/he.json
@@ -23,7 +23,9 @@
     "breadcrumbLabel": "פירורי לחם"
   },
   "footer": {
-    "attribution": "נוצר על ידי תלמידי בני ברוך אקדמיה לקבלה"
+    "attribution": "נוצר על ידי תלמידי {academy}",
+    "academy": "בני ברוך אקדמיה לקבלה",
+    "sourcesLinkTitle": "ספריית המקורות של בני ברוך בקבלה מדיה"
   },
   "reader": {
     "aiTranslated": "תרגום בינה מלאכותית",


### PR DESCRIPTION
Two small asks from the owner.

**Footer credit.** "Made by students of **Bnei Baruch Kabbalah Academy**" now
links the academy's name to `kabbalahmedia.info/<locale>/sources/` — their
own source library — falling back to English for the target languages they
don't serve.

The name is a separate message from the sentence around it, and the sentence
is split on a placeholder rather than stored as two half-sentences: Hebrew
puts the name in a different position, and asking a translator to hand-place
an `<a>` inside a translated string is how attribution gets mangled in the
languages nobody on the team reads. `<i18n-t>` would have been the idiomatic
way to do this, but it resolved the message and dropped the slot's markup
here, so the split is explicit.

**Thinner scrollbars.** The reader is three independently scrolling columns
plus the page itself, so default-width bars are up to four heavy stripes
competing with the text. Now 8px, thumb on the `--border` token so every
theme gets its own without a per-theme rule, transparent track. Both the
standard `scrollbar-width`/`scrollbar-color` and the `::-webkit-` fallback —
neither covers every target browser alone.

Deliberately still visible rather than hidden: a scrollable column with no
bar gives no indication there's more text below it, which is the same
"where am I" problem the panes already had.

## Verification

`task check` exit 0 — 856 unit tests, content validation, full generate,
5/5 e2e.

Built output, both locales:

```
/about      Made by students of <a href="https://kabbalahmedia.info/en/sources/" …>Bnei Baruch Kabbalah Academy</a>
/he/about   נוצר על ידי תלמידי <a href="https://kabbalahmedia.info/he/sources/" …>בני ברוך אקדמיה לקבלה</a>
```