### PR TITLE
fix(reader): hide the mobile swipe track's own scrollbar

### DIFF
--- a/app/assets/css/main.css
+++ b/app/assets/css/main.css
@@ -240,6 +240,25 @@ html {
   background-color: var(--text-muted);
 }
 
+/*
+ * The mobile pane swipe track (`MobileSwipePanes`) is gesture-driven and
+ * scroll-snapped — the pane-switcher pill is its control, not a scrollbar.
+ * A visible horizontal bar under the reading columns is chrome nobody uses,
+ * and it takes height from the panes on exactly the viewport that has least.
+ *
+ * Safe to hide here, unlike the reading columns above, precisely because
+ * position is already reported: the pill shows which of the three panes is
+ * current. This is the one scroll container in the app with an explicit
+ * indicator of its own.
+ */
+.tes-swipe-track {
+  scrollbar-width: none;
+}
+
+.tes-swipe-track::-webkit-scrollbar {
+  display: none;
+}
+
 .dark {
   color-scheme: dark;
 }

--- a/app/components/reader/MobileSwipePanes.vue
+++ b/app/components/reader/MobileSwipePanes.vue
@@ -249,7 +249,7 @@ const gridColsClass = computed(() =>
 <template>
   <div
     ref="trackRef"
-    class="flex min-h-0 w-full flex-1 snap-x snap-mandatory overflow-x-auto overflow-y-hidden overscroll-x-contain [contain:layout] lg:grid lg:snap-none lg:gap-0 lg:overflow-hidden lg:[contain:none]"
+    class="tes-swipe-track flex min-h-0 w-full flex-1 snap-x snap-mandatory overflow-x-auto overflow-y-hidden overscroll-x-contain [contain:layout] lg:grid lg:snap-none lg:gap-0 lg:overflow-hidden lg:[contain:none]"
     :class="gridColsClass"
   >
     <div


### PR DESCRIPTION
Follow-up to #100. The thin-scrollbar change gave the mobile pane swipe track a visible horizontal bar it never had reason to show: the track is gesture-driven and scroll-snapped, and `MobilePanePill` already reports which of the three panes is current.

This is the one scroll container safe to hide a bar on, precisely because it has an explicit position indicator of its own. The reading columns keep theirs — a column with no bar gives no sign there's more text below, which is the problem the pane work has been fixing all along.

## On the CI failure

The mobile swipe e2e failed on main after #100 (`trackScrollLeft` expected 0, got 780). I re-ran it and it passed, and it passed 3/3 locally — it is the known flake in that spec under worker contention, not a regression from the scrollbar change. Verified before assuming: the test also passes locally in isolation both before and after this change.

`task check` exit 0 — 856 unit tests, content validation, full generate, 5/5 e2e (run three times).