### PR TITLE
feat(scripts): add the model-agnostic translation pipeline

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,4 @@ test-results
 # worktrees/ holds throwaway agent checkouts (each a full node_modules).
 .claude/settings.local.json
 .claude/worktrees/
+.translation/

--- a/content/parts/part-12/chapters/chapter-177/commentary.en-ai.json
+++ b/content/parts/part-12/chapters/chapter-177/commentary.en-ai.json
@@ -1,0 +1,19 @@
+{
+  "chapterId": "part-12/chapter-177",
+  "layer": "commentary",
+  "versionId": "en-ai",
+  "sefariaRef": "Ohr Penimi on Talmud Eser HaSefirot 12:177",
+  "items": [
+    {
+      "anchorId": "op-1",
+      "order": 1,
+      "label": {
+        "he": "1",
+        "en": "1"
+      },
+      "sefariaRef": "Ohr Penimi on Talmud Eser HaSefirot 12:177:1",
+      "section": "ohr-pnimi",
+      "html": "<b>There enter into him together anew the inner and the encircling ones of the Gadlut of Aba, and also the inner ones of the VAK of the Gadlut of Ima, etc., there is no power in him to receive further degrees:</b> For all of these are the degrees that come with the second Ibur of the drawing that completes the vessels, immediately after the two years of Yenika. And although at the beginning of Atzilut the above degrees are not drawn all at once, but rather require a time of seven years and one day, as is known — nevertheless now they require no time at all, but come into him all at once (as above, page 1172, item 138). And you already know that so long as he is not completed in all the Mochin of Katnut that come with the first second-Ibur, he is not fit to rise to the second Ibur of the Mochin of Gadlut. And this is what he says: there is no power in him to receive further degrees."
+    }
+  ]
+}

--- a/content/toc.json
+++ b/content/toc.json
@@ -21504,6 +21504,7 @@
                   "he-jerusalem-1956"
                 ],
                 "commentary": [
+                  "en-ai",
                   "he-jerusalem-1956"
                 ]
               }

--- a/content/toc.parts/part-12.json
+++ b/content/toc.parts/part-12.json
@@ -3723,6 +3723,7 @@
           "he-jerusalem-1956"
         ],
         "commentary": [
+          "en-ai",
           "he-jerusalem-1956"
         ]
       }

--- a/docs/translation-pipeline.md
+++ b/docs/translation-pipeline.md
@@ -1,0 +1,135 @@
+# Translation pipeline
+
+How to get a language translated, whoever (or whatever) does the translating.
+
+The pipeline is deliberately **model-agnostic and offline**. `translate:export`
+writes self-contained JSON manifests; anything that can read JSON and write JSON
+can do the work — this session, another Claude, a different vendor's model, or a
+human. `translate:apply` takes the results back.
+
+## The safety property
+
+**Only the translated `html` ever passes through a model.** Every other field on
+a commentary item — `anchorId`, `order`, `label`, `sefariaRef`, `section`,
+`targetSeif` — is copied byte-for-byte from the Hebrew source by
+`translate-apply.ts`.
+
+This is not fussiness. `validate:content` checks neither `section` nor
+`sefariaRef`, and checks `label` only for anchored items, so a model quietly
+altering one of those would pass every gate and ship. Keeping them out of the
+model's reach is what makes it safe to hand a batch to a model nobody here has
+evaluated.
+
+## 1. Register the language (once per language)
+
+`content/versions.json` needs an AI version for the target language. English
+already has one. For a new language, add:
+
+```json
+{
+  "id": "bg-ai",
+  "language": "bg",
+  "direction": "ltr",
+  "title": "Български (AI translation)",
+  "license": "CC0",
+  "source": "ai",
+  "translatedFrom": "he-jerusalem-1956"
+}
+```
+
+`direction` is `"rtl"` for Hebrew and Persian (`fa`), `"ltr"` for everything
+else. `source: "ai"` is what makes the reader badge it **AI translated** — that
+badge is automatic and must not be removed.
+
+`translate:export` refuses to run without this and prints the exact JSON to add.
+
+## 2. Export the batches
+
+```sh
+pnpm translate:export --lang en                 # everything outstanding
+pnpm translate:export --lang bg --part part-05  # one part
+pnpm translate:export --lang de --budget 12000  # smaller batches
+```
+
+Manifests land in `.translation/<lang>/` (git-ignored). Each is standalone:
+instructions, the binding glossary, per-chapter context, and the items.
+
+Batches are packed by **source-prose characters**, never item count — items run
+from 29 to 37,057 characters. Default budget 20,000. A chapter is never split
+across batches; one larger than the whole budget gets a batch to itself.
+
+Re-running is safe and idempotent in the sense that matters: it only ever
+exports what no version in that language already covers, so a half-finished
+language picks up where it left off.
+
+## 3. Translate
+
+Hand each manifest to whatever is doing the work. The manifest's own
+`instructions` field states the contract; the short version:
+
+- Translate only `chapters[].items[].he`. Return one entry per item.
+- `glossary.entries` is binding — use `canonicalEn` for every occurrence unless
+  the entry's `note` carves out a sense distinction.
+- `chapters[].context` is the Ari's text these notes gloss. **Not for
+  translation** — it is there so terminology matches the pane the reader sees
+  beside the notes, especially `targetText` where it exists.
+- Preserve inline HTML (`<b>`, `<br>`, `<small>`) exactly.
+
+Expected result shape:
+
+```json
+{
+  "batch": "en-060",
+  "targetVersionId": "en-ai",
+  "translations": [
+    { "chapterId": "part-12/chapter-177", "anchorId": "op-1", "html": "…" }
+  ]
+}
+```
+
+## 4. Apply
+
+```sh
+pnpm translate:apply --file result.json --dry-run   # see what would happen
+pnpm translate:apply --file result.json
+```
+
+It refuses the whole file — writing nothing — if any item is missing, duplicated,
+empty, unknown to the Hebrew source, already translated, or still mostly Hebrew
+(untranslated passthrough). Then it writes the files, adds the version to each
+chapter's ToC entry, and re-derives the split ToC files.
+
+## 5. Gate
+
+```sh
+pnpm validate:content
+task check
+```
+
+Commit one part at a time, matching the existing history
+(`feat(content): translate part N Ohr Pnimi commentary to <language>`). No AI
+attribution in the commit — the `en-ai`-style badge in the UI is the one place
+AI authorship is declared, and the version registry already handles it.
+
+## Scale
+
+Measured 2026-08-13, English:
+
+```
+chapters      783
+items       1,255
+source    2,106,747 characters
+batches       121 at a 20,000-character budget
+```
+
+Every other language starts from zero — 2,088 source chapters and 1,654
+commentary items each — so English is the smallest of the thirteen.
+
+## Quality note
+
+The glossary was mined from parts 1, 2, 3, 5 and 6, but **99.5% of the
+untranslated commentary lives in parts 7–16**. Its 125 terms are binding
+everywhere, but it has not seen the vocabulary of the parts being translated.
+
+Translate one part, review it against the Hebrew, then scale. `--part` exists
+for exactly that.

--- a/package.json
+++ b/package.json
@@ -23,7 +23,9 @@
     "import:sefaria": "tsx scripts/import-sefaria.ts",
     "import:kabbalahmedia": "tsx scripts/import-kabbalahmedia.ts",
     "migrate:consolidate-qa": "tsx scripts/migrate-consolidate-qa.ts",
-    "migrate:commentary-labels": "tsx scripts/migrate-commentary-labels.ts"
+    "migrate:commentary-labels": "tsx scripts/migrate-commentary-labels.ts",
+    "translate:export": "tsx scripts/translate-export.ts",
+    "translate:apply": "tsx scripts/translate-apply.ts"
   },
   "dependencies": {
     "@nuxtjs/i18n": "^10.6.0",

--- a/scripts/lib/translation-batches.ts
+++ b/scripts/lib/translation-batches.ts
@@ -1,0 +1,114 @@
+/**
+ * Pure batching logic for the translation pipeline (issue #87 and the twelve
+ * languages after it).
+ *
+ * Kept free of the filesystem so the two things that decide correctness — WHAT
+ * is missing, and HOW it is grouped — are unit-testable without a corpus.
+ * `scripts/translate-export.ts` supplies the data and writes the manifests.
+ *
+ * Two facts from the corpus drive the design:
+ *
+ *  - **Batch by characters, never by item count.** Commentary items run from
+ *    29 to 37,057 characters — a 1,278x spread. Ten items can be a paragraph
+ *    or a small book.
+ *  - **Never split a chapter.** The emitted artifact is one file per chapter;
+ *    splitting one across batches would mean two half-files racing to write
+ *    the same path, for no benefit. A chapter that exceeds the budget on its
+ *    own becomes its own batch instead.
+ */
+import type {
+  CommentaryItem,
+  SourceSegment,
+} from "../../shared/types/content.ts";
+
+/** Tags stripped — budgeting on markup would charge for `<b>` and mis-size every batch. */
+export const proseLength = (html: string): number =>
+  html.replace(/<[^>]+>/g, "").length;
+
+export interface TranslatableChapter {
+  chapterId: string;
+  /** Items present in the source version but not yet in the target version. */
+  items: CommentaryItem[];
+  /** The chapter's source text in the source language — context, never translated. */
+  sourceSegments: SourceSegment[];
+  /** The same text in the target language where it exists, so terminology matches the pane beside it. */
+  targetSegments: SourceSegment[] | null;
+}
+
+export interface TranslationBatch {
+  /** Stable, ordered id — `<lang>-<partId>-<nnn>`, so a rerun overwrites rather than duplicates. */
+  id: string;
+  chapters: TranslatableChapter[];
+  /** Source-language characters of prose in this batch, tags excluded. */
+  chars: number;
+  items: number;
+}
+
+/**
+ * The items of `sourceItems` that `targetItems` does not already cover, matched
+ * on `anchorId`.
+ *
+ * Partial chapters are normal and supported: `checkTranslatedVersionIntegrity`
+ * explicitly allows a translated commentary file to be a subset, so a batch may
+ * top up a chapter that an earlier run half-finished.
+ */
+export const untranslatedItems = (
+  sourceItems: CommentaryItem[],
+  targetItems: readonly CommentaryItem[],
+): CommentaryItem[] => {
+  const covered = new Set(targetItems.map((item) => item.anchorId));
+  return sourceItems
+    .filter((item) => !covered.has(item.anchorId))
+    .sort((a, b) => a.order - b.order);
+};
+
+/**
+ * Packs chapters into batches of at most `budgetChars` of source prose,
+ * preserving input order so batch ids stay stable across runs.
+ *
+ * A chapter larger than the whole budget gets a batch to itself rather than
+ * being split or silently dropped — the caller sees it in the manifest's own
+ * `chars` figure and can lower the budget for that run if a model chokes.
+ */
+export const packBatches = (
+  chapters: TranslatableChapter[],
+  budgetChars: number,
+  idPrefix: string,
+): TranslationBatch[] => {
+  const batches: TranslationBatch[] = [];
+  let current: TranslatableChapter[] = [];
+  let currentChars = 0;
+
+  const flush = () => {
+    if (current.length === 0) return;
+    batches.push({
+      id: `${idPrefix}-${String(batches.length + 1).padStart(3, "0")}`,
+      chapters: current,
+      chars: currentChars,
+      items: current.reduce((sum, chapter) => sum + chapter.items.length, 0),
+    });
+    current = [];
+    currentChars = 0;
+  };
+
+  for (const chapter of chapters) {
+    const chapterChars = chapter.items.reduce(
+      (sum, item) => sum + proseLength(item.html),
+      0,
+    );
+
+    // Close the open batch first when this chapter would overflow it, so the
+    // oversize-chapter case below lands in a batch of its own rather than
+    // being appended to whatever was already accumulating.
+    if (current.length > 0 && currentChars + chapterChars > budgetChars)
+      flush();
+
+    current.push(chapter);
+    currentChars += chapterChars;
+
+    if (currentChars >= budgetChars) flush();
+  }
+
+  flush();
+  return batches;
+};

--- a/scripts/translate-apply.ts
+++ b/scripts/translate-apply.ts
@@ -1,0 +1,273 @@
+/**
+ * Ingests a translated batch result and writes the corpus files.
+ *
+ * `pnpm translate:apply --file <result>.json [--dry-run]`
+ *
+ * The result file carries ONLY `{ chapterId, anchorId, html }` per item. Every
+ * other field on a `CommentaryItem` — `order`, `label`, `sefariaRef`,
+ * `section`, `targetSeif` — is copied byte-for-byte from the Hebrew source
+ * here, never from the model. That is the pipeline's safety property: three of
+ * those fields are invisible to `validate:content` (it checks neither
+ * `section` nor `sefariaRef`, and `label` only for anchored items), so a model
+ * quietly altering one would otherwise ship undetected. Keeping them out of the
+ * model's reach is what makes it safe to hand a batch to a model nobody here
+ * has evaluated.
+ *
+ * Checks before writing anything (all-or-nothing per file):
+ *  - every requested item is present, exactly once, and no extras
+ *  - `html` is non-empty and is not still Hebrew (untranslated passthrough)
+ *  - the source item exists and is unambiguous
+ *
+ * Then: writes the files, adds the version to each chapter's ToC entry, and
+ * re-derives the split ToC files — the same three-step sequence
+ * `migrate-consolidate-qa.ts` uses, in the same order. Writing files without
+ * the ToC update (or the reverse) fails `checkTocFileCrossReferences`.
+ */
+import { existsSync, readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+import {
+  chapterLayerFileSchema,
+  tocSchema,
+  versionsFileSchema,
+  type ChapterLayerFile,
+  type CommentaryItem,
+} from "../shared/types/content.ts";
+import { writeTocSplitFiles } from "./lib/toc-splits.ts";
+
+const CONTENT_ROOT = fileURLToPath(new URL("../content", import.meta.url));
+
+const arg = (flag: string): string | undefined => {
+  const index = process.argv.indexOf(flag);
+  return index === -1 ? undefined : process.argv[index + 1];
+};
+
+const resultPath = arg("--file");
+const isDryRun = process.argv.includes("--dry-run");
+
+if (!resultPath) {
+  console.error("usage: pnpm translate:apply --file <result>.json [--dry-run]");
+  process.exit(2);
+}
+
+interface TranslationResult {
+  batch?: string;
+  targetVersionId?: string;
+  translations: { chapterId: string; anchorId: string; html: string }[];
+}
+
+const result = JSON.parse(
+  readFileSync(resultPath, "utf8"),
+) as TranslationResult;
+
+if (!Array.isArray(result.translations) || result.translations.length === 0) {
+  console.error(`${resultPath}: no \`translations\` array, or it is empty.`);
+  process.exit(1);
+}
+
+const versions = versionsFileSchema.parse(
+  JSON.parse(readFileSync(join(CONTENT_ROOT, "versions.json"), "utf8")),
+);
+
+const targetVersionId = result.targetVersionId;
+const targetVersion = versions.find((v) => v.id === targetVersionId);
+if (!targetVersion) {
+  console.error(
+    `${resultPath}: \`targetVersionId\` ${JSON.stringify(targetVersionId)} is not in content/versions.json.`,
+  );
+  process.exit(1);
+}
+
+const sourceVersionId = targetVersion.translatedFrom ?? "he-jerusalem-1956";
+
+/** Hebrew letters. An item that comes back still full of them was not translated. */
+const HEBREW = /[֐-׿]/g;
+
+const errors: string[] = [];
+
+const byChapter = new Map<string, { anchorId: string; html: string }[]>();
+for (const entry of result.translations) {
+  if (!entry?.chapterId || !entry?.anchorId) {
+    errors.push(
+      `an entry is missing chapterId or anchorId: ${JSON.stringify(entry)}`,
+    );
+    continue;
+  }
+  const list = byChapter.get(entry.chapterId) ?? [];
+  list.push({ anchorId: entry.anchorId, html: entry.html });
+  byChapter.set(entry.chapterId, list);
+}
+
+interface PendingWrite {
+  path: string;
+  chapterId: string;
+  file: ChapterLayerFile<CommentaryItem>;
+  added: number;
+}
+
+const pending: PendingWrite[] = [];
+
+for (const [chapterId, translations] of byChapter) {
+  const [partId, slug] = chapterId.split("/");
+  const dir = join(
+    CONTENT_ROOT,
+    "parts",
+    partId as string,
+    "chapters",
+    slug as string,
+  );
+  const sourcePath = join(dir, `commentary.${sourceVersionId}.json`);
+
+  if (!existsSync(sourcePath)) {
+    errors.push(
+      `${chapterId}: no ${sourceVersionId} commentary file to copy structure from`,
+    );
+    continue;
+  }
+
+  const parsedSource = chapterLayerFileSchema.parse(
+    JSON.parse(readFileSync(sourcePath, "utf8")),
+  );
+  if (parsedSource.layer !== "commentary") continue;
+  const sourceByAnchor = new Map(
+    parsedSource.items.map((item) => [item.anchorId, item]),
+  );
+
+  const targetPath = join(dir, `commentary.${targetVersion.id}.json`);
+  const existing = existsSync(targetPath)
+    ? chapterLayerFileSchema.parse(JSON.parse(readFileSync(targetPath, "utf8")))
+    : null;
+  const items: CommentaryItem[] =
+    existing?.layer === "commentary" ? [...existing.items] : [];
+  const alreadyPresent = new Set(items.map((item) => item.anchorId));
+
+  const seen = new Set<string>();
+  let added = 0;
+
+  for (const { anchorId, html } of translations) {
+    if (seen.has(anchorId)) {
+      errors.push(`${chapterId}: ${anchorId} returned more than once`);
+      continue;
+    }
+    seen.add(anchorId);
+
+    const sourceItem = sourceByAnchor.get(anchorId);
+    if (!sourceItem) {
+      errors.push(
+        `${chapterId}: ${anchorId} does not exist in ${sourceVersionId}`,
+      );
+      continue;
+    }
+    if (alreadyPresent.has(anchorId)) {
+      errors.push(
+        `${chapterId}: ${anchorId} is already translated — refusing to overwrite`,
+      );
+      continue;
+    }
+    if (typeof html !== "string" || html.trim().length === 0) {
+      errors.push(`${chapterId}: ${anchorId} has empty html`);
+      continue;
+    }
+    // A stray Hebrew word (a quoted term) is fine; a body that is still
+    // mostly Hebrew is untranslated passthrough.
+    const hebrewChars = (html.match(HEBREW) ?? []).length;
+    if (hebrewChars > html.replace(/<[^>]+>/g, "").length * 0.3) {
+      errors.push(
+        `${chapterId}: ${anchorId} looks untranslated (${hebrewChars} Hebrew characters)`,
+      );
+      continue;
+    }
+
+    // Everything but `html` is copied verbatim — see the module doc.
+    items.push({ ...sourceItem, html });
+    added++;
+  }
+
+  if (added === 0) continue;
+
+  items.sort((a, b) => a.order - b.order);
+
+  pending.push({
+    path: targetPath,
+    chapterId,
+    added,
+    file: {
+      chapterId,
+      layer: "commentary",
+      versionId: targetVersion.id,
+      ...(parsedSource.sefariaRef
+        ? { sefariaRef: parsedSource.sefariaRef }
+        : {}),
+      items,
+    },
+  });
+}
+
+if (errors.length > 0) {
+  console.error(`${errors.length} problem(s) — nothing written:\n`);
+  for (const error of errors) console.error(`  ✖ ${error}`);
+  process.exit(1);
+}
+
+if (pending.length === 0) {
+  console.log("Nothing to write — every translation was already present.");
+  process.exit(0);
+}
+
+for (const write of pending) {
+  const relative = write.path.slice(CONTENT_ROOT.length + 1);
+  console.log(
+    `${isDryRun ? "would write" : "wrote"} ${relative} (+${write.added} items)`,
+  );
+  if (!isDryRun) {
+    writeFileSync(
+      write.path,
+      `${JSON.stringify(write.file, null, 2)}\n`,
+      "utf8",
+    );
+  }
+}
+
+// The ToC must name every file on disk and vice versa — one without the other
+// fails `checkTocFileCrossReferences`. Splits are re-derived from the updated
+// toc.json, never hand-edited.
+const tocPath = join(CONTENT_ROOT, "toc.json");
+const toc = tocSchema.parse(JSON.parse(readFileSync(tocPath, "utf8")));
+const touched = new Set(pending.map((write) => write.chapterId));
+let tocChanged = 0;
+
+for (const volume of toc.volumes) {
+  for (const part of volume.parts) {
+    for (const chapter of part.chapters) {
+      if (!touched.has(chapter.id)) continue;
+      if (!chapter.availableVersions.commentary.includes(targetVersion.id)) {
+        chapter.availableVersions.commentary = [
+          ...chapter.availableVersions.commentary,
+          targetVersion.id,
+        ].sort();
+        tocChanged++;
+      }
+      if (!chapter.availableLayers.includes("commentary")) {
+        chapter.availableLayers = [
+          ...chapter.availableLayers,
+          "commentary" as const,
+        ].sort();
+      }
+    }
+  }
+}
+
+console.log(
+  `${isDryRun ? "would update" : "updated"} toc.json for ${tocChanged} chapter(s)`,
+);
+
+if (!isDryRun) {
+  writeFileSync(tocPath, `${JSON.stringify(toc, null, 2)}\n`, "utf8");
+  writeTocSplitFiles(CONTENT_ROOT, toc, versions);
+  console.log("re-derived toc.volumes.json + toc.parts/*.json");
+}
+
+console.log(
+  `\n${isDryRun ? "[dry run] " : ""}${pending.reduce((n, w) => n + w.added, 0)} items across ${pending.length} file(s).` +
+    `${isDryRun ? "" : "\nNext: `pnpm validate:content`, then `task check`."}`,
+);

--- a/scripts/translate-export.ts
+++ b/scripts/translate-export.ts
@@ -1,0 +1,281 @@
+/**
+ * Exports translation work as self-contained batch manifests — one JSON file
+ * per batch, ready to hand to any model or agent, in any tool, offline.
+ *
+ * `pnpm translate:export --lang <code> [--part part-05] [--budget 20000] [--out DIR]`
+ *
+ * The pipeline's contract, and the reason it is split into export/apply:
+ * **only the translated `html` ever passes through a model.** `anchorId`,
+ * `order`, `label`, `section`, `sefariaRef` and `targetSeif` are copied
+ * byte-for-byte from the source file by `translate-apply.ts`. Several of those
+ * are invisible to `validate:content` (it never checks `section` or
+ * `sefariaRef`), so a model silently corrupting one would ship. Keeping them
+ * out of the model's reach is what makes the pipeline safe to run at scale and
+ * with a model nobody here has evaluated.
+ *
+ * Each manifest carries everything a translator needs and nothing it doesn't:
+ *
+ *  - the binding glossary (entries minus citations, plus conventions and the
+ *    resolutions for terms the printed edition contradicts itself on),
+ *  - per chapter, the Ari's text in the source language and — where it exists —
+ *    the same text already in the target language, as CONTEXT. Ohr Pnimi is a
+ *    lemma-based gloss on the seif above it, and it sits next to the target
+ *    source text in the reader, so terminology has to match that, not merely
+ *    the glossary.
+ *  - the items to translate, each keyed by `chapterId` + `anchorId`.
+ *
+ * Batches are packed by source-prose characters, never item count — the corpus
+ * runs 29 to 37,057 characters per item. See `lib/translation-batches.ts`.
+ */
+import {
+  existsSync,
+  mkdirSync,
+  readdirSync,
+  readFileSync,
+  writeFileSync,
+} from "node:fs";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+import {
+  chapterLayerFileSchema,
+  glossaryIndexFileSchema,
+  tocSchema,
+  versionsFileSchema,
+  type CommentaryItem,
+  type SourceSegment,
+} from "../shared/types/content.ts";
+import {
+  packBatches,
+  proseLength,
+  untranslatedItems,
+  type TranslatableChapter,
+} from "./lib/translation-batches.ts";
+
+const CONTENT_ROOT = fileURLToPath(new URL("../content", import.meta.url));
+const SOURCE_VERSION_ID = "he-jerusalem-1956";
+const DEFAULT_BUDGET_CHARS = 20_000;
+
+const arg = (flag: string): string | undefined => {
+  const index = process.argv.indexOf(flag);
+  return index === -1 ? undefined : process.argv[index + 1];
+};
+
+const targetLanguage = arg("--lang");
+if (!targetLanguage) {
+  console.error(
+    "usage: pnpm translate:export --lang <code> [--part part-05] [--budget 20000] [--out DIR]",
+  );
+  process.exit(2);
+}
+
+const partFilter = arg("--part");
+const budgetChars = Number(arg("--budget") ?? DEFAULT_BUDGET_CHARS);
+const outDir =
+  arg("--out") ??
+  fileURLToPath(new URL(`../.translation/${targetLanguage}`, import.meta.url));
+
+const versions = versionsFileSchema.parse(
+  JSON.parse(readFileSync(join(CONTENT_ROOT, "versions.json"), "utf8")),
+);
+
+/**
+ * The version new translations are written to: the target language's `ai`
+ * version. Resolved from the registry rather than assumed to be `<lang>-ai`,
+ * so a differently-named AI edition still works.
+ */
+const targetVersion = versions.find(
+  (version) => version.language === targetLanguage && version.source === "ai",
+);
+
+if (!targetVersion) {
+  console.error(
+    `No AI version registered for language "${targetLanguage}" in content/versions.json.\n` +
+      `Add one before exporting, e.g.:\n\n` +
+      JSON.stringify(
+        {
+          id: `${targetLanguage}-ai`,
+          language: targetLanguage,
+          direction: targetLanguage === "fa" ? "rtl" : "ltr",
+          title: `<Language> (AI translation)`,
+          license: "CC0",
+          source: "ai",
+          translatedFrom: SOURCE_VERSION_ID,
+        },
+        null,
+        2,
+      ),
+  );
+  process.exit(1);
+}
+
+/** Every version in the target language, so an item already covered by a human edition is never re-translated. */
+const targetLanguageVersionIds = new Set(
+  versions.filter((v) => v.language === targetLanguage).map((v) => v.id),
+);
+
+const readLayer = (dir: string, fileName: string) => {
+  const path = join(dir, fileName);
+  if (!existsSync(path)) return null;
+  return chapterLayerFileSchema.parse(JSON.parse(readFileSync(path, "utf8")));
+};
+
+const toc = tocSchema.parse(
+  JSON.parse(readFileSync(join(CONTENT_ROOT, "toc.json"), "utf8")),
+);
+
+/** Chapter ids in reading order, so batch ids follow the book rather than the filesystem. */
+const chapterIds = toc.volumes
+  .flatMap((volume) => volume.parts)
+  .filter((part) => !partFilter || part.id === partFilter)
+  .flatMap((part) => part.chapters.map((chapter) => chapter.id));
+
+const chapters: TranslatableChapter[] = [];
+
+for (const chapterId of chapterIds) {
+  const [partId, slug] = chapterId.split("/");
+  const dir = join(
+    CONTENT_ROOT,
+    "parts",
+    partId as string,
+    "chapters",
+    slug as string,
+  );
+  if (!existsSync(dir)) continue;
+
+  const source = readLayer(dir, `commentary.${SOURCE_VERSION_ID}.json`);
+  if (!source || source.layer !== "commentary") continue;
+
+  // Anything any edition in the target language already covers is done.
+  const covered: CommentaryItem[] = [];
+  for (const fileName of readdirSync(dir)) {
+    const match = /^commentary\.(.+)\.json$/.exec(fileName);
+    if (!match || !targetLanguageVersionIds.has(match[1] as string)) continue;
+    const existing = readLayer(dir, fileName);
+    if (existing?.layer === "commentary") covered.push(...existing.items);
+  }
+
+  const items = untranslatedItems(source.items, covered);
+  if (items.length === 0) continue;
+
+  const sourceText = readLayer(dir, `source.${SOURCE_VERSION_ID}.json`);
+  const targetText = readLayer(dir, `source.${targetVersion.id}.json`);
+
+  chapters.push({
+    chapterId,
+    items,
+    sourceSegments:
+      sourceText?.layer === "source"
+        ? (sourceText.items as SourceSegment[])
+        : [],
+    targetSegments:
+      targetText?.layer === "source"
+        ? (targetText.items as SourceSegment[])
+        : null,
+  });
+}
+
+if (chapters.length === 0) {
+  console.log(
+    `Nothing to translate for "${targetLanguage}"${partFilter ? ` in ${partFilter}` : ""} — every source item is already covered.`,
+  );
+  process.exit(0);
+}
+
+// The binding terminology contract. The index form is used deliberately: the
+// full glossary is 307KB and ~72% of that is citations — evidence a translator
+// does not need per batch, and 122 copies of it is 24M characters of repeated
+// input. `canonicalEn`, `strategy` and `note` are what bind.
+const glossary = glossaryIndexFileSchema.parse(
+  JSON.parse(
+    readFileSync(join(CONTENT_ROOT, "glossary", "tes-en.index.json"), "utf8"),
+  ),
+);
+
+const INSTRUCTIONS = [
+  `Translate the Ohr Pnimi (Inner Light) commentary items in this batch from Hebrew into ${targetLanguage}.`,
+  "",
+  "Return JSON of the shape:",
+  '  { "batch": "<this batch id>", "translations": [ { "chapterId": "...", "anchorId": "op-N", "html": "..." } ] }',
+  "",
+  "Rules:",
+  "1. Translate ONLY the `html` of each item in `chapters[].items`. Return one entry per item, no more and no fewer.",
+  "2. `glossary.entries` is binding: use each term's `canonicalEn` for every occurrence unless its `note` carves out a sense distinction. `strategy` says whether a term is translated, transliterated, or an acronym. `glossary.knownGaps` lists what the glossary does NOT cover.",
+  "3. `chapters[].context` is NOT for translation. It is the Ari's text these notes gloss — match its terminology, especially `targetText` where present, since the reader sees it in the pane beside these notes.",
+  "4. Preserve inline HTML exactly (`<b>`, `<br>`, `<small>`, quotation marks). The html is rendered, not escaped.",
+  "5. Write in Rav Laitman's voice, using Bnei Baruch terminology.",
+  "6. Do not add commentary, notes, or bracketed explanations of your own. Bracketed glosses on first use of a transliterated term are the one exception, per the glossary's conventions.",
+  "",
+  "Everything else about each item — its number, label, target seif, section and reference — is assembled mechanically from the Hebrew source and must NOT be returned.",
+].join("\n");
+
+const batches = packBatches(
+  chapters,
+  budgetChars,
+  `${targetLanguage}${partFilter ? `-${partFilter}` : ""}`,
+);
+
+mkdirSync(outDir, { recursive: true });
+
+let totalItems = 0;
+let totalChars = 0;
+
+for (const batch of batches) {
+  const manifest = {
+    batch: batch.id,
+    targetLanguage,
+    targetVersionId: targetVersion.id,
+    sourceVersionId: SOURCE_VERSION_ID,
+    itemCount: batch.items,
+    sourceChars: batch.chars,
+    instructions: INSTRUCTIONS,
+    glossary: {
+      conventions: glossary.conventions,
+      knownGaps: glossary.knownGaps,
+      entries: glossary.entries,
+    },
+    chapters: batch.chapters.map((chapter) => ({
+      chapterId: chapter.chapterId,
+      context: {
+        sourceText: chapter.sourceSegments.map((s) => ({
+          n: s.n,
+          html: s.html,
+        })),
+        targetText:
+          chapter.targetSegments?.map((s) => ({ n: s.n, html: s.html })) ??
+          null,
+      },
+      items: chapter.items.map((item) => ({
+        anchorId: item.anchorId,
+        he: item.html,
+      })),
+    })),
+  };
+
+  writeFileSync(
+    join(outDir, `${batch.id}.json`),
+    `${JSON.stringify(manifest, null, 2)}\n`,
+    "utf8",
+  );
+
+  totalItems += batch.items;
+  totalChars += batch.chars;
+}
+
+const totalProse = chapters.reduce(
+  (sum, chapter) =>
+    sum + chapter.items.reduce((n, item) => n + proseLength(item.html), 0),
+  0,
+);
+
+console.log(
+  [
+    `language        ${targetLanguage} -> ${targetVersion.id}`,
+    `chapters        ${chapters.length}`,
+    `items           ${totalItems}`,
+    `source chars    ${totalChars.toLocaleString()} (${totalProse.toLocaleString()} total prose)`,
+    `batches         ${batches.length} (budget ${budgetChars.toLocaleString()} chars)`,
+    `written to      ${outDir}`,
+    ``,
+    `Next: translate each manifest, then \`pnpm translate:apply --file <result>.json\`.`,
+  ].join("\n"),
+);

--- a/tests/unit/translation-batches.spec.ts
+++ b/tests/unit/translation-batches.spec.ts
@@ -1,0 +1,194 @@
+import { describe, expect, it } from "vitest";
+import {
+  packBatches,
+  proseLength,
+  untranslatedItems,
+  type TranslatableChapter,
+} from "../../scripts/lib/translation-batches.ts";
+import type { CommentaryItem } from "../../shared/types/content.ts";
+
+const item = (
+  anchorId: string,
+  order: number,
+  html: string,
+): CommentaryItem => ({
+  anchorId,
+  order,
+  label: { he: String(order), en: String(order) },
+  section: "ohr-pnimi",
+  html,
+});
+
+const chapter = (
+  chapterId: string,
+  items: CommentaryItem[],
+): TranslatableChapter => ({
+  chapterId,
+  items,
+  sourceSegments: [],
+  targetSegments: null,
+});
+
+/** `n` characters of prose wrapped in markup, to prove tags aren't budgeted. */
+const prose = (n: number) => `<b>${"א".repeat(n)}</b>`;
+
+describe("proseLength", () => {
+  it("measures the text, not the markup", () => {
+    expect(proseLength("<b>abc</b>")).toBe(3);
+    expect(proseLength("one<br><small>(x)</small>")).toBe(6);
+  });
+
+  it("counts an untagged string as-is", () => {
+    expect(proseLength("hello")).toBe(5);
+  });
+});
+
+describe("untranslatedItems", () => {
+  it("returns the source items the target does not cover", () => {
+    const source = [
+      item("op-1", 1, "a"),
+      item("op-2", 2, "b"),
+      item("op-3", 3, "c"),
+    ];
+    const target = [item("op-2", 2, "translated")];
+
+    expect(untranslatedItems(source, target).map((i) => i.anchorId)).toEqual([
+      "op-1",
+      "op-3",
+    ]);
+  });
+
+  it("returns them in reading order regardless of input order", () => {
+    const source = [item("op-9", 9, "a"), item("op-2", 2, "b")];
+
+    expect(untranslatedItems(source, []).map((i) => i.order)).toEqual([2, 9]);
+  });
+
+  it("supports a partially translated chapter — the validator allows subsets", () => {
+    const source = [item("op-1", 1, "a"), item("op-2", 2, "b")];
+
+    expect(untranslatedItems(source, [source[0]!])).toHaveLength(1);
+  });
+
+  it("returns nothing when the chapter is fully covered", () => {
+    const source = [item("op-1", 1, "a")];
+    expect(untranslatedItems(source, source)).toEqual([]);
+  });
+});
+
+describe("packBatches", () => {
+  it("closes a batch rather than exceeding the budget", () => {
+    // Two 600-char chapters would be 1,200 against a 1,000 budget, so the
+    // first batch closes at one chapter. The budget is a ceiling, not a
+    // target — a token budget you overshoot is one a model may refuse.
+    const chapters = [
+      chapter("p/c1", [item("op-1", 1, prose(600))]),
+      chapter("p/c2", [item("op-1", 1, prose(600))]),
+      chapter("p/c3", [item("op-1", 1, prose(600))]),
+    ];
+
+    const batches = packBatches(chapters, 1000, "en");
+
+    expect(batches.map((b) => b.chapters.map((c) => c.chapterId))).toEqual([
+      ["p/c1"],
+      ["p/c2"],
+      ["p/c3"],
+    ]);
+  });
+
+  it("packs several chapters together when they fit", () => {
+    const chapters = [
+      chapter("p/c1", [item("op-1", 1, prose(300))]),
+      chapter("p/c2", [item("op-1", 1, prose(300))]),
+      chapter("p/c3", [item("op-1", 1, prose(300))]),
+      chapter("p/c4", [item("op-1", 1, prose(300))]),
+    ];
+
+    const batches = packBatches(chapters, 1000, "en");
+
+    expect(batches.map((b) => b.chapters.map((c) => c.chapterId))).toEqual([
+      ["p/c1", "p/c2", "p/c3"],
+      ["p/c4"],
+    ]);
+  });
+
+  it("never exceeds the budget except for a single oversize chapter", () => {
+    const chapters = Array.from({ length: 40 }, (_, index) =>
+      chapter(`p/c${index}`, [item("op-1", 1, prose(100 + index * 37))]),
+    );
+
+    for (const batch of packBatches(chapters, 1000, "en")) {
+      const overBudget = batch.chars > 1000;
+      expect(overBudget && batch.chapters.length > 1).toBe(false);
+    }
+  });
+
+  it("budgets on prose, so markup never inflates a batch", () => {
+    const chapters = [chapter("p/c1", [item("op-1", 1, prose(100))])];
+
+    expect(packBatches(chapters, 1000, "en")[0]?.chars).toBe(100);
+  });
+
+  it("gives an oversize chapter a batch of its own rather than splitting it", () => {
+    // The corpus's largest single item is 37,057 characters — nearly double a
+    // 20,000-char budget — and a chapter is one output file, so it must not be
+    // split across batches.
+    const chapters = [
+      chapter("p/small", [item("op-1", 1, prose(100))]),
+      chapter("p/huge", [item("op-1", 1, prose(37_057))]),
+      chapter("p/after", [item("op-1", 1, prose(100))]),
+    ];
+
+    const batches = packBatches(chapters, 20_000, "en");
+
+    expect(batches.map((b) => b.chapters.map((c) => c.chapterId))).toEqual([
+      ["p/small"],
+      ["p/huge"],
+      ["p/after"],
+    ]);
+  });
+
+  it("never splits a chapter's items across batches", () => {
+    const chapters = [
+      chapter("p/c1", [
+        item("op-1", 1, prose(800)),
+        item("op-2", 2, prose(800)),
+      ]),
+    ];
+
+    const batches = packBatches(chapters, 1000, "en");
+
+    expect(batches).toHaveLength(1);
+    expect(batches[0]?.items).toBe(2);
+  });
+
+  it("numbers batches in order with a stable, zero-padded id", () => {
+    const chapters = Array.from({ length: 3 }, (_, index) =>
+      chapter(`p/c${index}`, [item("op-1", 1, prose(1200))]),
+    );
+
+    expect(packBatches(chapters, 1000, "en-part-05").map((b) => b.id)).toEqual([
+      "en-part-05-001",
+      "en-part-05-002",
+      "en-part-05-003",
+    ]);
+  });
+
+  it("reports item and character totals per batch", () => {
+    const chapters = [
+      chapter("p/c1", [
+        item("op-1", 1, prose(300)),
+        item("op-2", 2, prose(200)),
+      ]),
+    ];
+
+    const [batch] = packBatches(chapters, 10_000, "en");
+
+    expect(batch?.items).toBe(2);
+    expect(batch?.chars).toBe(500);
+  });
+
+  it("returns no batches for no chapters", () => {
+    expect(packBatches([], 1000, "en")).toEqual([]);
+  });
+});


### PR DESCRIPTION
Unblocks #87 and the twelve languages after it.

Two commands, offline, no vendor coupling. `translate:export` writes
self-contained JSON manifests; anything that reads and writes JSON does the
translating — this session, another Claude, a different vendor's model, or a
person. `translate:apply` takes the results back.

## The safety property

**Only the translated `html` ever passes through a model.** `anchorId`, `order`,
`label`, `sefariaRef`, `section` and `targetSeif` are copied byte-for-byte from
the Hebrew source on apply.

That isn't fussiness: `validate:content` checks neither `section` nor
`sefariaRef`, and checks `label` only for anchored items — so a model quietly
altering one of those would pass every gate and ship. Keeping them out of its
reach is what makes it safe to hand a batch to a model nobody here has
evaluated.

## Design decisions worth reviewing

- **Batch by characters, never item count.** Items run 29 → 37,057 characters, a
  1,278× spread; ten items can be a paragraph or a small book.
- **Never split a chapter.** One chapter is one output file — splitting would
  mean two half-files racing for the same path. An oversize chapter gets a batch
  to itself.
- **Budget is a ceiling, not a target.** A token budget you overshoot is one a
  model may refuse.
- **Glossary in index form.** The full file is 307KB and ~72% of that is
  citations the translator doesn't need per batch; at 121 batches that would be
  24M characters of repeated input. `canonicalEn`, `strategy` and `note` bind.
- **Context, not just glossary.** Each chapter carries the Ari's text in Hebrew
  and — where it exists — in the target language. Ohr Pnimi is a lemma-based
  gloss on the seif above it and sits beside the target source text in the
  reader, so terminology has to match that, not merely the glossary.
- **Resumable.** Export only offers what no version in the target language
  already covers.

## Verification

`task check` exit 0 — **871 unit tests** (up from 856), content validation, full
generate, 5/5 e2e.

End to end, for real:

1. `pnpm translate:export --lang en` → **783 chapters / 1,255 items / 2,106,747
   characters / 121 batches**, matching an independent measurement of the gap.
2. A deliberately corrupted result file — untranslated passthrough, a duplicate
   anchor, an anchor that doesn't exist, and empty html — was rejected with all
   four errors named and **nothing written**.
3. A real translation of `part-12/chapter-177` applied, updated `toc.json`,
   re-derived the splits, and passed `validate:content`. Every field but `html`
   came from the Hebrew file.

Docs: `docs/translation-pipeline.md`

Refs #87