### PR TITLE
fix(import): apply Sefaria's index offsets when composing refs

### DIFF
--- a/scripts/import-sefaria.ts
+++ b/scripts/import-sefaria.ts
@@ -337,6 +337,7 @@ const importPart = async (
       unit.chapterRef,
       unit.heItems,
       extractHeadings,
+      unit.number - 1,
     );
     const en =
       unit.enItems.length > 0
@@ -345,6 +346,7 @@ const importPart = async (
             unit.chapterRef,
             unit.enItems,
             extractHeadings,
+            unit.number - 1,
           )
         : { segments: [], droppedAnchors: [] };
 
@@ -415,10 +417,17 @@ const importPart = async (
         unit.chapterRef,
         unit.heItems,
         false,
+        unit.number - 1,
       );
       const en =
         unit.enItems.length > 0
-          ? buildSourceSegments(node, unit.chapterRef, unit.enItems, false)
+          ? buildSourceSegments(
+              node,
+              unit.chapterRef,
+              unit.enItems,
+              false,
+              unit.number - 1,
+            )
           : { segments: [], droppedAnchors: [] };
 
       for (const dropped of [...he.droppedAnchors, ...en.droppedAnchors]) {

--- a/scripts/lib/chapter-units.ts
+++ b/scripts/lib/chapter-units.ts
@@ -55,6 +55,7 @@ export const buildChapterUnits = (
     const chapterRef = chapterRefFor(
       refBase,
       singleImplicitChapter ? undefined : number,
+      node.index_offsets_by_depth,
     );
 
     return {

--- a/scripts/lib/jagged-array.ts
+++ b/scripts/lib/jagged-array.ts
@@ -16,6 +16,13 @@ export interface JaggedNodeShape {
   depth?: number;
   /** e.g. `['Chapter', 'Seif']`, `['Paragraph']`, `['Siman', 'Paragraph']`, `['Chapter']`. */
   sectionNames?: string[];
+  /**
+   * Sefaria's `index_offsets_by_depth` — some nodes do not start at 1, and a
+   * ref composed without this names an item that 404s upstream (issue #103).
+   * Carried on the node so both ref builders receive it without every caller
+   * threading a separate argument. See `sefaria-refs.ts` for the two shapes.
+   */
+  index_offsets_by_depth?: Record<string, number | number[]>;
 }
 
 const asLeaf = (value: SefariaJaggedText): string =>

--- a/scripts/lib/sefaria-api-types.ts
+++ b/scripts/lib/sefaria-api-types.ts
@@ -26,6 +26,13 @@ export interface SefariaIndexNode {
   default?: boolean;
   titles?: SefariaIndexTitle[];
   nodes?: SefariaIndexNode[];
+  /**
+   * Sefaria's own snake_case field — some nodes do not start at 1, and a ref
+   * composed without it 404s upstream (issue #103). Kept under the wire name
+   * so a raw index node satisfies `JaggedNodeShape` structurally, the same way
+   * `sectionNames` already does.
+   */
+  index_offsets_by_depth?: Record<string, number | number[]>;
 }
 
 export interface SefariaIndex {

--- a/scripts/lib/sefaria-refs.ts
+++ b/scripts/lib/sefaria-refs.ts
@@ -3,35 +3,94 @@
  * (see `jagged-array.ts` for the same convention) and a base ref for the
  * node itself, builds the chapter-level and segment-level refs Sefaria
  * would recognize for a given (chapterIndex, itemIndex) position.
+ *
+ * ## Index offsets (issue #103)
+ *
+ * Some nodes do not start at 1. Sefaria publishes that as
+ * `index_offsets_by_depth` on the node, and a ref composed without it names
+ * an item that does not exist — verified live: the ref we used to write for
+ * `part-06/questions-topics-01` item 1 returns 404, and the offset-corrected
+ * one returns exactly that item's text.
+ *
+ * Two shapes, both observed in this book's index:
+ *
+ * - **`{"1": 30}` — a scalar on the FIRST address component.** Which
+ *   component that is depends on the node's depth: on a depth-1
+ *   `[Paragraph]` list it is the paragraph (the segment), on a depth-2
+ *   `[Siman, Paragraph]` list it is the siman (the chapter). Section VI's
+ *   topics questions/answers both carry 30 — that part's terminology answer
+ *   count — which is the same continuous-numbering model
+ *   `app/utils/sefariaCrossRefs.ts` documents for cross-links.
+ * - **`{"2": [0, 9, 14, …]}` — an array on the SECOND component, indexed by
+ *   chapter.** Histaklut Penimit uses this: chapter 2's paragraphs start
+ *   after 9, so its first paragraph is `…2:10`. Confirmed against the API —
+ *   `…Histaklut Penimit 2:1` is a 404 and `2:10` is a 200.
  */
 import type { JaggedNodeShape } from "./jagged-array.ts";
+
+/**
+ * `index_offsets_by_depth` as Sefaria publishes it: keyed by depth (as a
+ * string), each value either a scalar applying to every address at that
+ * depth, or an array giving a distinct offset per parent index.
+ */
+export type IndexOffsetsByDepth = Record<string, number | number[]>;
+
+/** The offset at `depth`, for a position under parent index `parentIndex` (0-based). */
+const offsetAt = (
+  offsets: IndexOffsetsByDepth | undefined,
+  depth: number,
+  parentIndex = 0,
+): number => {
+  const value = offsets?.[String(depth)];
+  if (value === undefined) return 0;
+  if (typeof value === "number") return value;
+  return value[parentIndex] ?? 0;
+};
 
 /**
  * The chapter-level ref for the `chapterIndex`-th (1-based) chapter of a
  * node. `chapterIndex` is `undefined` for depth-1 non-"Chapter" nodes
  * (sibling Paragraph lists), where the whole node is a single implicit
- * chapter and `refBase` itself already names it.
+ * chapter and `refBase` itself already names it — the depth-1 offset there
+ * belongs on the segment instead, and `segmentRefFor` applies it.
  */
 export const chapterRefFor = (
   refBase: string,
   chapterIndex: number | undefined,
+  offsets?: IndexOffsetsByDepth,
 ): string =>
-  chapterIndex === undefined ? refBase : `${refBase} ${chapterIndex}`;
+  chapterIndex === undefined
+    ? refBase
+    : `${refBase} ${chapterIndex + offsetAt(offsets, 1)}`;
 
 /**
  * The segment-level ref for the `itemIndex`-th (1-based) item within a
  * chapter whose own ref is `chapterRef`.
+ *
+ * `chapterIndex` is 0-based and only used to select a per-chapter offset
+ * from the depth-2 array form; it is irrelevant to the scalar form.
  */
 export const segmentRefFor = (
   chapterRef: string,
   node: JaggedNodeShape,
   itemIndex: number,
+  offsets?: IndexOffsetsByDepth,
+  chapterIndex = 0,
 ): string => {
   const depth = node.depth ?? 1;
 
-  if (depth >= 2) return `${chapterRef}:${itemIndex}`;
-  if ((node.sectionNames ?? [])[0] === "Chapter") return chapterRef; // whole chapter is the one segment
-  return `${chapterRef} ${itemIndex}`;
+  // Depth 2+: the item is the second component, so the depth-2 offset
+  // applies — per chapter, when it is given as an array.
+  if (depth >= 2)
+    return `${chapterRef}:${itemIndex + offsetAt(offsets, 2, chapterIndex)}`;
+
+  // Depth 1 addressed as `[Chapter]`: the whole chapter is the one segment,
+  // already named by `chapterRef` — there is no second component to offset.
+  if ((node.sectionNames ?? [])[0] === "Chapter") return chapterRef;
+
+  // Depth 1 `[Paragraph]`: the item IS the first address component, so the
+  // depth-1 offset lands here rather than on the chapter.
+  return `${chapterRef} ${itemIndex + offsetAt(offsets, 1)}`;
 };
 
 /** Chapter-level ref for the Ohr Penimi commentary index, addressed `[Section, Chapter, Seif]`. */

--- a/scripts/lib/transform.ts
+++ b/scripts/lib/transform.ts
@@ -81,6 +81,12 @@ export const buildSourceSegments = (
    * "don't force it" per the import brief.
    */
   extractHeadings: boolean,
+  /**
+   * 0-based position of this chapter within its node — selects the per-chapter
+   * entry when the node's depth-2 offset is given as an array (issue #103).
+   * Irrelevant to the scalar form, hence the default.
+   */
+  chapterIndex = 0,
 ): BuildSourceSegmentsResult => {
   const segments: SourceSegment[] = [];
   const droppedAnchors: DroppedAnchor[] = [];
@@ -89,7 +95,13 @@ export const buildSourceSegments = (
     if (rawHtml === "") return;
 
     const itemIndex = index + 1;
-    const sefariaRef = segmentRefFor(chapterRef, node, itemIndex);
+    const sefariaRef = segmentRefFor(
+      chapterRef,
+      node,
+      itemIndex,
+      node.index_offsets_by_depth,
+      chapterIndex,
+    );
     const { heading, rest } = extractHeadings
       ? extractLeadingHeading(rawHtml)
       : { heading: undefined, rest: rawHtml };

--- a/tests/unit/sefaria-refs-offsets.spec.ts
+++ b/tests/unit/sefaria-refs-offsets.spec.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it } from "vitest";
+import {
+  chapterRefFor,
+  segmentRefFor,
+  type IndexOffsetsByDepth,
+} from "../../scripts/lib/sefaria-refs.ts";
+
+// Shapes and offsets below are verbatim from Sefaria's own index for this
+// book (`/api/v2/raw/index/Talmud_Eser_HaSefirot`), and the expected refs
+// were confirmed live against `/api/v3/texts/…` — see issue #103.
+const PARAGRAPH_LIST = { depth: 1, sectionNames: ["Paragraph"] };
+const SIMAN_PARAGRAPH = { depth: 2, sectionNames: ["Siman", "Paragraph"] };
+const CHAPTER_PARAGRAPH = { depth: 2, sectionNames: ["Chapter", "Paragraph"] };
+const CHAPTER_ONLY = { depth: 1, sectionNames: ["Chapter"] };
+
+const SECTION_VI = "Talmud Eser HaSefirot, Section VI";
+const TOPICS_OFFSET: IndexOffsetsByDepth = { "1": 30 };
+/** Section I Histaklut Penimit — one cumulative paragraph offset per chapter. */
+const HISTAKLUT_OFFSET: IndexOffsetsByDepth = {
+  "2": [0, 9, 14, 15, 21, 23, 26, 28, 32, 34],
+};
+
+describe("index offsets — depth-1 scalar (issue #103)", () => {
+  const base = `${SECTION_VI}, List of Questions on Topics`;
+
+  it("offsets the segment on a flat Paragraph list, where the item is the first address component", () => {
+    // Verified live: `… List of Questions on Topics 1` is a 404 and `31` is a 200.
+    expect(segmentRefFor(base, PARAGRAPH_LIST, 1, TOPICS_OFFSET)).toBe(
+      `${base} 31`,
+    );
+    expect(segmentRefFor(base, PARAGRAPH_LIST, 12, TOPICS_OFFSET)).toBe(
+      `${base} 42`,
+    );
+  });
+
+  it("offsets the chapter on a Siman/Paragraph list, where the siman is the first component", () => {
+    const answers = `${SECTION_VI}, List of Answers on Topics`;
+
+    expect(chapterRefFor(answers, 1, TOPICS_OFFSET)).toBe(`${answers} 31`);
+    // ...and the paragraph within it is NOT offset — there is no depth-2 entry.
+    expect(
+      segmentRefFor(`${answers} 31`, SIMAN_PARAGRAPH, 1, TOPICS_OFFSET),
+    ).toBe(`${answers} 31:1`);
+  });
+
+  it("does not double-apply: a flat list's chapter ref is the base itself", () => {
+    expect(chapterRefFor(base, undefined, TOPICS_OFFSET)).toBe(base);
+  });
+});
+
+describe("index offsets — depth-2 array (issue #103)", () => {
+  const base = "Talmud Eser HaSefirot, Section I, Histaklut Penimit";
+
+  it("offsets the paragraph by its own chapter's entry", () => {
+    // Verified live: `…Histaklut Penimit 2:1` is a 404, `2:10` is a 200,
+    // and `3:15` is a 200.
+    expect(
+      segmentRefFor(`${base} 2`, CHAPTER_PARAGRAPH, 1, HISTAKLUT_OFFSET, 1),
+    ).toBe(`${base} 2:10`);
+    expect(
+      segmentRefFor(`${base} 3`, CHAPTER_PARAGRAPH, 1, HISTAKLUT_OFFSET, 2),
+    ).toBe(`${base} 3:15`);
+  });
+
+  it("leaves the first chapter unoffset — its entry is 0", () => {
+    expect(
+      segmentRefFor(`${base} 1`, CHAPTER_PARAGRAPH, 1, HISTAKLUT_OFFSET, 0),
+    ).toBe(`${base} 1:1`);
+  });
+
+  it("does not offset the chapter number itself — there is no depth-1 entry", () => {
+    expect(chapterRefFor(base, 2, HISTAKLUT_OFFSET)).toBe(`${base} 2`);
+  });
+
+  it("falls back to no offset for a chapter beyond the array", () => {
+    expect(
+      segmentRefFor(`${base} 99`, CHAPTER_PARAGRAPH, 1, HISTAKLUT_OFFSET, 98),
+    ).toBe(`${base} 99:1`);
+  });
+});
+
+describe("index offsets — nodes without them are unchanged", () => {
+  const base = "Talmud Eser HaSefirot, Section I";
+
+  it("composes a chapter ref with no offsets given", () => {
+    expect(chapterRefFor(base, 3)).toBe(`${base} 3`);
+  });
+
+  it("composes a segment ref with no offsets given", () => {
+    expect(segmentRefFor(`${base} 3`, CHAPTER_PARAGRAPH, 4)).toBe(
+      `${base} 3:4`,
+    );
+    expect(segmentRefFor(base, PARAGRAPH_LIST, 4)).toBe(`${base} 4`);
+  });
+
+  it("still treats a depth-1 [Chapter] node as its own single segment", () => {
+    expect(segmentRefFor(`${base} 3`, CHAPTER_ONLY, 1, { "1": 99 })).toBe(
+      `${base} 3`,
+    );
+  });
+});


### PR DESCRIPTION
Half of #103 — the composition fix. Some Sefaria nodes don't start at 1, and every ref we built for one pointed at an item that doesn't exist.

Verified live, before and after:

```
GET .../Section VI, List of Questions on Topics 1   -> 404
GET .../Section VI, List of Questions on Topics 31  -> 200  (exactly that item's text)
```

## Two offset shapes, both real, both confirmed against the API

- **`{"1": 30}` — scalar on the first address component.** Which component that is depends on depth: on a depth-1 `[Paragraph]` list it's the paragraph (segment level); on a depth-2 `[Siman, Paragraph]` list it's the siman (chapter level). Getting that distinction wrong would just write a *different* set of wrong refs, so it's tested both ways.
- **`{"2": [0, 9, 14, …]}` — array on the second component, indexed by chapter.** Histaklut Penimit uses this. Checked live: `…Histaklut Penimit 2:1` is a **404**, `2:10` is a **200**, `3:15` is a **200** — matching entries 9 and 14.

Section VI's topics offset is 30, which is that part's terminology answer count — the same continuous-numbering model `app/utils/sefariaCrossRefs.ts` already documents for cross-links.

## Design note

The offsets ride on the node under Sefaria's own snake_case field name, so a raw index node satisfies `JaggedNodeShape` structurally — exactly as `sectionNames` already does. No mapping layer, and no call site threading a separate argument.

## What this does NOT do

**The refs already in `content/` are still wrong.** This fixes composition, so a future import writes them correctly; rewriting the 32 topics nodes plus the Section I/II/IV Histaklut Penimit refs is the other half of #103 and needs its own migration.

Doing this half first matters for #86: the Cause-and-Effect nodes carry offset 137, so importing them before this landed would have written a fresh batch of broken refs.

## Verification

881 unit tests (up from 871), including 10 new ones asserting each offset shape against the exact values in Sefaria's index. Content validation, typecheck, lint, full generate all pass.

One e2e failure in the gate — `mobile reader › defaults to study mode and offers swipe panes` — is the known flake in that spec; it passed **3/3** standalone afterwards, and this change touches only importer libs with no app code in the diff.

Refs #103