### PR TITLE
fix(reader): let a pane tap win over the settle commit it interrupts

### DIFF
--- a/app/components/reader/MobileSwipePanes.vue
+++ b/app/components/reader/MobileSwipePanes.vue
@@ -220,6 +220,16 @@ const scrollToPane = (pane: PaneId, instant: boolean) => {
 };
 
 watch(activePane, (pane) => {
+  // Cancel first, then scroll. A pill tap during a swipe's settle window
+  // arrives with a commit already armed against the *pre-tap* ratios — that
+  // pending commit resolves the slide the finger left behind and immediately
+  // scrolls the track back to it, undoing the tap. Cancelling restarts the
+  // countdown from zero, so the observer's post-scroll batch (one frame away)
+  // always lands inside the new window and the commit that eventually fires
+  // resolves the pane the reader actually chose. When the commit itself is
+  // what changed `activePane`, the timer has already fired and this is a
+  // no-op. Root cause of the intermittent e2e failure in issue 106.
+  settleTimer.cancel();
   scrollToPane(pane, false);
 });
 

--- a/tests/e2e/reader.spec.ts
+++ b/tests/e2e/reader.spec.ts
@@ -181,6 +181,17 @@ test.describe("mobile reader", () => {
 
     // Swipe to the last slide, then tap back — the tap must scroll the
     // track even while the swipe's settle timer is still pending.
+    //
+    // This used to flake (issue 106) and the animation was a red herring:
+    // `reducedMotion: "reduce"` is already set project-wide in
+    // `playwright.config.ts`, so `scrollToPane`'s own scroll was instant the
+    // whole time. What raced was state, not motion — the settle commit armed
+    // by this smooth scroll resolved the pre-tap ratios and scrolled back to
+    // the last slide, which is exactly the 780 this assertion kept seeing.
+    // `MobileSwipePanes` now cancels that pending commit when `activePane`
+    // changes; `tests/unit/mobile-swipe-panes.spec.ts` pins the mechanism
+    // deterministically with fake timers, and this stays as the real-browser
+    // proof that a tap after a swipe moves the track.
     await page.evaluate(() => {
       const track = document.querySelector(
         "#reader-source-pane",

--- a/tests/unit/mobile-swipe-panes.spec.ts
+++ b/tests/unit/mobile-swipe-panes.spec.ts
@@ -13,6 +13,7 @@ import { mountSuspended } from "@nuxt/test-utils/runtime";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { defineComponent, h, nextTick } from "vue";
 import MobileSwipePanes from "~/components/reader/MobileSwipePanes.vue";
+import { DEFAULT_SETTLE_MS } from "~/utils/mobilePaneSync";
 import type { PaneId } from "~/utils/readerAnchorState";
 
 const stubMatchMedia = (matches: boolean) => {
@@ -29,6 +30,21 @@ const stubMatchMedia = (matches: boolean) => {
     })),
   );
 };
+
+/**
+ * The only fields `onIntersect` reads — `target` (for its `data-pane`) and
+ * `intersectionRatio`. Everything else on a real entry is layout the DOM
+ * stub cannot produce anyway.
+ */
+const entryFor = (
+  wrapper: { find: (selector: string) => { element: Element } },
+  pane: PaneId,
+  intersectionRatio: number,
+): IntersectionObserverEntry =>
+  ({
+    target: wrapper.find(`[data-pane="${pane}"]`).element,
+    intersectionRatio,
+  }) as IntersectionObserverEntry;
 
 const Host = defineComponent({
   props: {
@@ -125,6 +141,67 @@ describe("MobileSwipePanes", () => {
     await nextTick();
 
     expect(Element.prototype.scrollTo).toHaveBeenCalled();
+  });
+
+  it("lets a pill tap win over a settle commit still armed from the swipe it interrupted", async () => {
+    // The one piece of the swipe->settle direction that can be driven
+    // without real layout: the observer callback is captured and fed
+    // hand-written ratios, so the commit debounce runs for real against a
+    // known pre-tap visibility state. Reproduces the intermittent e2e
+    // failure in issue 106 — without the `settleTimer.cancel()` in the
+    // `activePane` watcher this ends on "inner-observation".
+    stubMatchMedia(true);
+    vi.useFakeTimers();
+    let notify: IntersectionObserverCallback | undefined;
+    vi.stubGlobal(
+      "IntersectionObserver",
+      class {
+        constructor(callback: IntersectionObserverCallback) {
+          notify = callback;
+        }
+        observe() {}
+        disconnect() {}
+      },
+    );
+
+    try {
+      const wrapper = await mountSuspended(Host);
+      await nextTick();
+
+      // A swipe has just carried the track to the last slide: the observer
+      // reports it fully visible, which arms a commit ~100ms out.
+      notify?.(
+        [
+          entryFor(wrapper, "source", 0),
+          entryFor(wrapper, "inner-observation", 1),
+        ],
+        {} as IntersectionObserver,
+      );
+      vi.advanceTimersByTime(DEFAULT_SETTLE_MS - 10);
+
+      // The reader taps "Inner Light" with 10ms left on that countdown.
+      wrapper.vm.state.setActivePane("commentary");
+      await nextTick();
+
+      // The stale deadline passes before the observer's post-scroll batch
+      // arrives — the window in which the interrupted commit used to fire
+      // and drag the track back to the slide the finger left behind.
+      vi.advanceTimersByTime(10);
+      await nextTick();
+      expect(wrapper.vm.state.activePane.value).toBe("commentary");
+
+      // The post-tap batch then confirms the same pane, one frame later.
+      notify?.(
+        [entryFor(wrapper, "commentary", 1), entryFor(wrapper, "source", 0)],
+        {} as IntersectionObserver,
+      );
+      vi.advanceTimersByTime(DEFAULT_SETTLE_MS);
+      await nextTick();
+
+      expect(wrapper.vm.state.activePane.value).toBe("commentary");
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it("never auto-scrolls on a wide (desktop grid) viewport", async () => {


### PR DESCRIPTION
Closes #106.

## The cause was state, not motion

The issue's leading theory was the smooth scroll racing the 5s poll deadline. That was a red herring: `playwright.config.ts` has set `reducedMotion: "reduce"` project-wide since the spec was written, and `scrollToPane` already honours `prefersReducedMotion()` — its scroll was instant the whole time.

What actually raced is the settle commit. `MobileSwipePanes` debounces `IntersectionObserver` batches and commits an `activePane` from the settled ratios. A pill tap that lands inside that window arrives with a commit already armed against the **pre-tap** ratios; when it fires it resolves the slide the finger left behind and scrolls the track straight back to it. That is exactly the `Received: 780` the assertion kept seeing.

## Fix

Cancel the pending commit when `activePane` changes. The countdown restarts from zero, so the observer's post-scroll batch (one frame away) always lands inside the new window and the commit that eventually fires agrees with the pane the reader chose. When the commit itself is what changed `activePane`, the timer has already fired and the cancel is a no-op.

One line of behaviour — the comment around it is the part worth reading.

## Verification

- `tests/unit/mobile-swipe-panes.spec.ts` gains a fake-timer test that drives the observer callback directly (the only way to exercise the swipe→settle direction without real layout). Red-green checked: without the fix it ends on `inner-observation` instead of `commentary`.
- Full e2e suite 10 consecutive runs at `--workers=4`: 5 passed each time.
- `task check` green — 882 unit tests, content validation, full generate, 5/5 e2e.

## For a reviewer

The judgement call is cancelling on *every* `activePane` change rather than only on explicit taps. The watcher cannot tell a tap from a commit, and cancelling after a commit is a no-op, so the simpler rule is also the correct one — but that is the line to push on.