### PR TITLE
fix(scripts): keep the file's own key order through the ref migration

### DIFF
--- a/content/parts/part-01/chapters/answers-topics-01/source.en-bb.json
+++ b/content/parts/part-01/chapters/answers-topics-01/source.en-bb.json
@@ -1,8 +1,8 @@
 {
   "chapterId": "part-01/answers-topics-01",
+  "layer": "source",
   "versionId": "en-bb",
   "sefariaRef": "Talmud Eser HaSefirot, Section I, List of Answers on Topics",
-  "layer": "source",
   "items": [
     {
       "n": 1,

--- a/content/parts/part-01/chapters/answers-topics-01/source.he-jerusalem-1956.json
+++ b/content/parts/part-01/chapters/answers-topics-01/source.he-jerusalem-1956.json
@@ -1,8 +1,8 @@
 {
   "chapterId": "part-01/answers-topics-01",
+  "layer": "source",
   "versionId": "he-jerusalem-1956",
   "sefariaRef": "Talmud Eser HaSefirot, Section I, List of Answers on Topics",
-  "layer": "source",
   "items": [
     {
       "n": 1,

--- a/content/parts/part-01/chapters/inner-observation-02/source.en-ai.json
+++ b/content/parts/part-01/chapters/inner-observation-02/source.en-ai.json
@@ -1,8 +1,8 @@
 {
   "chapterId": "part-01/inner-observation-02",
+  "layer": "source",
   "versionId": "en-ai",
   "sefariaRef": "Talmud Eser HaSefirot, Section I, Histaklut Penimit 2",
-  "layer": "source",
   "items": [
     {
       "n": 1,

--- a/content/parts/part-01/chapters/inner-observation-02/source.he-jerusalem-1956.json
+++ b/content/parts/part-01/chapters/inner-observation-02/source.he-jerusalem-1956.json
@@ -1,8 +1,8 @@
 {
   "chapterId": "part-01/inner-observation-02",
+  "layer": "source",
   "versionId": "he-jerusalem-1956",
   "sefariaRef": "Talmud Eser HaSefirot, Section I, Histaklut Penimit 2",
-  "layer": "source",
   "items": [
     {
       "n": 1,

--- a/content/parts/part-01/chapters/inner-observation-03/source.en-ai.json
+++ b/content/parts/part-01/chapters/inner-observation-03/source.en-ai.json
@@ -1,8 +1,8 @@
 {
   "chapterId": "part-01/inner-observation-03",
+  "layer": "source",
   "versionId": "en-ai",
   "sefariaRef": "Talmud Eser HaSefirot, Section I, Histaklut Penimit 3",
-  "layer": "source",
   "items": [
     {
       "n": 1,

--- a/content/parts/part-01/chapters/inner-observation-03/source.he-jerusalem-1956.json
+++ b/content/parts/part-01/chapters/inner-observation-03/source.he-jerusalem-1956.json
@@ -1,8 +1,8 @@
 {
   "chapterId": "part-01/inner-observation-03",
+  "layer": "source",
   "versionId": "he-jerusalem-1956",
   "sefariaRef": "Talmud Eser HaSefirot, Section I, Histaklut Penimit 3",
-  "layer": "source",
   "items": [
     {
       "n": 1,

--- a/content/parts/part-01/chapters/inner-observation-04/source.en-ai.json
+++ b/content/parts/part-01/chapters/inner-observation-04/source.en-ai.json
@@ -1,8 +1,8 @@
 {
   "chapterId": "part-01/inner-observation-04",
+  "layer": "source",
   "versionId": "en-ai",
   "sefariaRef": "Talmud Eser HaSefirot, Section I, Histaklut Penimit 4",
-  "layer": "source",
   "items": [
     {
       "n": 1,

--- a/content/parts/part-01/chapters/inner-observation-04/source.he-jerusalem-1956.json
+++ b/content/parts/part-01/chapters/inner-observation-04/source.he-jerusalem-1956.json
@@ -1,8 +1,8 @@
 {
   "chapterId": "part-01/inner-observation-04",
+  "layer": "source",
   "versionId": "he-jerusalem-1956",
   "sefariaRef": "Talmud Eser HaSefirot, Section I, Histaklut Penimit 4",
-  "layer": "source",
   "items": [
     {
       "n": 1,

--- a/content/parts/part-01/chapters/inner-observation-05/source.en-ai.json
+++ b/content/parts/part-01/chapters/inner-observation-05/source.en-ai.json
@@ -1,8 +1,8 @@
 {
   "chapterId": "part-01/inner-observation-05",
+  "layer": "source",
   "versionId": "en-ai",
   "sefariaRef": "Talmud Eser HaSefirot, Section I, Histaklut Penimit 5",
-  "layer": "source",
   "items": [
     {
       "n": 1,

--- a/content/parts/part-01/chapters/inner-observation-05/source.he-jerusalem-1956.json
+++ b/content/parts/part-01/chapters/inner-observation-05/source.he-jerusalem-1956.json
@@ -1,8 +1,8 @@
 {
   "chapterId": "part-01/inner-observation-05",
+  "layer": "source",
   "versionId": "he-jerusalem-1956",
   "sefariaRef": "Talmud Eser HaSefirot, Section I, Histaklut Penimit 5",
-  "layer": "source",
   "items": [
     {
       "n": 1,

--- a/content/parts/part-01/chapters/inner-observation-06/source.en-ai.json
+++ b/content/parts/part-01/chapters/inner-observation-06/source.en-ai.json
@@ -1,8 +1,8 @@
 {
   "chapterId": "part-01/inner-observation-06",
+  "layer": "source",
   "versionId": "en-ai",
   "sefariaRef": "Talmud Eser HaSefirot, Section I, Histaklut Penimit 6",
-  "layer": "source",
   "items": [
     {
       "n": 1,

--- a/content/parts/part-01/chapters/inner-observation-06/source.he-jerusalem-1956.json
+++ b/content/parts/part-01/chapters/inner-observation-06/source.he-jerusalem-1956.json
@@ -1,8 +1,8 @@
 {
   "chapterId": "part-01/inner-observation-06",
+  "layer": "source",
   "versionId": "he-jerusalem-1956",
   "sefariaRef": "Talmud Eser HaSefirot, Section I, Histaklut Penimit 6",
-  "layer": "source",
   "items": [
     {
       "n": 1,

--- a/content/parts/part-01/chapters/inner-observation-07/source.en-ai.json
+++ b/content/parts/part-01/chapters/inner-observation-07/source.en-ai.json
@@ -1,8 +1,8 @@
 {
   "chapterId": "part-01/inner-observation-07",
+  "layer": "source",
   "versionId": "en-ai",
   "sefariaRef": "Talmud Eser HaSefirot, Section I, Histaklut Penimit 7",
-  "layer": "source",
   "items": [
     {
       "n": 1,

--- a/content/parts/part-01/chapters/inner-observation-07/source.he-jerusalem-1956.json
+++ b/content/parts/part-01/chapters/inner-observation-07/source.he-jerusalem-1956.json
@@ -1,8 +1,8 @@
 {
   "chapterId": "part-01/inner-observation-07",
+  "layer": "source",
   "versionId": "he-jerusalem-1956",
   "sefariaRef": "Talmud Eser HaSefirot, Section I, Histaklut Penimit 7",
-  "layer": "source",
   "items": [
     {
       "n": 1,

--- a/content/parts/part-01/chapters/inner-observation-08/source.en-ai.json
+++ b/content/parts/part-01/chapters/inner-observation-08/source.en-ai.json
@@ -1,8 +1,8 @@
 {
   "chapterId": "part-01/inner-observation-08",
+  "layer": "source",
   "versionId": "en-ai",
   "sefariaRef": "Talmud Eser HaSefirot, Section I, Histaklut Penimit 8",
-  "layer": "source",
   "items": [
     {
       "n": 1,

--- a/content/parts/part-01/chapters/inner-observation-08/source.he-jerusalem-1956.json
+++ b/content/parts/part-01/chapters/inner-observation-08/source.he-jerusalem-1956.json
@@ -1,8 +1,8 @@
 {
   "chapterId": "part-01/inner-observation-08",
+  "layer": "source",
   "versionId": "he-jerusalem-1956",
   "sefariaRef": "Talmud Eser HaSefirot, Section I, Histaklut Penimit 8",
-  "layer": "source",
   "items": [
     {
       "n": 1,

--- a/content/parts/part-01/chapters/inner-observation-09/source.en-ai.json
+++ b/content/parts/part-01/chapters/inner-observation-09/source.en-ai.json
@@ -1,8 +1,8 @@
 {
   "chapterId": "part-01/inner-observation-09",
+  "layer": "source",
   "versionId": "en-ai",
   "sefariaRef": "Talmud Eser HaSefirot, Section I, Histaklut Penimit 9",
-  "layer": "source",
   "items": [
     {
       "n": 1,

--- a/content/parts/part-01/chapters/inner-observation-09/source.he-jerusalem-1956.json
+++ b/content/parts/part-01/chapters/inner-observation-09/source.he-jerusalem-1956.json
@@ -1,8 +1,8 @@
 {
   "chapterId": "part-01/inner-observation-09",
+  "layer": "source",
   "versionId": "he-jerusalem-1956",
   "sefariaRef": "Talmud Eser HaSefirot, Section I, Histaklut Penimit 9",
-  "layer": "source",
   "items": [
     {
       "n": 1,

--- a/content/parts/part-01/chapters/inner-observation-10/source.en-ai.json
+++ b/content/parts/part-01/chapters/inner-observation-10/source.en-ai.json
@@ -1,8 +1,8 @@
 {
   "chapterId": "part-01/inner-observation-10",
+  "layer": "source",
   "versionId": "en-ai",
   "sefariaRef": "Talmud Eser HaSefirot, Section I, Histaklut Penimit 10",
-  "layer": "source",
   "items": [
     {
       "n": 1,

--- a/content/parts/part-01/chapters/inner-observation-10/source.he-jerusalem-1956.json
+++ b/content/parts/part-01/chapters/inner-observation-10/source.he-jerusalem-1956.json
@@ -1,8 +1,8 @@
 {
   "chapterId": "part-01/inner-observation-10",
+  "layer": "source",
   "versionId": "he-jerusalem-1956",
   "sefariaRef": "Talmud Eser HaSefirot, Section I, Histaklut Penimit 10",
-  "layer": "source",
   "items": [
     {
       "n": 1,

--- a/content/parts/part-01/chapters/questions-topics-01/source.en-bb.json
+++ b/content/parts/part-01/chapters/questions-topics-01/source.en-bb.json
@@ -1,8 +1,8 @@
 {
   "chapterId": "part-01/questions-topics-01",
+  "layer": "source",
   "versionId": "en-bb",
   "sefariaRef": "Talmud Eser HaSefirot, Section I, List of Questions on Topics",
-  "layer": "source",
   "items": [
     {
       "n": 1,

--- a/content/parts/part-01/chapters/questions-topics-01/source.he-jerusalem-1956.json
+++ b/content/parts/part-01/chapters/questions-topics-01/source.he-jerusalem-1956.json
@@ -1,8 +1,8 @@
 {
   "chapterId": "part-01/questions-topics-01",
+  "layer": "source",
   "versionId": "he-jerusalem-1956",
   "sefariaRef": "Talmud Eser HaSefirot, Section I, List of Questions on Topics",
-  "layer": "source",
   "items": [
     {
       "n": 1,

--- a/content/parts/part-02/chapters/answers-topics-01/source.en-bb.json
+++ b/content/parts/part-02/chapters/answers-topics-01/source.en-bb.json
@@ -1,8 +1,8 @@
 {
   "chapterId": "part-02/answers-topics-01",
+  "layer": "source",
   "versionId": "en-bb",
   "sefariaRef": "Talmud Eser HaSefirot, Section II, List of Answers on Topics",
-  "layer": "source",
   "items": [
     {
       "n": 1,

--- a/content/parts/part-02/chapters/answers-topics-01/source.he-jerusalem-1956.json
+++ b/content/parts/part-02/chapters/answers-topics-01/source.he-jerusalem-1956.json
@@ -1,8 +1,8 @@
 {
   "chapterId": "part-02/answers-topics-01",
+  "layer": "source",
   "versionId": "he-jerusalem-1956",
   "sefariaRef": "Talmud Eser HaSefirot, Section II, List of Answers on Topics",
-  "layer": "source",
   "items": [
     {
       "n": 1,

--- a/content/parts/part-02/chapters/inner-observation-02/source.en-ai.json
+++ b/content/parts/part-02/chapters/inner-observation-02/source.en-ai.json
@@ -1,8 +1,8 @@
 {
   "chapterId": "part-02/inner-observation-02",
+  "layer": "source",
   "versionId": "en-ai",
   "sefariaRef": "Talmud Eser HaSefirot, Section II, Histaklut Penimit 2",
-  "layer": "source",
   "items": [
     {
       "n": 1,

--- a/content/parts/part-02/chapters/inner-observation-02/source.he-jerusalem-1956.json
+++ b/content/parts/part-02/chapters/inner-observation-02/source.he-jerusalem-1956.json
@@ -1,8 +1,8 @@
 {
   "chapterId": "part-02/inner-observation-02",
+  "layer": "source",
   "versionId": "he-jerusalem-1956",
   "sefariaRef": "Talmud Eser HaSefirot, Section II, Histaklut Penimit 2",
-  "layer": "source",
   "items": [
     {
       "n": 1,

--- a/content/parts/part-02/chapters/inner-observation-03/source.en-ai.json
+++ b/content/parts/part-02/chapters/inner-observation-03/source.en-ai.json
@@ -1,8 +1,8 @@
 {
   "chapterId": "part-02/inner-observation-03",
+  "layer": "source",
   "versionId": "en-ai",
   "sefariaRef": "Talmud Eser HaSefirot, Section II, Histaklut Penimit 3",
-  "layer": "source",
   "items": [
     {
       "n": 1,

--- a/content/parts/part-02/chapters/inner-observation-03/source.he-jerusalem-1956.json
+++ b/content/parts/part-02/chapters/inner-observation-03/source.he-jerusalem-1956.json
@@ -1,8 +1,8 @@
 {
   "chapterId": "part-02/inner-observation-03",
+  "layer": "source",
   "versionId": "he-jerusalem-1956",
   "sefariaRef": "Talmud Eser HaSefirot, Section II, Histaklut Penimit 3",
-  "layer": "source",
   "items": [
     {
       "n": 1,

--- a/content/parts/part-02/chapters/inner-observation-04/source.en-ai.json
+++ b/content/parts/part-02/chapters/inner-observation-04/source.en-ai.json
@@ -1,8 +1,8 @@
 {
   "chapterId": "part-02/inner-observation-04",
+  "layer": "source",
   "versionId": "en-ai",
   "sefariaRef": "Talmud Eser HaSefirot, Section II, Histaklut Penimit 4",
-  "layer": "source",
   "items": [
     {
       "n": 1,

--- a/content/parts/part-02/chapters/inner-observation-04/source.he-jerusalem-1956.json
+++ b/content/parts/part-02/chapters/inner-observation-04/source.he-jerusalem-1956.json
@@ -1,8 +1,8 @@
 {
   "chapterId": "part-02/inner-observation-04",
+  "layer": "source",
   "versionId": "he-jerusalem-1956",
   "sefariaRef": "Talmud Eser HaSefirot, Section II, Histaklut Penimit 4",
-  "layer": "source",
   "items": [
     {
       "n": 1,

--- a/content/parts/part-02/chapters/inner-observation-05/source.en-ai.json
+++ b/content/parts/part-02/chapters/inner-observation-05/source.en-ai.json
@@ -1,8 +1,8 @@
 {
   "chapterId": "part-02/inner-observation-05",
+  "layer": "source",
   "versionId": "en-ai",
   "sefariaRef": "Talmud Eser HaSefirot, Section II, Histaklut Penimit 5",
-  "layer": "source",
   "items": [
     {
       "n": 1,

--- a/content/parts/part-02/chapters/inner-observation-05/source.he-jerusalem-1956.json
+++ b/content/parts/part-02/chapters/inner-observation-05/source.he-jerusalem-1956.json
@@ -1,8 +1,8 @@
 {
   "chapterId": "part-02/inner-observation-05",
+  "layer": "source",
   "versionId": "he-jerusalem-1956",
   "sefariaRef": "Talmud Eser HaSefirot, Section II, Histaklut Penimit 5",
-  "layer": "source",
   "items": [
     {
       "n": 1,

--- a/content/parts/part-02/chapters/inner-observation-06/source.en-ai.json
+++ b/content/parts/part-02/chapters/inner-observation-06/source.en-ai.json
@@ -1,8 +1,8 @@
 {
   "chapterId": "part-02/inner-observation-06",
+  "layer": "source",
   "versionId": "en-ai",
   "sefariaRef": "Talmud Eser HaSefirot, Section II, Histaklut Penimit 6",
-  "layer": "source",
   "items": [
     {
       "n": 1,

--- a/content/parts/part-02/chapters/inner-observation-06/source.he-jerusalem-1956.json
+++ b/content/parts/part-02/chapters/inner-observation-06/source.he-jerusalem-1956.json
@@ -1,8 +1,8 @@
 {
   "chapterId": "part-02/inner-observation-06",
+  "layer": "source",
   "versionId": "he-jerusalem-1956",
   "sefariaRef": "Talmud Eser HaSefirot, Section II, Histaklut Penimit 6",
-  "layer": "source",
   "items": [
     {
       "n": 1,

--- a/content/parts/part-02/chapters/inner-observation-07/source.en-ai.json
+++ b/content/parts/part-02/chapters/inner-observation-07/source.en-ai.json
@@ -1,8 +1,8 @@
 {
   "chapterId": "part-02/inner-observation-07",
+  "layer": "source",
   "versionId": "en-ai",
   "sefariaRef": "Talmud Eser HaSefirot, Section II, Histaklut Penimit 7",
-  "layer": "source",
   "items": [
     {
       "n": 1,

--- a/content/parts/part-02/chapters/inner-observation-07/source.he-jerusalem-1956.json
+++ b/content/parts/part-02/chapters/inner-observation-07/source.he-jerusalem-1956.json
@@ -1,8 +1,8 @@
 {
   "chapterId": "part-02/inner-observation-07",
+  "layer": "source",
   "versionId": "he-jerusalem-1956",
   "sefariaRef": "Talmud Eser HaSefirot, Section II, Histaklut Penimit 7",
-  "layer": "source",
   "items": [
     {
       "n": 1,

--- a/content/parts/part-02/chapters/inner-observation-08/source.en-ai.json
+++ b/content/parts/part-02/chapters/inner-observation-08/source.en-ai.json
@@ -1,8 +1,8 @@
 {
   "chapterId": "part-02/inner-observation-08",
+  "layer": "source",
   "versionId": "en-ai",
   "sefariaRef": "Talmud Eser HaSefirot, Section II, Histaklut Penimit 8",
-  "layer": "source",
   "items": [
     {
       "n": 1,

--- a/content/parts/part-02/chapters/inner-observation-08/source.he-jerusalem-1956.json
+++ b/content/parts/part-02/chapters/inner-observation-08/source.he-jerusalem-1956.json
@@ -1,8 +1,8 @@
 {
   "chapterId": "part-02/inner-observation-08",
+  "layer": "source",
   "versionId": "he-jerusalem-1956",
   "sefariaRef": "Talmud Eser HaSefirot, Section II, Histaklut Penimit 8",
-  "layer": "source",
   "items": [
     {
       "n": 1,

--- a/content/parts/part-02/chapters/inner-observation-09/source.en-ai.json
+++ b/content/parts/part-02/chapters/inner-observation-09/source.en-ai.json
@@ -1,8 +1,8 @@
 {
   "chapterId": "part-02/inner-observation-09",
+  "layer": "source",
   "versionId": "en-ai",
   "sefariaRef": "Talmud Eser HaSefirot, Section II, Histaklut Penimit 9",
-  "layer": "source",
   "items": [
     {
       "n": 1,

--- a/content/parts/part-02/chapters/inner-observation-09/source.he-jerusalem-1956.json
+++ b/content/parts/part-02/chapters/inner-observation-09/source.he-jerusalem-1956.json
@@ -1,8 +1,8 @@
 {
   "chapterId": "part-02/inner-observation-09",
+  "layer": "source",
   "versionId": "he-jerusalem-1956",
   "sefariaRef": "Talmud Eser HaSefirot, Section II, Histaklut Penimit 9",
-  "layer": "source",
   "items": [
     {
       "n": 1,

--- a/content/parts/part-02/chapters/inner-observation-10/source.en-ai.json
+++ b/content/parts/part-02/chapters/inner-observation-10/source.en-ai.json
@@ -1,8 +1,8 @@
 {
   "chapterId": "part-02/inner-observation-10",
+  "layer": "source",
   "versionId": "en-ai",
   "sefariaRef": "Talmud Eser HaSefirot, Section II, Histaklut Penimit 10",
-  "layer": "source",
   "items": [
     {
       "n": 1,

--- a/content/parts/part-02/chapters/inner-observation-10/source.he-jerusalem-1956.json
+++ b/content/parts/part-02/chapters/inner-observation-10/source.he-jerusalem-1956.json
@@ -1,8 +1,8 @@
 {
   "chapterId": "part-02/inner-observation-10",
+  "layer": "source",
   "versionId": "he-jerusalem-1956",
   "sefariaRef": "Talmud Eser HaSefirot, Section II, Histaklut Penimit 10",
-  "layer": "source",
   "items": [
     {
       "n": 1,

--- a/content/parts/part-02/chapters/questions-topics-01/source.en-bb.json
+++ b/content/parts/part-02/chapters/questions-topics-01/source.en-bb.json
@@ -1,8 +1,8 @@
 {
   "chapterId": "part-02/questions-topics-01",
+  "layer": "source",
   "versionId": "en-bb",
   "sefariaRef": "Talmud Eser HaSefirot, Section II, List of Questions on Topics",
-  "layer": "source",
   "items": [
     {
       "n": 1,

--- a/content/parts/part-02/chapters/questions-topics-01/source.he-jerusalem-1956.json
+++ b/content/parts/part-02/chapters/questions-topics-01/source.he-jerusalem-1956.json
@@ -1,8 +1,8 @@
 {
   "chapterId": "part-02/questions-topics-01",
+  "layer": "source",
   "versionId": "he-jerusalem-1956",
   "sefariaRef": "Talmud Eser HaSefirot, Section II, List of Questions on Topics",
-  "layer": "source",
   "items": [
     {
       "n": 1,

--- a/content/parts/part-03/chapters/answers-topics-01/source.en-ai.json
+++ b/content/parts/part-03/chapters/answers-topics-01/source.en-ai.json
@@ -1,8 +1,8 @@
 {
   "chapterId": "part-03/answers-topics-01",
+  "layer": "source",
   "versionId": "en-ai",
   "sefariaRef": "Talmud Eser HaSefirot, Section III, List of Answers on Topics",
-  "layer": "source",
   "items": [
     {
       "n": 1,

--- a/content/parts/part-03/chapters/answers-topics-01/source.he-jerusalem-1956.json
+++ b/content/parts/part-03/chapters/answers-topics-01/source.he-jerusalem-1956.json
@@ -1,8 +1,8 @@
 {
   "chapterId": "part-03/answers-topics-01",
+  "layer": "source",
   "versionId": "he-jerusalem-1956",
   "sefariaRef": "Talmud Eser HaSefirot, Section III, List of Answers on Topics",
-  "layer": "source",
   "items": [
     {
       "n": 1,

--- a/content/parts/part-03/chapters/questions-topics-01/source.en-ai.json
+++ b/content/parts/part-03/chapters/questions-topics-01/source.en-ai.json
@@ -1,8 +1,8 @@
 {
   "chapterId": "part-03/questions-topics-01",
+  "layer": "source",
   "versionId": "en-ai",
   "sefariaRef": "Talmud Eser HaSefirot, Section III, List of Questions on Topics",
-  "layer": "source",
   "items": [
     {
       "n": 1,

--- a/content/parts/part-03/chapters/questions-topics-01/source.he-jerusalem-1956.json
+++ b/content/parts/part-03/chapters/questions-topics-01/source.he-jerusalem-1956.json
@@ -1,8 +1,8 @@
 {
   "chapterId": "part-03/questions-topics-01",
+  "layer": "source",
   "versionId": "he-jerusalem-1956",
   "sefariaRef": "Talmud Eser HaSefirot, Section III, List of Questions on Topics",
-  "layer": "source",
   "items": [
     {
       "n": 1,

--- a/content/parts/part-04/chapters/answers-topics-01/source.en-ai.json
+++ b/content/parts/part-04/chapters/answers-topics-01/source.en-ai.json
@@ -1,8 +1,8 @@
 {
   "chapterId": "part-04/answers-topics-01",
+  "layer": "source",
   "versionId": "en-ai",
   "sefariaRef": "Talmud Eser HaSefirot, Section IV, List of Answers on Topics",
-  "layer": "source",
   "items": [
     {
       "n": 1,

--- a/content/parts/part-04/chapters/answers-topics-01/source.he-jerusalem-1956.json
+++ b/content/parts/part-04/chapters/answers-topics-01/source.he-jerusalem-1956.json
@@ -1,8 +1,8 @@
 {
   "chapterId": "part-04/answers-topics-01",
+  "layer": "source",
   "versionId": "he-jerusalem-1956",
   "sefariaRef": "Talmud Eser HaSefirot, Section IV, List of Answers on Topics",
-  "layer": "source",
   "items": [
     {
       "n": 1,

--- a/content/parts/part-04/chapters/inner-observation-02/source.en-ai.json
+++ b/content/parts/part-04/chapters/inner-observation-02/source.en-ai.json
@@ -1,8 +1,8 @@
 {
   "chapterId": "part-04/inner-observation-02",
+  "layer": "source",
   "versionId": "en-ai",
   "sefariaRef": "Talmud Eser HaSefirot, Section IV, Histaklut Penimit 2",
-  "layer": "source",
   "items": [
     {
       "n": 1,

--- a/content/parts/part-04/chapters/inner-observation-02/source.he-jerusalem-1956.json
+++ b/content/parts/part-04/chapters/inner-observation-02/source.he-jerusalem-1956.json
@@ -1,8 +1,8 @@
 {
   "chapterId": "part-04/inner-observation-02",
+  "layer": "source",
   "versionId": "he-jerusalem-1956",
   "sefariaRef": "Talmud Eser HaSefirot, Section IV, Histaklut Penimit 2",
-  "layer": "source",
   "items": [
     {
       "n": 1,

--- a/content/parts/part-04/chapters/inner-observation-03/source.en-ai.json
+++ b/content/parts/part-04/chapters/inner-observation-03/source.en-ai.json
@@ -1,8 +1,8 @@
 {
   "chapterId": "part-04/inner-observation-03",
+  "layer": "source",
   "versionId": "en-ai",
   "sefariaRef": "Talmud Eser HaSefirot, Section IV, Histaklut Penimit 3",
-  "layer": "source",
   "items": [
     {
       "n": 1,

--- a/content/parts/part-04/chapters/inner-observation-03/source.he-jerusalem-1956.json
+++ b/content/parts/part-04/chapters/inner-observation-03/source.he-jerusalem-1956.json
@@ -1,8 +1,8 @@
 {
   "chapterId": "part-04/inner-observation-03",
+  "layer": "source",
   "versionId": "he-jerusalem-1956",
   "sefariaRef": "Talmud Eser HaSefirot, Section IV, Histaklut Penimit 3",
-  "layer": "source",
   "items": [
     {
       "n": 1,

--- a/content/parts/part-04/chapters/inner-observation-04/source.en-ai.json
+++ b/content/parts/part-04/chapters/inner-observation-04/source.en-ai.json
@@ -1,8 +1,8 @@
 {
   "chapterId": "part-04/inner-observation-04",
+  "layer": "source",
   "versionId": "en-ai",
   "sefariaRef": "Talmud Eser HaSefirot, Section IV, Histaklut Penimit 4",
-  "layer": "source",
   "items": [
     {
       "n": 1,

--- a/content/parts/part-04/chapters/inner-observation-04/source.he-jerusalem-1956.json
+++ b/content/parts/part-04/chapters/inner-observation-04/source.he-jerusalem-1956.json
@@ -1,8 +1,8 @@
 {
   "chapterId": "part-04/inner-observation-04",
+  "layer": "source",
   "versionId": "he-jerusalem-1956",
   "sefariaRef": "Talmud Eser HaSefirot, Section IV, Histaklut Penimit 4",
-  "layer": "source",
   "items": [
     {
       "n": 1,

--- a/content/parts/part-04/chapters/inner-observation-05/source.en-ai.json
+++ b/content/parts/part-04/chapters/inner-observation-05/source.en-ai.json
@@ -1,8 +1,8 @@
 {
   "chapterId": "part-04/inner-observation-05",
+  "layer": "source",
   "versionId": "en-ai",
   "sefariaRef": "Talmud Eser HaSefirot, Section IV, Histaklut Penimit 5",
-  "layer": "source",
   "items": [
     {
       "n": 1,

--- a/content/parts/part-04/chapters/inner-observation-05/source.he-jerusalem-1956.json
+++ b/content/parts/part-04/chapters/inner-observation-05/source.he-jerusalem-1956.json
@@ -1,8 +1,8 @@
 {
   "chapterId": "part-04/inner-observation-05",
+  "layer": "source",
   "versionId": "he-jerusalem-1956",
   "sefariaRef": "Talmud Eser HaSefirot, Section IV, Histaklut Penimit 5",
-  "layer": "source",
   "items": [
     {
       "n": 1,

--- a/content/parts/part-04/chapters/inner-observation-06/source.en-ai.json
+++ b/content/parts/part-04/chapters/inner-observation-06/source.en-ai.json
@@ -1,8 +1,8 @@
 {
   "chapterId": "part-04/inner-observation-06",
+  "layer": "source",
   "versionId": "en-ai",
   "sefariaRef": "Talmud Eser HaSefirot, Section IV, Histaklut Penimit 6",
-  "layer": "source",
   "items": [
     {
       "n": 1,

--- a/content/parts/part-04/chapters/inner-observation-06/source.he-jerusalem-1956.json
+++ b/content/parts/part-04/chapters/inner-observation-06/source.he-jerusalem-1956.json
@@ -1,8 +1,8 @@
 {
   "chapterId": "part-04/inner-observation-06",
+  "layer": "source",
   "versionId": "he-jerusalem-1956",
   "sefariaRef": "Talmud Eser HaSefirot, Section IV, Histaklut Penimit 6",
-  "layer": "source",
   "items": [
     {
       "n": 1,

--- a/content/parts/part-04/chapters/questions-topics-01/source.en-ai.json
+++ b/content/parts/part-04/chapters/questions-topics-01/source.en-ai.json
@@ -1,8 +1,8 @@
 {
   "chapterId": "part-04/questions-topics-01",
+  "layer": "source",
   "versionId": "en-ai",
   "sefariaRef": "Talmud Eser HaSefirot, Section IV, List of Questions on Topics",
-  "layer": "source",
   "items": [
     {
       "n": 1,

--- a/content/parts/part-04/chapters/questions-topics-01/source.he-jerusalem-1956.json
+++ b/content/parts/part-04/chapters/questions-topics-01/source.he-jerusalem-1956.json
@@ -1,8 +1,8 @@
 {
   "chapterId": "part-04/questions-topics-01",
+  "layer": "source",
   "versionId": "he-jerusalem-1956",
   "sefariaRef": "Talmud Eser HaSefirot, Section IV, List of Questions on Topics",
-  "layer": "source",
   "items": [
     {
       "n": 1,

--- a/content/parts/part-05/chapters/answers-topics-01/source.en-bb.json
+++ b/content/parts/part-05/chapters/answers-topics-01/source.en-bb.json
@@ -1,8 +1,8 @@
 {
   "chapterId": "part-05/answers-topics-01",
+  "layer": "source",
   "versionId": "en-bb",
   "sefariaRef": "Talmud Eser HaSefirot, Section V, List of Answers on Topics",
-  "layer": "source",
   "items": [
     {
       "n": 1,

--- a/content/parts/part-05/chapters/answers-topics-01/source.he-jerusalem-1956.json
+++ b/content/parts/part-05/chapters/answers-topics-01/source.he-jerusalem-1956.json
@@ -1,8 +1,8 @@
 {
   "chapterId": "part-05/answers-topics-01",
+  "layer": "source",
   "versionId": "he-jerusalem-1956",
   "sefariaRef": "Talmud Eser HaSefirot, Section V, List of Answers on Topics",
-  "layer": "source",
   "items": [
     {
       "n": 1,

--- a/content/parts/part-05/chapters/questions-topics-01/source.en-bb.json
+++ b/content/parts/part-05/chapters/questions-topics-01/source.en-bb.json
@@ -1,8 +1,8 @@
 {
   "chapterId": "part-05/questions-topics-01",
+  "layer": "source",
   "versionId": "en-bb",
   "sefariaRef": "Talmud Eser HaSefirot, Section V, List of Questions on Topics",
-  "layer": "source",
   "items": [
     {
       "n": 1,

--- a/content/parts/part-05/chapters/questions-topics-01/source.he-jerusalem-1956.json
+++ b/content/parts/part-05/chapters/questions-topics-01/source.he-jerusalem-1956.json
@@ -1,8 +1,8 @@
 {
   "chapterId": "part-05/questions-topics-01",
+  "layer": "source",
   "versionId": "he-jerusalem-1956",
   "sefariaRef": "Talmud Eser HaSefirot, Section V, List of Questions on Topics",
-  "layer": "source",
   "items": [
     {
       "n": 1,

--- a/content/parts/part-06/chapters/answers-topics-01/source.en-bb.json
+++ b/content/parts/part-06/chapters/answers-topics-01/source.en-bb.json
@@ -1,8 +1,8 @@
 {
   "chapterId": "part-06/answers-topics-01",
+  "layer": "source",
   "versionId": "en-bb",
   "sefariaRef": "Talmud Eser HaSefirot, Section VI, List of Answers on Topics",
-  "layer": "source",
   "items": [
     {
       "n": 1,

--- a/content/parts/part-06/chapters/answers-topics-01/source.he-jerusalem-1956.json
+++ b/content/parts/part-06/chapters/answers-topics-01/source.he-jerusalem-1956.json
@@ -1,8 +1,8 @@
 {
   "chapterId": "part-06/answers-topics-01",
+  "layer": "source",
   "versionId": "he-jerusalem-1956",
   "sefariaRef": "Talmud Eser HaSefirot, Section VI, List of Answers on Topics",
-  "layer": "source",
   "items": [
     {
       "n": 1,

--- a/content/parts/part-06/chapters/questions-topics-01/source.en-bb.json
+++ b/content/parts/part-06/chapters/questions-topics-01/source.en-bb.json
@@ -1,8 +1,8 @@
 {
   "chapterId": "part-06/questions-topics-01",
+  "layer": "source",
   "versionId": "en-bb",
   "sefariaRef": "Talmud Eser HaSefirot, Section VI, List of Questions on Topics",
-  "layer": "source",
   "items": [
     {
       "n": 1,

--- a/content/parts/part-06/chapters/questions-topics-01/source.he-jerusalem-1956.json
+++ b/content/parts/part-06/chapters/questions-topics-01/source.he-jerusalem-1956.json
@@ -1,8 +1,8 @@
 {
   "chapterId": "part-06/questions-topics-01",
+  "layer": "source",
   "versionId": "he-jerusalem-1956",
   "sefariaRef": "Talmud Eser HaSefirot, Section VI, List of Questions on Topics",
-  "layer": "source",
   "items": [
     {
       "n": 1,

--- a/content/parts/part-07/chapters/answers-topics-01/source.en-ai.json
+++ b/content/parts/part-07/chapters/answers-topics-01/source.en-ai.json
@@ -1,8 +1,8 @@
 {
   "chapterId": "part-07/answers-topics-01",
+  "layer": "source",
   "versionId": "en-ai",
   "sefariaRef": "Talmud Eser HaSefirot, Section VII, List of Answers on Topics",
-  "layer": "source",
   "items": [
     {
       "n": 1,

--- a/content/parts/part-07/chapters/answers-topics-01/source.he-jerusalem-1956.json
+++ b/content/parts/part-07/chapters/answers-topics-01/source.he-jerusalem-1956.json
@@ -1,8 +1,8 @@
 {
   "chapterId": "part-07/answers-topics-01",
+  "layer": "source",
   "versionId": "he-jerusalem-1956",
   "sefariaRef": "Talmud Eser HaSefirot, Section VII, List of Answers on Topics",
-  "layer": "source",
   "items": [
     {
       "n": 1,

--- a/content/parts/part-07/chapters/questions-topics-01/source.en-ai.json
+++ b/content/parts/part-07/chapters/questions-topics-01/source.en-ai.json
@@ -1,8 +1,8 @@
 {
   "chapterId": "part-07/questions-topics-01",
+  "layer": "source",
   "versionId": "en-ai",
   "sefariaRef": "Talmud Eser HaSefirot, Section VII, List of Questions on Topics",
-  "layer": "source",
   "items": [
     {
       "n": 1,

--- a/content/parts/part-07/chapters/questions-topics-01/source.he-jerusalem-1956.json
+++ b/content/parts/part-07/chapters/questions-topics-01/source.he-jerusalem-1956.json
@@ -1,8 +1,8 @@
 {
   "chapterId": "part-07/questions-topics-01",
+  "layer": "source",
   "versionId": "he-jerusalem-1956",
   "sefariaRef": "Talmud Eser HaSefirot, Section VII, List of Questions on Topics",
-  "layer": "source",
   "items": [
     {
       "n": 1,

--- a/content/parts/part-08/chapters/answers-topics-01/source.en-ai.json
+++ b/content/parts/part-08/chapters/answers-topics-01/source.en-ai.json
@@ -1,8 +1,8 @@
 {
   "chapterId": "part-08/answers-topics-01",
+  "layer": "source",
   "versionId": "en-ai",
   "sefariaRef": "Talmud Eser HaSefirot, Section VIII, List of Answers on Topics",
-  "layer": "source",
   "items": [
     {
       "n": 1,

--- a/content/parts/part-08/chapters/answers-topics-01/source.he-jerusalem-1956.json
+++ b/content/parts/part-08/chapters/answers-topics-01/source.he-jerusalem-1956.json
@@ -1,8 +1,8 @@
 {
   "chapterId": "part-08/answers-topics-01",
+  "layer": "source",
   "versionId": "he-jerusalem-1956",
   "sefariaRef": "Talmud Eser HaSefirot, Section VIII, List of Answers on Topics",
-  "layer": "source",
   "items": [
     {
       "n": 1,

--- a/content/parts/part-08/chapters/questions-topics-01/source.en-ai.json
+++ b/content/parts/part-08/chapters/questions-topics-01/source.en-ai.json
@@ -1,8 +1,8 @@
 {
   "chapterId": "part-08/questions-topics-01",
+  "layer": "source",
   "versionId": "en-ai",
   "sefariaRef": "Talmud Eser HaSefirot, Section VIII, List of Questions on Topics",
-  "layer": "source",
   "items": [
     {
       "n": 1,

--- a/content/parts/part-08/chapters/questions-topics-01/source.he-jerusalem-1956.json
+++ b/content/parts/part-08/chapters/questions-topics-01/source.he-jerusalem-1956.json
@@ -1,8 +1,8 @@
 {
   "chapterId": "part-08/questions-topics-01",
+  "layer": "source",
   "versionId": "he-jerusalem-1956",
   "sefariaRef": "Talmud Eser HaSefirot, Section VIII, List of Questions on Topics",
-  "layer": "source",
   "items": [
     {
       "n": 1,

--- a/content/parts/part-09/chapters/answers-topics-01/source.en-ai.json
+++ b/content/parts/part-09/chapters/answers-topics-01/source.en-ai.json
@@ -1,8 +1,8 @@
 {
   "chapterId": "part-09/answers-topics-01",
+  "layer": "source",
   "versionId": "en-ai",
   "sefariaRef": "Talmud Eser HaSefirot, Section IX, List of Answers on Topics",
-  "layer": "source",
   "items": [
     {
       "n": 1,

--- a/content/parts/part-09/chapters/answers-topics-01/source.he-jerusalem-1956.json
+++ b/content/parts/part-09/chapters/answers-topics-01/source.he-jerusalem-1956.json
@@ -1,8 +1,8 @@
 {
   "chapterId": "part-09/answers-topics-01",
+  "layer": "source",
   "versionId": "he-jerusalem-1956",
   "sefariaRef": "Talmud Eser HaSefirot, Section IX, List of Answers on Topics",
-  "layer": "source",
   "items": [
     {
       "n": 1,

--- a/content/parts/part-09/chapters/questions-topics-01/source.en-ai.json
+++ b/content/parts/part-09/chapters/questions-topics-01/source.en-ai.json
@@ -1,8 +1,8 @@
 {
   "chapterId": "part-09/questions-topics-01",
+  "layer": "source",
   "versionId": "en-ai",
   "sefariaRef": "Talmud Eser HaSefirot, Section IX, List of Questions on Topics",
-  "layer": "source",
   "items": [
     {
       "n": 1,

--- a/content/parts/part-09/chapters/questions-topics-01/source.he-jerusalem-1956.json
+++ b/content/parts/part-09/chapters/questions-topics-01/source.he-jerusalem-1956.json
@@ -1,8 +1,8 @@
 {
   "chapterId": "part-09/questions-topics-01",
+  "layer": "source",
   "versionId": "he-jerusalem-1956",
   "sefariaRef": "Talmud Eser HaSefirot, Section IX, List of Questions on Topics",
-  "layer": "source",
   "items": [
     {
       "n": 1,

--- a/content/parts/part-10/chapters/answers-topics-01/source.en-ai.json
+++ b/content/parts/part-10/chapters/answers-topics-01/source.en-ai.json
@@ -1,8 +1,8 @@
 {
   "chapterId": "part-10/answers-topics-01",
+  "layer": "source",
   "versionId": "en-ai",
   "sefariaRef": "Talmud Eser HaSefirot, Section X, List of Answers on Topics",
-  "layer": "source",
   "items": [
     {
       "n": 1,

--- a/content/parts/part-10/chapters/answers-topics-01/source.he-jerusalem-1956.json
+++ b/content/parts/part-10/chapters/answers-topics-01/source.he-jerusalem-1956.json
@@ -1,8 +1,8 @@
 {
   "chapterId": "part-10/answers-topics-01",
+  "layer": "source",
   "versionId": "he-jerusalem-1956",
   "sefariaRef": "Talmud Eser HaSefirot, Section X, List of Answers on Topics",
-  "layer": "source",
   "items": [
     {
       "n": 1,

--- a/content/parts/part-10/chapters/questions-topics-01/source.en-ai.json
+++ b/content/parts/part-10/chapters/questions-topics-01/source.en-ai.json
@@ -1,8 +1,8 @@
 {
   "chapterId": "part-10/questions-topics-01",
+  "layer": "source",
   "versionId": "en-ai",
   "sefariaRef": "Talmud Eser HaSefirot, Section X, List of Questions on Topics",
-  "layer": "source",
   "items": [
     {
       "n": 1,

--- a/content/parts/part-10/chapters/questions-topics-01/source.he-jerusalem-1956.json
+++ b/content/parts/part-10/chapters/questions-topics-01/source.he-jerusalem-1956.json
@@ -1,8 +1,8 @@
 {
   "chapterId": "part-10/questions-topics-01",
+  "layer": "source",
   "versionId": "he-jerusalem-1956",
   "sefariaRef": "Talmud Eser HaSefirot, Section X, List of Questions on Topics",
-  "layer": "source",
   "items": [
     {
       "n": 1,

--- a/content/parts/part-11/chapters/answers-topics-01/source.en-ai.json
+++ b/content/parts/part-11/chapters/answers-topics-01/source.en-ai.json
@@ -1,8 +1,8 @@
 {
   "chapterId": "part-11/answers-topics-01",
+  "layer": "source",
   "versionId": "en-ai",
   "sefariaRef": "Talmud Eser HaSefirot, Section XI, List of Answers on Topics",
-  "layer": "source",
   "items": [
     {
       "n": 1,

--- a/content/parts/part-11/chapters/answers-topics-01/source.he-jerusalem-1956.json
+++ b/content/parts/part-11/chapters/answers-topics-01/source.he-jerusalem-1956.json
@@ -1,8 +1,8 @@
 {
   "chapterId": "part-11/answers-topics-01",
+  "layer": "source",
   "versionId": "he-jerusalem-1956",
   "sefariaRef": "Talmud Eser HaSefirot, Section XI, List of Answers on Topics",
-  "layer": "source",
   "items": [
     {
       "n": 1,

--- a/content/parts/part-11/chapters/questions-topics-01/source.en-ai.json
+++ b/content/parts/part-11/chapters/questions-topics-01/source.en-ai.json
@@ -1,8 +1,8 @@
 {
   "chapterId": "part-11/questions-topics-01",
+  "layer": "source",
   "versionId": "en-ai",
   "sefariaRef": "Talmud Eser HaSefirot, Section XI, List of Questions on Topics",
-  "layer": "source",
   "items": [
     {
       "n": 1,

--- a/content/parts/part-11/chapters/questions-topics-01/source.he-jerusalem-1956.json
+++ b/content/parts/part-11/chapters/questions-topics-01/source.he-jerusalem-1956.json
@@ -1,8 +1,8 @@
 {
   "chapterId": "part-11/questions-topics-01",
+  "layer": "source",
   "versionId": "he-jerusalem-1956",
   "sefariaRef": "Talmud Eser HaSefirot, Section XI, List of Questions on Topics",
-  "layer": "source",
   "items": [
     {
       "n": 1,

--- a/content/parts/part-12/chapters/answers-topics-01/source.en-ai.json
+++ b/content/parts/part-12/chapters/answers-topics-01/source.en-ai.json
@@ -1,8 +1,8 @@
 {
   "chapterId": "part-12/answers-topics-01",
+  "layer": "source",
   "versionId": "en-ai",
   "sefariaRef": "Talmud Eser HaSefirot, Section XII, List of Answers on Topics",
-  "layer": "source",
   "items": [
     {
       "n": 1,

--- a/content/parts/part-12/chapters/answers-topics-01/source.he-jerusalem-1956.json
+++ b/content/parts/part-12/chapters/answers-topics-01/source.he-jerusalem-1956.json
@@ -1,8 +1,8 @@
 {
   "chapterId": "part-12/answers-topics-01",
+  "layer": "source",
   "versionId": "he-jerusalem-1956",
   "sefariaRef": "Talmud Eser HaSefirot, Section XII, List of Answers on Topics",
-  "layer": "source",
   "items": [
     {
       "n": 1,

--- a/content/parts/part-12/chapters/questions-topics-01/source.en-ai.json
+++ b/content/parts/part-12/chapters/questions-topics-01/source.en-ai.json
@@ -1,8 +1,8 @@
 {
   "chapterId": "part-12/questions-topics-01",
+  "layer": "source",
   "versionId": "en-ai",
   "sefariaRef": "Talmud Eser HaSefirot, Section XII, List of Questions on Topics",
-  "layer": "source",
   "items": [
     {
       "n": 1,

--- a/content/parts/part-12/chapters/questions-topics-01/source.he-jerusalem-1956.json
+++ b/content/parts/part-12/chapters/questions-topics-01/source.he-jerusalem-1956.json
@@ -1,8 +1,8 @@
 {
   "chapterId": "part-12/questions-topics-01",
+  "layer": "source",
   "versionId": "he-jerusalem-1956",
   "sefariaRef": "Talmud Eser HaSefirot, Section XII, List of Questions on Topics",
-  "layer": "source",
   "items": [
     {
       "n": 1,

--- a/content/parts/part-13/chapters/answers-topics-01/source.en-ai.json
+++ b/content/parts/part-13/chapters/answers-topics-01/source.en-ai.json
@@ -1,8 +1,8 @@
 {
   "chapterId": "part-13/answers-topics-01",
+  "layer": "source",
   "versionId": "en-ai",
   "sefariaRef": "Talmud Eser HaSefirot, Section XIII, List of Answers on Topics",
-  "layer": "source",
   "items": [
     {
       "n": 1,

--- a/content/parts/part-13/chapters/answers-topics-01/source.he-jerusalem-1956.json
+++ b/content/parts/part-13/chapters/answers-topics-01/source.he-jerusalem-1956.json
@@ -1,8 +1,8 @@
 {
   "chapterId": "part-13/answers-topics-01",
+  "layer": "source",
   "versionId": "he-jerusalem-1956",
   "sefariaRef": "Talmud Eser HaSefirot, Section XIII, List of Answers on Topics",
-  "layer": "source",
   "items": [
     {
       "n": 1,

--- a/content/parts/part-13/chapters/questions-topics-01/source.en-ai.json
+++ b/content/parts/part-13/chapters/questions-topics-01/source.en-ai.json
@@ -1,8 +1,8 @@
 {
   "chapterId": "part-13/questions-topics-01",
+  "layer": "source",
   "versionId": "en-ai",
   "sefariaRef": "Talmud Eser HaSefirot, Section XIII, List of Questions on Topics",
-  "layer": "source",
   "items": [
     {
       "n": 1,

--- a/content/parts/part-13/chapters/questions-topics-01/source.he-jerusalem-1956.json
+++ b/content/parts/part-13/chapters/questions-topics-01/source.he-jerusalem-1956.json
@@ -1,8 +1,8 @@
 {
   "chapterId": "part-13/questions-topics-01",
+  "layer": "source",
   "versionId": "he-jerusalem-1956",
   "sefariaRef": "Talmud Eser HaSefirot, Section XIII, List of Questions on Topics",
-  "layer": "source",
   "items": [
     {
       "n": 1,

--- a/content/parts/part-14/chapters/answers-topics-01/source.en-ai.json
+++ b/content/parts/part-14/chapters/answers-topics-01/source.en-ai.json
@@ -1,8 +1,8 @@
 {
   "chapterId": "part-14/answers-topics-01",
+  "layer": "source",
   "versionId": "en-ai",
   "sefariaRef": "Talmud Eser HaSefirot, Section XIV, List of Answers on Topics",
-  "layer": "source",
   "items": [
     {
       "n": 1,

--- a/content/parts/part-14/chapters/answers-topics-01/source.he-jerusalem-1956.json
+++ b/content/parts/part-14/chapters/answers-topics-01/source.he-jerusalem-1956.json
@@ -1,8 +1,8 @@
 {
   "chapterId": "part-14/answers-topics-01",
+  "layer": "source",
   "versionId": "he-jerusalem-1956",
   "sefariaRef": "Talmud Eser HaSefirot, Section XIV, List of Answers on Topics",
-  "layer": "source",
   "items": [
     {
       "n": 1,

--- a/content/parts/part-14/chapters/questions-topics-01/source.en-ai.json
+++ b/content/parts/part-14/chapters/questions-topics-01/source.en-ai.json
@@ -1,8 +1,8 @@
 {
   "chapterId": "part-14/questions-topics-01",
+  "layer": "source",
   "versionId": "en-ai",
   "sefariaRef": "Talmud Eser HaSefirot, Section XIV, List of Questions on Topics",
-  "layer": "source",
   "items": [
     {
       "n": 1,

--- a/content/parts/part-14/chapters/questions-topics-01/source.he-jerusalem-1956.json
+++ b/content/parts/part-14/chapters/questions-topics-01/source.he-jerusalem-1956.json
@@ -1,8 +1,8 @@
 {
   "chapterId": "part-14/questions-topics-01",
+  "layer": "source",
   "versionId": "he-jerusalem-1956",
   "sefariaRef": "Talmud Eser HaSefirot, Section XIV, List of Questions on Topics",
-  "layer": "source",
   "items": [
     {
       "n": 1,

--- a/content/parts/part-15/chapters/answers-topics-01/source.en-ai.json
+++ b/content/parts/part-15/chapters/answers-topics-01/source.en-ai.json
@@ -1,8 +1,8 @@
 {
   "chapterId": "part-15/answers-topics-01",
+  "layer": "source",
   "versionId": "en-ai",
   "sefariaRef": "Talmud Eser HaSefirot, Section XV, List of Answers on Topics",
-  "layer": "source",
   "items": [
     {
       "n": 1,

--- a/content/parts/part-15/chapters/answers-topics-01/source.he-jerusalem-1956.json
+++ b/content/parts/part-15/chapters/answers-topics-01/source.he-jerusalem-1956.json
@@ -1,8 +1,8 @@
 {
   "chapterId": "part-15/answers-topics-01",
+  "layer": "source",
   "versionId": "he-jerusalem-1956",
   "sefariaRef": "Talmud Eser HaSefirot, Section XV, List of Answers on Topics",
-  "layer": "source",
   "items": [
     {
       "n": 1,

--- a/content/parts/part-15/chapters/questions-topics-01/source.en-ai.json
+++ b/content/parts/part-15/chapters/questions-topics-01/source.en-ai.json
@@ -1,8 +1,8 @@
 {
   "chapterId": "part-15/questions-topics-01",
+  "layer": "source",
   "versionId": "en-ai",
   "sefariaRef": "Talmud Eser HaSefirot, Section XV, List of Questions on Topics",
-  "layer": "source",
   "items": [
     {
       "n": 1,

--- a/content/parts/part-15/chapters/questions-topics-01/source.he-jerusalem-1956.json
+++ b/content/parts/part-15/chapters/questions-topics-01/source.he-jerusalem-1956.json
@@ -1,8 +1,8 @@
 {
   "chapterId": "part-15/questions-topics-01",
+  "layer": "source",
   "versionId": "he-jerusalem-1956",
   "sefariaRef": "Talmud Eser HaSefirot, Section XV, List of Questions on Topics",
-  "layer": "source",
   "items": [
     {
       "n": 1,

--- a/content/parts/part-16/chapters/answers-topics-01/source.en-ai.json
+++ b/content/parts/part-16/chapters/answers-topics-01/source.en-ai.json
@@ -1,8 +1,8 @@
 {
   "chapterId": "part-16/answers-topics-01",
+  "layer": "source",
   "versionId": "en-ai",
   "sefariaRef": "Talmud Eser HaSefirot, Section XVI, List of Answers on Topics",
-  "layer": "source",
   "items": [
     {
       "n": 1,

--- a/content/parts/part-16/chapters/answers-topics-01/source.he-jerusalem-1956.json
+++ b/content/parts/part-16/chapters/answers-topics-01/source.he-jerusalem-1956.json
@@ -1,8 +1,8 @@
 {
   "chapterId": "part-16/answers-topics-01",
+  "layer": "source",
   "versionId": "he-jerusalem-1956",
   "sefariaRef": "Talmud Eser HaSefirot, Section XVI, List of Answers on Topics",
-  "layer": "source",
   "items": [
     {
       "n": 1,

--- a/content/parts/part-16/chapters/questions-topics-01/source.en-ai.json
+++ b/content/parts/part-16/chapters/questions-topics-01/source.en-ai.json
@@ -1,8 +1,8 @@
 {
   "chapterId": "part-16/questions-topics-01",
+  "layer": "source",
   "versionId": "en-ai",
   "sefariaRef": "Talmud Eser HaSefirot, Section XVI, List of Questions on Topics",
-  "layer": "source",
   "items": [
     {
       "n": 1,

--- a/content/parts/part-16/chapters/questions-topics-01/source.he-jerusalem-1956.json
+++ b/content/parts/part-16/chapters/questions-topics-01/source.he-jerusalem-1956.json
@@ -1,8 +1,8 @@
 {
   "chapterId": "part-16/questions-topics-01",
+  "layer": "source",
   "versionId": "he-jerusalem-1956",
   "sefariaRef": "Talmud Eser HaSefirot, Section XVI, List of Questions on Topics",
-  "layer": "source",
   "items": [
     {
       "n": 1,

--- a/scripts/migrate-sefaria-refs.ts
+++ b/scripts/migrate-sefaria-refs.ts
@@ -165,9 +165,15 @@ for (const dir of chapterDirs()) {
 
     const filePath = join(dir, fileName);
     const relative = filePath.slice(CONTENT_ROOT.length + 1);
-    const file: ParsedChapterLayerFile = chapterLayerFileSchema.parse(
-      JSON.parse(readFileSync(filePath, "utf-8")),
-    );
+    // Validated through Zod, but written back from the object `JSON.parse`
+    // produced. `.parse()` returns a NEW object with the schema's key order,
+    // not the file's, so serialising its output rewrites `layer` to a
+    // different position in all 110 files — a diff that says nothing, and
+    // one the importer would immediately flip back on its next run.
+    const raw = JSON.parse(readFileSync(filePath, "utf-8")) as {
+      items: unknown[];
+    };
+    const file: ParsedChapterLayerFile = chapterLayerFileSchema.parse(raw);
     // Narrows `items` off the layer discriminant — summaries are curated
     // prose with no Sefaria address at all, and the filename filter above
     // has already excluded them.
@@ -182,7 +188,7 @@ for (const dir of chapterDirs()) {
 
     let changedHere = 0;
 
-    for (const item of file.items) {
+    for (const [index, item] of file.items.entries()) {
       const committed = "sefariaRef" in item ? item.sefariaRef : undefined;
       if (committed === undefined) continue;
 
@@ -225,7 +231,9 @@ for (const dir of chapterDirs()) {
         continue;
       }
 
-      item.sefariaRef = withOffsets;
+      // Written onto `raw`, whose key order is the file's own — `file` is
+      // the validated read model, not what gets serialised.
+      (raw.items as { sefariaRef?: string }[])[index]!.sefariaRef = withOffsets;
       changedHere++;
     }
 
@@ -238,7 +246,7 @@ for (const dir of chapterDirs()) {
     );
 
     if (!isDryRun) {
-      writeFileSync(filePath, `${JSON.stringify(file, null, 2)}\n`, "utf-8");
+      writeFileSync(filePath, `${JSON.stringify(raw, null, 2)}\n`, "utf-8");
     }
   }
 }


### PR DESCRIPTION
Follow-up to #108, which I got wrong in a small way worth correcting before it spreads.

## What happened

`migrate-sefaria-refs` wrote back the object `chapterLayerFileSchema.parse()` returns. Zod's `.parse()` builds a **new** object with the schema's key order, not the file's — so all 110 migrated files came out with `"layer"` below `"sefariaRef"`:

```diff
 {
   "chapterId": "part-01/answers-topics-01",
+  "layer": "source",
   "versionId": "he-jerusalem-1956",
   "sefariaRef": "Talmud Eser HaSefirot, Section I, List of Answers on Topics",
-  "layer": "source",
```

Harmless in itself, but the importer writes the other order, so every future `import:sefaria --part N` would rewrite all of those files to say nothing. I found it because a part-6 import came back with two files modified for no reason.

## Fix

Validate through Zod, serialise the object `JSON.parse` produced. The ref rewrite is applied to that object by index — the parsed copy stays the read model.

## Verification

Re-derived rather than hand-patched: the 110 files were restored to their pre-#108 state and re-migrated with the fixed script.

- Diff against `main` is **exactly 110 lines, all `"layer": "source"` moving back** — no ref changed.
- Migration re-run: `0 refs in 0 files rewritten; 7580 already correct; 0 unexplained`.
- `import:sefaria --part 1` over the result: **zero** `"layer"` lines in the diff, where before it rewrote all 24 of that part's affected files.
- `task check` green — 898 unit tests, content validation, full generate, 5/5 e2e.

## Noticed while verifying, not fixed here

That same `import:sefaria --part 1` round-trip *does* still rewrite 28 `label.en` values on `he-jerusalem-1956` commentary files — the importer writes the gematria marker (`"20"`) where the tree holds the old invented ordinal (`"11"`). #99's migration only rewrote each version's own language, so `label.en` on Hebrew-version files was never corrected. Pre-existing and unrelated to this PR; filing separately.