### PR TITLE
feat(reader): overlay mobile panes chrome so the pane gets the whole screen

### DIFF
--- a/app/components/reader/ReaderPane.vue
+++ b/app/components/reader/ReaderPane.vue
@@ -24,11 +24,53 @@ defineProps<{
 const emit = defineEmits<{ "update:modelValue": [value: string] }>();
 
 const containerRef = provideReaderPaneContainer();
+
+// In mobile panes mode this header joins the navbar and toolbar as an
+// overlay above the pane body rather than a row above it, so the body can
+// own the full viewport height — see `useReaderChromeOverlay`. Above `lg`
+// (and in study mode) nothing here changes: the header stays a plain flow
+// row and the body scrolls beneath it.
+const overlay = useReaderChromeOverlay();
+const headerRef = ref<HTMLElement | null>(null);
+overlay.register("pane-header", headerRef);
+
+const headerTop = overlay.offsetOf("pane-header");
+const headerStyle = computed(() =>
+  overlay.active.value
+    ? {
+        top: `${headerTop.value}px`,
+        transform: `translateY(${overlay.shift.value}px)`,
+      }
+    : {},
+);
+
+/**
+ * The body never moves; its *content* starts below the chrome. That is the
+ * whole point — a scroller whose top edge stays put cannot make the text
+ * jump when the chrome slides away. `scroll-padding` keeps `#seif-N` anchor
+ * jumps from landing underneath it.
+ */
+const bodyStyle = computed(() =>
+  overlay.active.value
+    ? {
+        paddingBlockStart: `${overlay.height.value}px`,
+        scrollPaddingBlockStart: `${overlay.height.value}px`,
+      }
+    : {},
+);
 </script>
 
 <template>
-  <section class="tes-pane-shell">
-    <header class="tes-pane-header">
+  <section class="tes-pane-shell" :class="overlay.active.value && 'relative'">
+    <header
+      ref="headerRef"
+      :style="headerStyle"
+      class="tes-pane-header"
+      :class="[
+        overlay.active.value &&
+          'absolute inset-x-0 z-20 transition-transform duration-200 ease-out motion-reduce:transition-none',
+      ]"
+    >
       <ReaderPaneHeader
         :title="title"
         :language-options="languageOptions"
@@ -43,6 +85,7 @@ const containerRef = provideReaderPaneContainer();
 
     <div
       ref="containerRef"
+      :style="bodyStyle"
       class="tes-pane-body"
       :dir="meta?.direction ?? 'ltr'"
       :lang="meta?.language"

--- a/app/components/reader/ReaderToolbar.vue
+++ b/app/components/reader/ReaderToolbar.vue
@@ -31,6 +31,23 @@ const { mode, setMode } = useReaderMode();
 const { visible: chromeVisible } = useAutoHidingChrome();
 const isStudyMode = computed(() => mode.value === "study");
 
+// Panes mode on mobile lifts this bar out of flow too, stacked under the
+// navbar — see `useReaderChromeOverlay` for why the whole stack overlays
+// the pane rather than sitting above it.
+const overlay = useReaderChromeOverlay();
+const toolbarRef = ref<HTMLElement | null>(null);
+overlay.register("toolbar", toolbarRef);
+
+const toolbarTop = overlay.offsetOf("toolbar");
+const overlayStyle = computed(() =>
+  overlay.active.value
+    ? {
+        top: `${toolbarTop.value}px`,
+        transform: `translateY(${overlay.shift.value}px)`,
+      }
+    : {},
+);
+
 const modeOptions = computed(() => [
   { value: "study" as ReaderMode, label: t("reader.mode.study") },
   { value: "panes" as ReaderMode, label: t("reader.mode.panes") },
@@ -55,11 +72,15 @@ const {
 
 <template>
   <div
+    ref="toolbarRef"
+    :style="overlayStyle"
     class="flex flex-col gap-3 border-b border-(--border) bg-(--surface) px-4 py-3 sm:px-6"
     :class="[
       isStudyMode &&
         'sticky top-0 z-30 transition-transform duration-200 ease-out motion-reduce:transition-none',
       isStudyMode && !chromeVisible && '-translate-y-full',
+      overlay.active.value &&
+        'fixed inset-x-0 z-30 transition-transform duration-200 ease-out motion-reduce:transition-none',
     ]"
   >
     <h1 class="sr-only">{{ chapterTitle }}</h1>

--- a/app/composables/useAutoHidingChrome.ts
+++ b/app/composables/useAutoHidingChrome.ts
@@ -20,12 +20,25 @@
  * disclosure is open near the top" rule baked into
  * `nextChromeVisibilityState`.
  *
- * The scroll listener itself is gated to study mode (`useReaderMode`):
- * panes mode never shows any auto-hiding chrome, so it should cost zero
- * scroll work — the listener attaches when `mode` becomes `"study"` and
- * detaches the moment it isn't, rather than running for the lifetime of
- * the page regardless of mode. Handler work is also rAF-throttled, same
- * pattern as `ProgressRail`'s scroll/resize handling.
+ * Both modes are tracked, from different sources (issue 113). Study mode
+ * scrolls the document, so it listens on `window`. Panes mode scrolls inside
+ * each pane's own `.tes-pane-body` container, and there are up to three of
+ * them mounted at once — so it listens on `document` in the **capture**
+ * phase, which is the one way to see a scroll event from an element that
+ * does not bubble it, and filters to the pane bodies by class. That avoids
+ * a registration protocol between this and every pane, and it also means a
+ * pane mounted later (a chapter with an Inner Light layer, say) is picked up
+ * with no extra wiring.
+ *
+ * `lastScrollTop` is tracked per scrolling element, not globally: swiping
+ * from a pane scrolled halfway to one at the top would otherwise read as one
+ * enormous upward scroll and yank the chrome back. A pane the reader has not
+ * scrolled simply contributes no events.
+ *
+ * The listener attaches on the mode it belongs to and detaches the moment
+ * the mode changes, rather than running for the page's lifetime. Handler
+ * work is rAF-throttled, same pattern as `ProgressRail`'s scroll/resize
+ * handling.
  */
 import type { ComputedRef, InjectionKey, Ref } from "vue";
 import {
@@ -52,19 +65,43 @@ const createAutoHidingChrome = (
     return typeof window === "undefined" ? 0 : window.scrollY;
   };
 
-  let rafHandle: number | null = null;
+  /** Per-element previous offset — see the module doc for why not one shared value. */
+  const lastScrollTops = new WeakMap<object, number>();
+  const WINDOW_KEY = {};
 
-  const measure = () => {
+  let rafHandle: number | null = null;
+  let pendingSource: object | null = null;
+  let pendingScrollTop = 0;
+
+  const commit = () => {
     rafHandle = null;
-    state.value = nextChromeVisibilityState(state.value, {
-      scrollTop: readScrollTop(),
-      hasOpenDisclosure: expandedAnchors.value.size > 0,
-    });
+    const source = pendingSource ?? WINDOW_KEY;
+    state.value = nextChromeVisibilityState(
+      { ...state.value, lastScrollTop: lastScrollTops.get(source) ?? 0 },
+      {
+        scrollTop: pendingScrollTop,
+        hasOpenDisclosure: expandedAnchors.value.size > 0,
+      },
+    );
+    lastScrollTops.set(source, pendingScrollTop);
   };
 
-  const handleScroll = () => {
+  const schedule = (source: object, scrollTop: number) => {
+    pendingSource = source;
+    pendingScrollTop = scrollTop;
     if (rafHandle !== null) return;
-    rafHandle = requestAnimationFrame(measure);
+    rafHandle = requestAnimationFrame(commit);
+  };
+
+  const handleWindowScroll = () => schedule(WINDOW_KEY, readScrollTop());
+
+  const PANE_BODY_SELECTOR = ".tes-pane-body";
+
+  const handlePaneScroll = (event: Event) => {
+    const target = event.target;
+    if (!(target instanceof HTMLElement)) return;
+    if (!target.matches(PANE_BODY_SELECTOR)) return;
+    schedule(target, target.scrollTop);
   };
 
   const cancelPendingMeasure = () => {
@@ -74,22 +111,43 @@ const createAutoHidingChrome = (
   };
 
   onMounted(() => {
-    const target: EventTarget | null | undefined = scrollRef
+    const windowTarget: EventTarget | null = scrollRef
       ? scrollRef.value
       : typeof window === "undefined"
         ? null
         : window;
-    if (!target) return;
 
     watch(
       mode,
       (current, _previous, onCleanup) => {
-        if (current !== "study") return;
+        if (current === "study") {
+          if (!windowTarget) return;
+          windowTarget.addEventListener("scroll", handleWindowScroll, {
+            passive: true,
+          });
+          onCleanup(() => {
+            windowTarget.removeEventListener("scroll", handleWindowScroll);
+            cancelPendingMeasure();
+          });
+          return;
+        }
 
-        target.addEventListener("scroll", handleScroll, { passive: true });
+        if (current !== "panes" || typeof document === "undefined") return;
+
+        // Capture phase: `scroll` does not bubble, so a listener on
+        // `document` only ever sees an inner container's scroll this way.
+        document.addEventListener("scroll", handlePaneScroll, {
+          capture: true,
+          passive: true,
+        });
         onCleanup(() => {
-          target.removeEventListener("scroll", handleScroll);
+          document.removeEventListener("scroll", handlePaneScroll, {
+            capture: true,
+          });
           cancelPendingMeasure();
+          // Leaving panes mode with the chrome mid-hide would strand it
+          // off-screen in a mode that has no way to bring it back.
+          state.value = initialChromeVisibilityState();
         });
       },
       { immediate: true },

--- a/app/composables/useReaderChromeOverlay.ts
+++ b/app/composables/useReaderChromeOverlay.ts
@@ -1,0 +1,115 @@
+/**
+ * Mobile panes mode's chrome overlay (issue 113).
+ *
+ * Study mode's auto-hiding chrome works because the whole document scrolls:
+ * the navbar and toolbar are `sticky`, the stream slides under them, and
+ * translating them away costs the reader nothing. Panes mode cannot do that.
+ * Each pane owns an inner `overflow-y-auto` container (`.tes-pane-body`) with
+ * a bounded height, and the chrome sits *above* it in normal flow — so
+ * collapsing the chrome moves the scroller's top edge up, and the text the
+ * reader is looking at jumps up with it by the full height of whatever was
+ * hidden. That, not the animation, is why this needed more than removing the
+ * study-mode gate on `useAutoHidingChrome`.
+ *
+ * So below `lg`, in panes mode, the chrome stops taking space: the navbar,
+ * the reader toolbar and each pane's header all become fixed/absolute
+ * overlays, the pane body fills the viewport, and its *content* is padded
+ * down far enough to start below them. Hiding is then a pure transform —
+ * the scroller never moves, so nothing under the reader's eyes ever jumps,
+ * and the pane gains the whole 245px it was giving up on a 412x915 screen.
+ *
+ * The three pieces live in three components that cannot see each other
+ * (`layouts/reader.vue`, `ReaderToolbar`, `ReaderPane`), so each registers
+ * its own element here and reads back where it belongs. Heights are measured
+ * rather than hardcoded because all three wrap: the breadcrumb at a long
+ * chapter title, the pane header at a narrow width.
+ *
+ * Positions come back as `:style` bindings, never `v-bind()` in scoped CSS —
+ * that is the documented Nuxt SSR hydration-mismatch trap.
+ */
+import { useElementSize, useMediaQuery } from "@vueuse/core";
+import type { ComputedRef, InjectionKey, Ref } from "vue";
+import {
+  chromeOffsetOf,
+  chromeShift,
+  chromeStackHeight,
+  emptyChromeHeights,
+  type ReaderChromeHeights,
+  type ReaderChromePiece,
+} from "~/utils/readerChrome";
+import { STUDY_MODE_MEDIA_QUERY } from "~/utils/readerMode";
+
+export interface ReaderChromeOverlay {
+  /**
+   * Measures `el` as this piece and keeps it measured. Every mounted pane
+   * registers its own header under the one `"pane-header"` key — they are
+   * siblings of identical height (one per swipe slide), so last-writer-wins
+   * is not a race, just redundancy.
+   */
+  register: (piece: ReaderChromePiece, el: Ref<HTMLElement | null>) => void;
+  /** Whether the overlay treatment applies at all: narrow viewport, panes mode. */
+  active: ComputedRef<boolean>;
+  /** Distance from the top of the pane area to this piece's own top edge, px. */
+  offsetOf: (piece: ReaderChromePiece) => ComputedRef<number>;
+  /** Total chrome height — what `.tes-pane-body` pads its content by, px. */
+  height: ComputedRef<number>;
+  /**
+   * The single transform every piece shares: `0` while visible, and while
+   * hidden the full stack height, so each piece clears the top edge exactly
+   * as the one above it does. One value for all three is what makes them
+   * read as a single surface sliding away rather than three racing.
+   */
+  shift: ComputedRef<number>;
+}
+
+const READER_CHROME_OVERLAY_KEY: InjectionKey<ReaderChromeOverlay> = Symbol(
+  "reader-chrome-overlay",
+);
+
+const createReaderChromeOverlay = (): ReaderChromeOverlay => {
+  const { mode } = useReaderMode();
+  const { visible } = useAutoHidingChrome();
+  const isNarrowViewport = useMediaQuery(STUDY_MODE_MEDIA_QUERY);
+
+  const heights = reactive<ReaderChromeHeights>(emptyChromeHeights());
+
+  const register = (
+    piece: ReaderChromePiece,
+    el: Ref<HTMLElement | null>,
+  ): void => {
+    // Border-box: the toolbar carries `py-3` and a `border-b`, and the
+    // default content-box measurement misses all 25px of it — the chrome
+    // then translates 25px short and leaves a sliver of itself on screen.
+    const { height } = useElementSize(el, undefined, { box: "border-box" });
+    watch(height, (value) => {
+      // A hidden/unmounted element measures 0. Keeping the last real height
+      // means the pane's padding doesn't collapse mid-transition, when the
+      // chrome is translated out but still very much occupying its slot.
+      if (value > 0) heights[piece] = value;
+    });
+  };
+
+  const active = computed(
+    () => isNarrowViewport.value && mode.value === "panes",
+  );
+
+  const height = computed(() => chromeStackHeight(heights));
+
+  const offsetOf = (piece: ReaderChromePiece): ComputedRef<number> =>
+    computed(() => chromeOffsetOf(heights, piece));
+
+  const shift = computed(() =>
+    chromeShift(heights, !active.value || visible.value),
+  );
+
+  return { register, active, offsetOf, height, shift };
+};
+
+export const useReaderChromeOverlay = (): ReaderChromeOverlay => {
+  const existing = inject(READER_CHROME_OVERLAY_KEY, null);
+  if (existing) return existing;
+
+  const overlay = createReaderChromeOverlay();
+  provide(READER_CHROME_OVERLAY_KEY, overlay);
+  return overlay;
+};

--- a/app/layouts/reader.vue
+++ b/app/layouts/reader.vue
@@ -42,6 +42,20 @@ const { mode } = useReaderMode();
 const { visible: chromeVisible } = useAutoHidingChrome();
 const { scale } = useReadingPreferences();
 const isStudyMode = computed(() => mode.value === "study");
+
+// Panes mode's chrome overlay (issue 113) — see `useReaderChromeOverlay`
+// for why panes mode cannot reuse study mode's sticky treatment. This layout
+// is the provider for the same reason it provides the others: it renders
+// around the page, so its call runs first.
+const overlay = useReaderChromeOverlay();
+const navbarRef = ref<HTMLElement | null>(null);
+overlay.register("navbar", navbarRef);
+
+const navbarStyle = computed(() =>
+  overlay.active.value
+    ? { transform: `translateY(${overlay.shift.value}px)` }
+    : {},
+);
 </script>
 
 <template>
@@ -53,10 +67,17 @@ const isStudyMode = computed(() => mode.value === "study");
       {{ t("common.skipToContent") }}
     </a>
     <div
+      ref="navbarRef"
+      :style="navbarStyle"
       :class="[
         isStudyMode &&
           'sticky top-0 z-40 transition-transform duration-200 ease-out motion-reduce:transition-none',
         isStudyMode && !chromeVisible && '-translate-y-full',
+        // Out of flow entirely, so `main` below gets the whole viewport and
+        // the pane it holds keeps its height whether the chrome is showing
+        // or not — see `useReaderChromeOverlay`.
+        overlay.active.value &&
+          'fixed inset-x-0 top-0 z-40 transition-transform duration-200 ease-out motion-reduce:transition-none',
       ]"
     >
       <AppNavBar />

--- a/app/utils/readerChrome.ts
+++ b/app/utils/readerChrome.ts
@@ -1,0 +1,56 @@
+/**
+ * Pure stacking arithmetic for mobile panes mode's chrome overlay
+ * (`useReaderChromeOverlay`, issue 113). Kept out of the composable for the
+ * same reason `~/utils/autoHidingChrome` is: the rules are worth testing
+ * without mounting a reader.
+ *
+ * The model is one vertical stack, top to bottom, laid over a pane body that
+ * never moves. A piece's `top` is everything above it; the stack's height is
+ * what the pane body pads its content by; and hiding translates every piece
+ * by that same total, which is the smallest shift that clears the top edge
+ * for the *lowest* piece — and therefore clears it for all of them.
+ */
+
+/** The chrome pieces, in the order they stack. */
+export const READER_CHROME_PIECES = [
+  "navbar",
+  "toolbar",
+  "pane-header",
+] as const;
+export type ReaderChromePiece = (typeof READER_CHROME_PIECES)[number];
+
+export type ReaderChromeHeights = Record<ReaderChromePiece, number>;
+
+export const emptyChromeHeights = (): ReaderChromeHeights => ({
+  navbar: 0,
+  toolbar: 0,
+  "pane-header": 0,
+});
+
+/** Distance from the top of the pane area to `piece`'s own top edge. */
+export const chromeOffsetOf = (
+  heights: ReaderChromeHeights,
+  piece: ReaderChromePiece,
+): number =>
+  READER_CHROME_PIECES.slice(0, READER_CHROME_PIECES.indexOf(piece)).reduce(
+    (sum, earlier) => sum + heights[earlier],
+    0,
+  );
+
+/** Total stack height — the pane body's content padding. */
+export const chromeStackHeight = (heights: ReaderChromeHeights): number =>
+  READER_CHROME_PIECES.reduce((sum, piece) => sum + heights[piece], 0);
+
+/**
+ * The shared transform: `0` while visible, `-stackHeight` while hidden.
+ *
+ * One value for every piece, deliberately. Translating each piece by only
+ * its own height would clear the navbar but leave the pane header — the
+ * lowest and most visible piece — sitting most of the way down where it
+ * started, which is the bug this function exists to make impossible to
+ * write by accident.
+ */
+export const chromeShift = (
+  heights: ReaderChromeHeights,
+  visible: boolean,
+): number => (visible ? 0 : -chromeStackHeight(heights));

--- a/tests/e2e/reader.spec.ts
+++ b/tests/e2e/reader.spec.ts
@@ -206,4 +206,63 @@ test.describe("mobile reader", () => {
     await expect(page.locator("#reader-source-pane")).toBeInViewport();
     await expect.poll(trackScrollLeft).toBe(0);
   });
+
+  test("gives the pane the whole viewport by overlaying its chrome", async ({
+    page,
+  }) => {
+    // Issue 113. The pane body must not move when the chrome hides — that
+    // is the difference between this and study mode's sticky treatment,
+    // and the only reason the text does not jump under the reader. The
+    // chrome must also clear the top edge completely: an earlier version
+    // translated each piece by its own height and left the pane header
+    // sitting most of the way down the screen.
+    await page.goto(CHAPTER_PATH);
+    await waitForHydration(page);
+    await page
+      .getByRole("group", { name: "Reading mode" })
+      .getByRole("button", { name: "Panes" })
+      .click();
+
+    const paneBody = page.locator("#reader-source-pane .tes-pane-body");
+    await expect(paneBody).toBeVisible();
+
+    const bodyBox = async () => {
+      const box = await paneBody.boundingBox();
+      return { top: Math.round(box!.y), height: Math.round(box!.height) };
+    };
+    const chromeBottoms = async () =>
+      page.evaluate(() =>
+        ["header", ".tes-pane-header"].map((selector) =>
+          Math.round(
+            document.querySelector(selector)?.getBoundingClientRect().bottom ??
+              0,
+          ),
+        ),
+      );
+
+    const atTop = await bodyBox();
+    expect((await chromeBottoms()).every((bottom) => bottom > 0)).toBe(true);
+
+    await paneBody.evaluate((el) => {
+      el.scrollTop = 600;
+      el.dispatchEvent(new Event("scroll"));
+    });
+    await expect
+      .poll(async () => (await chromeBottoms()).every((bottom) => bottom <= 0))
+      .toBe(true);
+
+    // The scroller itself never moved or resized.
+    expect(await bodyBox()).toEqual(atTop);
+
+    // Scrolling back up brings every piece of it back, including the
+    // pane header's language switcher.
+    await paneBody.evaluate((el) => {
+      el.scrollTop = 400;
+      el.dispatchEvent(new Event("scroll"));
+    });
+    await expect
+      .poll(async () => (await chromeBottoms()).every((bottom) => bottom > 0))
+      .toBe(true);
+    expect(await bodyBox()).toEqual(atTop);
+  });
 });

--- a/tests/unit/reader-chrome.spec.ts
+++ b/tests/unit/reader-chrome.spec.ts
@@ -1,0 +1,71 @@
+// Mobile panes mode's chrome stacking (issue 113). The measured numbers
+// below are the real ones from a 412x915 viewport: navbar 60, toolbar 137,
+// pane header 48.
+import { describe, expect, it } from "vitest";
+import {
+  chromeOffsetOf,
+  chromeShift,
+  chromeStackHeight,
+  emptyChromeHeights,
+  READER_CHROME_PIECES,
+  type ReaderChromeHeights,
+} from "~/utils/readerChrome";
+
+const MEASURED: ReaderChromeHeights = {
+  navbar: 60,
+  toolbar: 137,
+  "pane-header": 48,
+};
+
+describe("chromeOffsetOf", () => {
+  it("puts each piece directly below the one above it", () => {
+    expect(chromeOffsetOf(MEASURED, "navbar")).toBe(0);
+    expect(chromeOffsetOf(MEASURED, "toolbar")).toBe(60);
+    expect(chromeOffsetOf(MEASURED, "pane-header")).toBe(197);
+  });
+
+  it("leaves no gap and no overlap anywhere in the stack", () => {
+    for (const [index, piece] of READER_CHROME_PIECES.entries()) {
+      const next = READER_CHROME_PIECES[index + 1];
+      if (!next) continue;
+      expect(chromeOffsetOf(MEASURED, next)).toBe(
+        chromeOffsetOf(MEASURED, piece) + MEASURED[piece],
+      );
+    }
+  });
+});
+
+describe("chromeStackHeight", () => {
+  it("is what the pane body pads its content by", () => {
+    expect(chromeStackHeight(MEASURED)).toBe(245);
+  });
+
+  it("is zero before anything has been measured", () => {
+    expect(chromeStackHeight(emptyChromeHeights())).toBe(0);
+  });
+});
+
+describe("chromeShift", () => {
+  it("is nothing while the chrome is visible", () => {
+    expect(chromeShift(MEASURED, true)).toBe(0);
+  });
+
+  it("clears the top edge for every piece, not just the first", () => {
+    // The failure this guards: shifting each piece by its own height hides
+    // the navbar and leaves the pane header 197px down the screen, still
+    // covering the text it was meant to give back.
+    const shift = chromeShift(MEASURED, false);
+
+    for (const piece of READER_CHROME_PIECES) {
+      const bottomEdge = chromeOffsetOf(MEASURED, piece) + MEASURED[piece];
+      expect(bottomEdge + shift).toBeLessThanOrEqual(0);
+    }
+  });
+
+  it("moves the lowest piece exactly clear, never further", () => {
+    const lowest = READER_CHROME_PIECES[READER_CHROME_PIECES.length - 1]!;
+    const bottomEdge = chromeOffsetOf(MEASURED, lowest) + MEASURED[lowest];
+
+    expect(bottomEdge + chromeShift(MEASURED, false)).toBe(0);
+  });
+});


### PR DESCRIPTION
Closes #113.

## The measurement

On a 412x915 phone in panes mode, 245px was permanent chrome: navbar 60, toolbar 137, pane header 48. The text got 670px of 915.

## Why this wasn't "delete the study-mode gate"

`useAutoHidingChrome` exists and works — in study mode, where the document scrolls and the chrome is `sticky`, so hiding it costs the reader nothing.

Panes mode is a different shape. Each pane scrolls inside its own bounded `.tes-pane-body`, with the chrome above it in normal flow. Collapse that chrome and the scroller's top edge moves up 245px — and the paragraph the reader is mid-sentence on goes with it. The animation was never the hard part.

## What this does

Below `lg`, in panes mode, the chrome stops occupying layout: navbar, toolbar and pane header all become overlays, the pane body fills the viewport, and its **content** is padded down to start below them. Hiding is then a pure transform on elements that own no space — the scroller cannot move, so nothing jumps.

Measured on the built site, same viewport:

| | at top | scrolled down |
|---|---|---|
| navbar top | 0 | −245 |
| toolbar top | 60 | −185 |
| pane header top | 197 | −48 |
| **pane body** | **top 0, height 915** | **top 0, height 915** |

Every piece clears the top edge exactly; the scroller is byte-identical in both states.

## Two things worth knowing

**Scroll source.** `useAutoHidingChrome` now listens on `document` in the **capture** phase and filters to `.tes-pane-body`. `scroll` does not bubble, so that is the only way to see an inner container's scroll from one listener — which avoids a registration protocol between the composable and every pane, and means a pane mounted later (a chapter that has an Inner Light layer) is picked up with no extra wiring.

**Per-element scroll history.** Previous offsets are tracked per scrolling element. Sharing one would make swiping from a pane scrolled halfway to one sitting at the top read as a single enormous upward scroll, snapping the chrome back for no reason.

## The rule the tests exist for

Every piece translates by the **stack's** total height, not its own. Translating each by its own height clears the navbar and leaves the pane header — the lowest and most visible piece — 197px down the screen, still covering the text it was meant to give back. `chromeShift` is a pure function and `tests/unit/reader-chrome.spec.ts` asserts each piece's bottom edge ends at or above 0.

I hit exactly one real bug building this, and it was this class: `useElementSize` measures the **content** box by default, so the toolbar's `py-3` + `border-b` went uncounted and the chrome translated 25px short, leaving a sliver on screen. Now measured border-box.

## Verification

- `task check` green: 913 unit tests (7 new), content validation, full generate, **6/6 e2e** (one new).
- New e2e asserts the pane body's box is unchanged across hide and show, and that both `header` and `.tes-pane-header` have bottom ≤ 0 when hidden and > 0 when shown.
- Desktop grid and study mode untouched — `active` is gated on the narrow-viewport media query and `mode === "panes"`, and the existing desktop/study specs still pass.
- Screenshots at 412x915 attached in the thread: at rest the chrome is exactly as before; scrolled, the text has the entire screen with only the pane pill left.

## For a reviewer

- Leaving panes mode resets the visibility state — otherwise the chrome could be stranded mid-hide in a mode with no scroll listener to bring it back.
- The pane header registers under one key from up to three mounted panes. They are identical-height siblings, so last-writer-wins is redundancy rather than a race, but it is the sort of thing worth a second opinion.