### PR TITLE
fix(reader): stop the mobile panes chrome bouncing on every scroll correction

### DIFF
--- a/app/assets/css/main.css
+++ b/app/assets/css/main.css
@@ -535,7 +535,11 @@ html {
  */
 .tes-commentary-seif-heading,
 .tes-prose-section-heading {
-  top: calc(-1 * var(--pane-pad-block-start, 0px));
+  /* `--pane-chrome-visible` is the height of chrome currently overlaying
+     the top of this scroller — 0 everywhere except mobile panes mode, where
+     `ReaderPane` sets it (issue 113). Without it these pin flush to the
+     scroller's top edge, which in that mode sits *behind* the navbar. */
+  top: calc(var(--pane-chrome-visible, 0px) - var(--pane-pad-block-start, 0px));
   margin-block-start: calc(-1 * var(--pane-pad-block-start, 0px));
   padding-block-start: calc(0.5rem + var(--pane-pad-block-start, 0px));
 }
@@ -666,9 +670,16 @@ html {
 .tes-pane-body {
   @apply min-h-0 flex-1 overflow-y-auto px-4 pb-24 lg:pb-4;
   /* Named rather than a bare `pt-4` because the sticky headings inside have
-     to cancel exactly this value — see `.tes-commentary-seif-heading`. */
+     to cancel exactly this value — see `.tes-commentary-seif-heading`.
+     `--pane-chrome-inset` is separate and additive: in mobile panes mode
+     this scroller runs the full height of the viewport with the chrome
+     overlaying its top, so its content starts that much further down
+     (issue 113) — but the reading padding above a heading is still 1rem,
+     and that is the number the sticky rule has to cancel. */
   --pane-pad-block-start: 1rem;
-  padding-block-start: var(--pane-pad-block-start);
+  padding-block-start: calc(
+    var(--pane-pad-block-start) + var(--pane-chrome-inset, 0px)
+  );
 }
 
 /* The small uppercase "eyebrow" heading style: pane titles

--- a/app/components/reader/ReaderPane.vue
+++ b/app/components/reader/ReaderPane.vue
@@ -49,11 +49,29 @@ const headerStyle = computed(() =>
  * whole point — a scroller whose top edge stays put cannot make the text
  * jump when the chrome slides away. `scroll-padding` keeps `#seif-N` anchor
  * jumps from landing underneath it.
+ *
+ * Sets variables, never `padding-block-start` directly. That property is
+ * derived from `--pane-pad-block-start`, which is the exact value
+ * `.tes-commentary-seif-heading` cancels to pin flush (issue #102) —
+ * overriding it behind that rule's back left every sticky heading in Inner
+ * Light compensating 16px against a real padding of 245px, and pinning them
+ * behind the navbar.
  */
 const bodyStyle = computed(() =>
   overlay.active.value
     ? {
-        paddingBlockStart: `${overlay.height.value}px`,
+        // How far the content starts below the scroller's own top edge.
+        // Constant while the mode is active: the scroller must not resize
+        // when the chrome hides, or the text jumps.
+        "--pane-chrome-inset": `${overlay.height.value}px`,
+        // How much chrome is on screen *right now* — sticky headings pin
+        // below it, so they follow the chrome up and back down.
+        "--pane-chrome-visible": `${overlay.height.value + overlay.shift.value}px`,
+        // The full stack, not the currently-visible part: an anchor jump
+        // is a large scroll, which can be exactly the gesture that brings
+        // the chrome back — landing the target where it is about to be
+        // covered. Reserving the whole height is never wrong, only
+        // occasionally generous.
         scrollPaddingBlockStart: `${overlay.height.value}px`,
       }
     : {},

--- a/app/composables/useReaderChromeOverlay.ts
+++ b/app/composables/useReaderChromeOverlay.ts
@@ -34,6 +34,7 @@ import {
   chromeShift,
   chromeStackHeight,
   emptyChromeHeights,
+  READER_CHROME_PIECES,
   type ReaderChromeHeights,
   type ReaderChromePiece,
 } from "~/utils/readerChrome";
@@ -89,8 +90,21 @@ const createReaderChromeOverlay = (): ReaderChromeOverlay => {
     });
   };
 
+  /**
+   * Every piece measured at least once. Without this gate the first frame
+   * in panes mode lays the stack out against zeros — traced entering the
+   * mode, the pane's content padding stepped 197px then 245px on the next
+   * frame, so the text visibly hopped as the header found its place. The
+   * overlay is worth nothing until it can be positioned correctly, and the
+   * in-flow layout it falls back to for that one frame is the same one the
+   * reader was already looking at.
+   */
+  const measured = computed(() =>
+    READER_CHROME_PIECES.every((piece) => heights[piece] > 0),
+  );
+
   const active = computed(
-    () => isNarrowViewport.value && mode.value === "panes",
+    () => isNarrowViewport.value && mode.value === "panes" && measured.value,
   );
 
   const height = computed(() => chromeStackHeight(heights));

--- a/app/utils/autoHidingChrome.ts
+++ b/app/utils/autoHidingChrome.ts
@@ -1,24 +1,72 @@
 /**
- * Pure state machine for the study mode's auto-hiding chrome
- * (`useAutoHidingChrome`): the reader toolbar (and, on mobile, the site
- * navbar) translates away on scroll-down and returns on scroll-up, so the
- * reading stream gets the full viewport without chrome ever being
+ * Pure state machine for the reader's auto-hiding chrome
+ * (`useAutoHidingChrome`): the toolbar, the navbar, and in panes mode each
+ * pane's header translate away on scroll-down and return on scroll-up, so
+ * the reading surface gets the full viewport without chrome ever being
  * unreachable. Kept free of the DOM so the transition rules are
  * unit-testable without mounting anything — the composable only measures
  * `scrollTop` and forwards it here.
+ *
+ * ## Why this decides on accumulated travel, not on the last delta
+ *
+ * The first version flipped on the sign of a single scroll delta, past an
+ * 8px threshold. A finger does not move that way. Real reading scroll is
+ * mostly-down with constant small corrections — traced on a 412x915 device,
+ * a normal downward read produced deltas like
+ * `+14 +20 +26 +22 -9 -12 +18 +24 +20 -10 -14 …`, and every one of those
+ * corrections read as "the reader wants the chrome back". The 245px stack
+ * spent the whole gesture retargeting a 200ms transition mid-flight, its top
+ * edge bouncing `-168 -29 -187 -115 -159 -232 -69 -212 …` instead of ever
+ * settling. It was unusable, and no amount of tuning a per-event threshold
+ * fixes it: a 12px correction is a real 12px correction.
+ *
+ * So the state machine accumulates **net travel toward the next flip** and
+ * only commits when the reader has clearly meant it. A correction costs the
+ * gesture a little of its progress rather than flipping anything, and travel
+ * in the direction that is already satisfied banks nothing at all — which
+ * is what stops a wobble from moving the chrome, without letting a
+ * mostly-downward read be held up forever by its own tremor.
+ *
+ * The thresholds are asymmetric on purpose: reaching for chrome that is
+ * gone is a deliberate act and should feel prompt, while hiding it should
+ * take enough sustained reading motion that it never happens by accident.
  */
 export interface ChromeVisibilityState {
   visible: boolean;
   lastScrollTop: number;
+  /**
+   * Signed distance banked toward the next flip. Positive is downward.
+   * Clamped so it never accumulates in the direction that cannot commit,
+   * and reset to zero whenever visibility does commit — so the next flip
+   * needs its own full stroke rather than riding on leftover momentum.
+   */
+  travel: number;
 }
 
 export const initialChromeVisibilityState = (): ChromeVisibilityState => ({
   visible: true,
   lastScrollTop: 0,
+  travel: 0,
 });
 
-/** Sub-pixel/momentum-scroll jitter smaller than this never toggles visibility. */
-const HIDE_THRESHOLD_PX = 8;
+/** Sub-pixel/rounding noise smaller than this is not movement at all. */
+const NOISE_PX = 2;
+
+/**
+ * Sustained downward travel before the chrome hides. Roughly two lines of
+ * body text at the default reading scale — long enough that no correction
+ * or momentum bounce reaches it, short enough that a deliberate scroll
+ * clears the chrome on the first stroke.
+ */
+const HIDE_AFTER_PX = 72;
+
+/**
+ * Sustained upward travel before it returns. Shorter than the hide
+ * threshold: a reader scrolling back up is usually reaching for the chrome
+ * (the language switcher, the mode toggle, prev/next), and making them work
+ * for it is worse than showing it a little eagerly.
+ */
+const SHOW_AFTER_PX = 40;
 
 /** Always visible within this many px of the very top of the stream. */
 const NEAR_TOP_PX = 48;
@@ -38,19 +86,37 @@ export const nextChromeVisibilityState = (
 ): ChromeVisibilityState => {
   const { scrollTop, hasOpenDisclosure } = params;
 
-  if (scrollTop <= NEAR_TOP_PX) {
-    return { visible: true, lastScrollTop: scrollTop };
-  }
-
-  if (hasOpenDisclosure && scrollTop <= NEAR_TOP_WITH_DISCLOSURE_PX) {
-    return { visible: true, lastScrollTop: scrollTop };
+  if (
+    scrollTop <= NEAR_TOP_PX ||
+    (hasOpenDisclosure && scrollTop <= NEAR_TOP_WITH_DISCLOSURE_PX)
+  ) {
+    return { visible: true, lastScrollTop: scrollTop, travel: 0 };
   }
 
   const delta = scrollTop - state.lastScrollTop;
-  if (Math.abs(delta) < HIDE_THRESHOLD_PX) {
+  if (Math.abs(delta) < NOISE_PX) {
     return { ...state, lastScrollTop: scrollTop };
   }
 
-  // Scrolling down (positive delta) hides; scrolling up shows.
-  return { visible: delta < 0, lastScrollTop: scrollTop };
+  const travel = state.travel + delta;
+
+  // Only intent that could still change something is banked. While the
+  // chrome is up, downward travel accumulates and upward travel is floored
+  // at zero; while it is down, the reverse. Corrections therefore cost a
+  // gesture a little progress instead of discarding it — a mostly-downward
+  // read still reaches the threshold through its tremor — and a run in the
+  // direction that is already satisfied banks nothing, so the *next* flip
+  // always needs its own full stroke rather than unwinding a page of
+  // momentum first.
+  if (state.visible) {
+    if (travel >= HIDE_AFTER_PX) {
+      return { visible: false, lastScrollTop: scrollTop, travel: 0 };
+    }
+    return { ...state, lastScrollTop: scrollTop, travel: Math.max(travel, 0) };
+  }
+
+  if (travel <= -SHOW_AFTER_PX) {
+    return { visible: true, lastScrollTop: scrollTop, travel: 0 };
+  }
+  return { ...state, lastScrollTop: scrollTop, travel: Math.min(travel, 0) };
 };

--- a/tests/unit/auto-hiding-chrome.spec.ts
+++ b/tests/unit/auto-hiding-chrome.spec.ts
@@ -1,18 +1,40 @@
 import { describe, expect, it } from "vitest";
 
+/** Feeds a run of deltas through the machine, the way a scroll actually arrives. */
+const scrollBy = (
+  state: ChromeVisibilityState,
+  deltas: number[],
+  hasOpenDisclosure = false,
+) => {
+  let current = state;
+  for (const delta of deltas) {
+    current = nextChromeVisibilityState(current, {
+      scrollTop: current.lastScrollTop + delta,
+      hasOpenDisclosure,
+    });
+  }
+  return current;
+};
+
+const reading = (overrides: Partial<ChromeVisibilityState> = {}) => ({
+  ...initialChromeVisibilityState(),
+  lastScrollTop: 400,
+  ...overrides,
+});
+
 describe("initialChromeVisibilityState", () => {
-  it("starts visible, at the top", () => {
+  it("starts visible, at the top, with nothing accumulated", () => {
     expect(initialChromeVisibilityState()).toEqual({
       visible: true,
       lastScrollTop: 0,
+      travel: 0,
     });
   });
 });
 
 describe("nextChromeVisibilityState", () => {
   it("hides on a clear scroll-down past the near-top band", () => {
-    const state = { visible: true, lastScrollTop: 100 };
-    const next = nextChromeVisibilityState(state, {
+    const next = nextChromeVisibilityState(reading({ lastScrollTop: 100 }), {
       scrollTop: 200,
       hasOpenDisclosure: false,
     });
@@ -22,8 +44,7 @@ describe("nextChromeVisibilityState", () => {
   });
 
   it("shows again on a clear scroll-up", () => {
-    const state = { visible: false, lastScrollTop: 400 };
-    const next = nextChromeVisibilityState(state, {
+    const next = nextChromeVisibilityState(reading({ visible: false }), {
       scrollTop: 300,
       hasOpenDisclosure: false,
     });
@@ -32,8 +53,7 @@ describe("nextChromeVisibilityState", () => {
   });
 
   it("stays visible within the near-top band regardless of direction", () => {
-    const state = { visible: true, lastScrollTop: 0 };
-    const next = nextChromeVisibilityState(state, {
+    const next = nextChromeVisibilityState(initialChromeVisibilityState(), {
       scrollTop: 20,
       hasOpenDisclosure: false,
     });
@@ -41,20 +61,18 @@ describe("nextChromeVisibilityState", () => {
     expect(next.visible).toBe(true);
   });
 
-  it("ignores sub-threshold jitter without toggling visibility", () => {
-    const state = { visible: false, lastScrollTop: 500 };
-    const next = nextChromeVisibilityState(state, {
-      scrollTop: 503,
+  it("ignores sub-pixel jitter without toggling visibility", () => {
+    const next = nextChromeVisibilityState(reading({ visible: false }), {
+      scrollTop: 401,
       hasOpenDisclosure: false,
     });
 
     expect(next.visible).toBe(false);
-    expect(next.lastScrollTop).toBe(503);
+    expect(next.lastScrollTop).toBe(401);
   });
 
   it("never hides while a disclosure is open near the top, even past the plain near-top band", () => {
-    const state = { visible: true, lastScrollTop: 60 };
-    const next = nextChromeVisibilityState(state, {
+    const next = nextChromeVisibilityState(reading({ lastScrollTop: 60 }), {
       scrollTop: 200,
       hasOpenDisclosure: true,
     });
@@ -63,22 +81,82 @@ describe("nextChromeVisibilityState", () => {
   });
 
   it("still hides on scroll-down once far enough past the disclosure-open band", () => {
-    const state = { visible: true, lastScrollTop: 250 };
-    const next = nextChromeVisibilityState(state, {
+    const next = nextChromeVisibilityState(reading({ lastScrollTop: 250 }), {
       scrollTop: 400,
       hasOpenDisclosure: true,
     });
 
     expect(next.visible).toBe(false);
   });
+});
 
-  it("hides normally on scroll-down once the disclosure closes", () => {
-    const state = { visible: true, lastScrollTop: 100 };
-    const next = nextChromeVisibilityState(state, {
-      scrollTop: 200,
-      hasOpenDisclosure: false,
-    });
+// The reason this machine accumulates travel instead of reading the sign of
+// the last delta. Every sequence below is a real one, traced off a 412x915
+// device — under the per-delta rule they made the 245px chrome stack bounce
+// through its whole range mid-gesture.
+describe("nextChromeVisibilityState — a finger, not a wheel", () => {
+  it("does not resurface the chrome on the small corrections in a downward read", () => {
+    const afterHiding = scrollBy(reading(), [14, 20, 26, 22]);
+    expect(afterHiding.visible).toBe(false);
 
-    expect(next.visible).toBe(false);
+    const wobbling = scrollBy(afterHiding, [-9, -12, 18, 24, 20, -10, -14, 16]);
+
+    expect(wobbling.visible).toBe(false);
+  });
+
+  it("still gets there through the tremor, rather than being held up by it", () => {
+    // The exact trace that used to make it bounce. It must end hidden:
+    // refusing to ever hide is the opposite failure, not a fix.
+    const state = scrollBy(reading(), [26, 22, -9, -12, 18, 24, 20]);
+
+    expect(state.visible).toBe(false);
+  });
+
+  it("keeps the chrome up through the corrections in an upward read", () => {
+    const atTop = scrollBy(reading(), [-14, -20, -12]);
+    expect(atTop.visible).toBe(true);
+
+    const wobbling = scrollBy(atTop, [8, 11, -16, -20, 9, 12, -14]);
+
+    expect(wobbling.visible).toBe(true);
+  });
+
+  it("banks nothing in the direction that is already satisfied", () => {
+    // Scrolling up while the chrome is already up must not build credit
+    // toward hiding it, and vice versa — otherwise a long read in one
+    // direction makes the first flick back feel dead.
+    const afterLongUp = scrollBy(
+      reading({ lastScrollTop: 2000 }),
+      [-300, -300, -300],
+    );
+    expect(afterLongUp.visible).toBe(true);
+    expect(afterLongUp.travel).toBe(0);
+
+    const afterLongDown = scrollBy(
+      reading({ visible: false }),
+      [300, 300, 300],
+    );
+    expect(afterLongDown.visible).toBe(false);
+    expect(afterLongDown.travel).toBe(0);
+    // One ordinary upward stroke, not a page of unwinding.
+    expect(scrollBy(afterLongDown, [-20, -22]).visible).toBe(true);
+  });
+
+  it("still commits on a deliberate stroke in one direction", () => {
+    expect(scrollBy(reading(), [24, 24, 24]).visible).toBe(false);
+
+    const hidden = scrollBy(reading({ visible: false }), [24, 24, 24]);
+    expect(hidden.visible).toBe(false);
+    expect(scrollBy(hidden, [-20, -20]).visible).toBe(true);
+  });
+
+  it("needs its own full run to flip back, never riding leftover momentum", () => {
+    // The stroke that hides the chrome banks nothing: an immediate small
+    // bounce upward must not undo it.
+    const hidden = scrollBy(reading(), [30, 30, 30]);
+    expect(hidden.visible).toBe(false);
+    expect(hidden.travel).toBe(0);
+
+    expect(scrollBy(hidden, [-12, -12]).visible).toBe(false);
   });
 });


### PR DESCRIPTION
Closes #115. You were right, and it was worse than "janky" — it was unusable.

## What was actually wrong

Three faults, one symptom.

### 1. The chrome flipped on the sign of a single scroll delta

A finger does not move that way. Traced on a 412x915 device, an ordinary downward read produces:

```
+14 +20 +26 +22 -9 -12 +18 +24 +20 -10 -14 +16 +22 +26 -11 -9 …
```

Every one of those corrections said "bring the chrome back", so the 245px stack spent the whole gesture retargeting a 200ms transition mid-flight. Navbar top edge, sampled every 4 frames through one gesture:

```
before:  0  0  -168  -29  -187  -115  -159  -232  -69  -212  -196  -125  -165  -235  -245
after:   0  0     0    0     0  -168  -229  -245  -245  -245  -245  -245  -245  -245  -245
```

Tuning the 8px threshold could never fix this — a 12px correction is a real 12px correction. The state machine now accumulates **net travel toward the next flip**: a correction costs a gesture some progress instead of reversing it, and travel in the direction that is already satisfied banks nothing, so the next flip always needs its own full stroke rather than unwinding a page of momentum first. Hide at 72px sustained, show at 40px — asymmetric because reaching for chrome that is gone is deliberate and should feel prompt.

**Study mode gets the same fix.** It always had the same defect; it just had less chrome to throw around, so it read as twitchy rather than broken.

### 2. Entering panes mode laid the stack out against unmeasured zeros

The pane's content padding stepped 197 then 245 on the next frame — the text visibly hopped. The overlay now waits until every piece has a real height, falling back for that one frame to the layout the reader was already looking at. Measured: text now enters panes mode at exactly the position it left.

### 3. I set the pane body's padding behind the CSS contract's back

This is the one I'd flag hardest. `--pane-pad-block-start` is the exact value `.tes-commentary-seif-heading` cancels to pin its sticky headings flush (#102). #114 overrode `padding-block-start` directly, so every sticky heading in Inner Light was compensating 16px against a real padding of 245px — and pinned **behind the navbar**. Inner Light read straight through is your main reading path, so this was likely a good part of what felt broken.

Split into two variables:

- `--pane-chrome-inset` — how far content starts below the scroller's top. Constant while the mode is active, so the scroller never resizes and the text never jumps.
- `--pane-chrome-visible` — how much chrome is on screen right now. Sticky headings pin below it, so they ride up with the chrome and come back down with it.

Verified live: with the chrome hidden the heading's computed `top` is `-16px` and `--pane-chrome-visible` is `0px`; with it shown they are `228.9px` and `244.9px`.

## Verification

- `task check` green: 918 unit tests (5 new), content validation, full generate, 6/6 e2e.
- The state machine's new spec is driven by the **real traced delta sequences**, including the one that used to bounce — asserting both that a wobble no longer moves the chrome and that a mostly-downward read still gets there through its own tremor (refusing to ever hide is the opposite failure, not a fix).
- Anchor jumps now reserve the full stack height as scroll-padding rather than the visible part: a jump is a large scroll, which can itself be the gesture that brings the chrome back, and landing a target where it is about to be covered is worse than landing it a little low.

## For a reviewer

The thresholds (72 / 40) are judgement, tuned against traced gestures rather than derived. If hiding still feels too eager or too reluctant on a real device, those two constants are the dial — everything else is mechanism.