### PR TITLE
fix(reader): decide chrome visibility on sustained scroll, not a single delta

### DIFF
--- a/app/utils/autoHidingChrome.ts
+++ b/app/utils/autoHidingChrome.ts
@@ -1,24 +1,73 @@
 /**
- * Pure state machine for the study mode's auto-hiding chrome
- * (`useAutoHidingChrome`): the reader toolbar (and, on mobile, the site
- * navbar) translates away on scroll-down and returns on scroll-up, so the
+ * Pure state machine for the reader's auto-hiding chrome
+ * (`useAutoHidingChrome`): the reader toolbar and, on mobile, the site
+ * navbar translate away on scroll-down and return on scroll-up, so the
  * reading stream gets the full viewport without chrome ever being
  * unreachable. Kept free of the DOM so the transition rules are
  * unit-testable without mounting anything — the composable only measures
  * `scrollTop` and forwards it here.
+ *
+ * ## Why this decides on accumulated travel, not on the last delta
+ *
+ * The first version flipped on the sign of a single scroll delta, past an
+ * 8px threshold. A finger does not move that way. Real reading scroll is
+ * mostly-down with constant small corrections — traced on a 412x915 device,
+ * a normal downward read produced deltas like
+ * `+14 +20 +26 +22 -9 -12 +18 +24 +20 -10 -14 …`, and every one of those
+ * corrections read as "the reader wants the chrome back", so the chrome
+ * spent the whole gesture retargeting a 200ms transition mid-flight instead
+ * of ever settling — its top edge bouncing
+ * `-168 -29 -187 -115 -159 -232 -69 -212 …` when it had a tall stack to
+ * throw around. No amount of tuning a per-event threshold fixes it: a 12px
+ * correction is a real 12px correction.
+ *
+ * So the state machine accumulates **net travel toward the next flip** and
+ * only commits when the reader has clearly meant it. A correction costs the
+ * gesture a little of its progress rather than flipping anything, and travel
+ * in the direction that is already satisfied banks nothing at all — which
+ * is what stops a wobble from moving the chrome, without letting a
+ * mostly-downward read be held up forever by its own tremor.
+ *
+ * The thresholds are asymmetric on purpose: reaching for chrome that is
+ * gone is a deliberate act and should feel prompt, while hiding it should
+ * take enough sustained reading motion that it never happens by accident.
  */
 export interface ChromeVisibilityState {
   visible: boolean;
   lastScrollTop: number;
+  /**
+   * Signed distance banked toward the next flip. Positive is downward.
+   * Clamped so it never accumulates in the direction that cannot commit,
+   * and reset to zero whenever visibility does commit — so the next flip
+   * needs its own full stroke rather than riding on leftover momentum.
+   */
+  travel: number;
 }
 
 export const initialChromeVisibilityState = (): ChromeVisibilityState => ({
   visible: true,
   lastScrollTop: 0,
+  travel: 0,
 });
 
-/** Sub-pixel/momentum-scroll jitter smaller than this never toggles visibility. */
-const HIDE_THRESHOLD_PX = 8;
+/** Sub-pixel/rounding noise smaller than this is not movement at all. */
+const NOISE_PX = 2;
+
+/**
+ * Sustained downward travel before the chrome hides. Roughly two lines of
+ * body text at the default reading scale — long enough that no correction
+ * or momentum bounce reaches it, short enough that a deliberate scroll
+ * clears the chrome on the first stroke.
+ */
+const HIDE_AFTER_PX = 72;
+
+/**
+ * Sustained upward travel before it returns. Shorter than the hide
+ * threshold: a reader scrolling back up is usually reaching for the chrome
+ * (the language switcher, the mode toggle, prev/next), and making them work
+ * for it is worse than showing it a little eagerly.
+ */
+const SHOW_AFTER_PX = 40;
 
 /** Always visible within this many px of the very top of the stream. */
 const NEAR_TOP_PX = 48;
@@ -38,19 +87,37 @@ export const nextChromeVisibilityState = (
 ): ChromeVisibilityState => {
   const { scrollTop, hasOpenDisclosure } = params;
 
-  if (scrollTop <= NEAR_TOP_PX) {
-    return { visible: true, lastScrollTop: scrollTop };
-  }
-
-  if (hasOpenDisclosure && scrollTop <= NEAR_TOP_WITH_DISCLOSURE_PX) {
-    return { visible: true, lastScrollTop: scrollTop };
+  if (
+    scrollTop <= NEAR_TOP_PX ||
+    (hasOpenDisclosure && scrollTop <= NEAR_TOP_WITH_DISCLOSURE_PX)
+  ) {
+    return { visible: true, lastScrollTop: scrollTop, travel: 0 };
   }
 
   const delta = scrollTop - state.lastScrollTop;
-  if (Math.abs(delta) < HIDE_THRESHOLD_PX) {
+  if (Math.abs(delta) < NOISE_PX) {
     return { ...state, lastScrollTop: scrollTop };
   }
 
-  // Scrolling down (positive delta) hides; scrolling up shows.
-  return { visible: delta < 0, lastScrollTop: scrollTop };
+  const travel = state.travel + delta;
+
+  // Only intent that could still change something is banked. While the
+  // chrome is up, downward travel accumulates and upward travel is floored
+  // at zero; while it is down, the reverse. Corrections therefore cost a
+  // gesture a little progress instead of discarding it — a mostly-downward
+  // read still reaches the threshold through its tremor — and a run in the
+  // direction that is already satisfied banks nothing, so the *next* flip
+  // always needs its own full stroke rather than unwinding a page of
+  // momentum first.
+  if (state.visible) {
+    if (travel >= HIDE_AFTER_PX) {
+      return { visible: false, lastScrollTop: scrollTop, travel: 0 };
+    }
+    return { ...state, lastScrollTop: scrollTop, travel: Math.max(travel, 0) };
+  }
+
+  if (travel <= -SHOW_AFTER_PX) {
+    return { visible: true, lastScrollTop: scrollTop, travel: 0 };
+  }
+  return { ...state, lastScrollTop: scrollTop, travel: Math.min(travel, 0) };
 };

--- a/tests/unit/auto-hiding-chrome.spec.ts
+++ b/tests/unit/auto-hiding-chrome.spec.ts
@@ -1,18 +1,40 @@
 import { describe, expect, it } from "vitest";
 
+/** Feeds a run of deltas through the machine, the way a scroll actually arrives. */
+const scrollBy = (
+  state: ChromeVisibilityState,
+  deltas: number[],
+  hasOpenDisclosure = false,
+) => {
+  let current = state;
+  for (const delta of deltas) {
+    current = nextChromeVisibilityState(current, {
+      scrollTop: current.lastScrollTop + delta,
+      hasOpenDisclosure,
+    });
+  }
+  return current;
+};
+
+const reading = (overrides: Partial<ChromeVisibilityState> = {}) => ({
+  ...initialChromeVisibilityState(),
+  lastScrollTop: 400,
+  ...overrides,
+});
+
 describe("initialChromeVisibilityState", () => {
-  it("starts visible, at the top", () => {
+  it("starts visible, at the top, with nothing accumulated", () => {
     expect(initialChromeVisibilityState()).toEqual({
       visible: true,
       lastScrollTop: 0,
+      travel: 0,
     });
   });
 });
 
 describe("nextChromeVisibilityState", () => {
   it("hides on a clear scroll-down past the near-top band", () => {
-    const state = { visible: true, lastScrollTop: 100 };
-    const next = nextChromeVisibilityState(state, {
+    const next = nextChromeVisibilityState(reading({ lastScrollTop: 100 }), {
       scrollTop: 200,
       hasOpenDisclosure: false,
     });
@@ -22,8 +44,7 @@ describe("nextChromeVisibilityState", () => {
   });
 
   it("shows again on a clear scroll-up", () => {
-    const state = { visible: false, lastScrollTop: 400 };
-    const next = nextChromeVisibilityState(state, {
+    const next = nextChromeVisibilityState(reading({ visible: false }), {
       scrollTop: 300,
       hasOpenDisclosure: false,
     });
@@ -32,8 +53,7 @@ describe("nextChromeVisibilityState", () => {
   });
 
   it("stays visible within the near-top band regardless of direction", () => {
-    const state = { visible: true, lastScrollTop: 0 };
-    const next = nextChromeVisibilityState(state, {
+    const next = nextChromeVisibilityState(initialChromeVisibilityState(), {
       scrollTop: 20,
       hasOpenDisclosure: false,
     });
@@ -41,20 +61,18 @@ describe("nextChromeVisibilityState", () => {
     expect(next.visible).toBe(true);
   });
 
-  it("ignores sub-threshold jitter without toggling visibility", () => {
-    const state = { visible: false, lastScrollTop: 500 };
-    const next = nextChromeVisibilityState(state, {
-      scrollTop: 503,
+  it("ignores sub-pixel jitter without toggling visibility", () => {
+    const next = nextChromeVisibilityState(reading({ visible: false }), {
+      scrollTop: 401,
       hasOpenDisclosure: false,
     });
 
     expect(next.visible).toBe(false);
-    expect(next.lastScrollTop).toBe(503);
+    expect(next.lastScrollTop).toBe(401);
   });
 
   it("never hides while a disclosure is open near the top, even past the plain near-top band", () => {
-    const state = { visible: true, lastScrollTop: 60 };
-    const next = nextChromeVisibilityState(state, {
+    const next = nextChromeVisibilityState(reading({ lastScrollTop: 60 }), {
       scrollTop: 200,
       hasOpenDisclosure: true,
     });
@@ -63,22 +81,82 @@ describe("nextChromeVisibilityState", () => {
   });
 
   it("still hides on scroll-down once far enough past the disclosure-open band", () => {
-    const state = { visible: true, lastScrollTop: 250 };
-    const next = nextChromeVisibilityState(state, {
+    const next = nextChromeVisibilityState(reading({ lastScrollTop: 250 }), {
       scrollTop: 400,
       hasOpenDisclosure: true,
     });
 
     expect(next.visible).toBe(false);
   });
+});
 
-  it("hides normally on scroll-down once the disclosure closes", () => {
-    const state = { visible: true, lastScrollTop: 100 };
-    const next = nextChromeVisibilityState(state, {
-      scrollTop: 200,
-      hasOpenDisclosure: false,
-    });
+// Why this machine accumulates travel instead of reading the sign of the
+// last delta. Every sequence below is a real one, traced off a 412x915
+// device — under the per-delta rule they made the chrome bounce through its
+// whole range mid-gesture instead of settling once.
+describe("nextChromeVisibilityState — a finger, not a wheel", () => {
+  it("does not resurface the chrome on the small corrections in a downward read", () => {
+    const afterHiding = scrollBy(reading(), [14, 20, 26, 22]);
+    expect(afterHiding.visible).toBe(false);
 
-    expect(next.visible).toBe(false);
+    const wobbling = scrollBy(afterHiding, [-9, -12, 18, 24, 20, -10, -14, 16]);
+
+    expect(wobbling.visible).toBe(false);
+  });
+
+  it("still gets there through the tremor, rather than being held up by it", () => {
+    // The exact trace that used to make it bounce. It must end hidden:
+    // refusing to ever hide is the opposite failure, not a fix.
+    const state = scrollBy(reading(), [26, 22, -9, -12, 18, 24, 20]);
+
+    expect(state.visible).toBe(false);
+  });
+
+  it("keeps the chrome up through the corrections in an upward read", () => {
+    const atTop = scrollBy(reading(), [-14, -20, -12]);
+    expect(atTop.visible).toBe(true);
+
+    const wobbling = scrollBy(atTop, [8, 11, -16, -20, 9, 12, -14]);
+
+    expect(wobbling.visible).toBe(true);
+  });
+
+  it("banks nothing in the direction that is already satisfied", () => {
+    // Scrolling up while the chrome is already up must not build credit
+    // toward hiding it, and vice versa — otherwise a long read in one
+    // direction makes the first flick back feel dead.
+    const afterLongUp = scrollBy(
+      reading({ lastScrollTop: 2000 }),
+      [-300, -300, -300],
+    );
+    expect(afterLongUp.visible).toBe(true);
+    expect(afterLongUp.travel).toBe(0);
+
+    const afterLongDown = scrollBy(
+      reading({ visible: false }),
+      [300, 300, 300],
+    );
+    expect(afterLongDown.visible).toBe(false);
+    expect(afterLongDown.travel).toBe(0);
+    // One ordinary upward stroke, not a page of unwinding.
+    expect(scrollBy(afterLongDown, [-20, -22]).visible).toBe(true);
+  });
+
+  it("still commits on a deliberate stroke in one direction", () => {
+    expect(scrollBy(reading(), [24, 24, 24]).visible).toBe(false);
+
+    const hidden = scrollBy(reading({ visible: false }), [24, 24, 24]);
+    expect(hidden.visible).toBe(false);
+    expect(scrollBy(hidden, [-20, -20]).visible).toBe(true);
+  });
+
+  it("needs its own full run to flip back, never riding leftover momentum", () => {
+    // The stroke that hides the chrome banks nothing: an immediate small
+    // bounce upward must not undo it.
+    const hidden = scrollBy(reading(), [30, 30, 30]);
+    expect(hidden.visible).toBe(false);
+    expect(hidden.travel).toBe(0);
+
+    expect(scrollBy(hidden, [-12, -12]).visible).toBe(false);
   });
 });


### PR DESCRIPTION
Salvaged from #116, rebased onto the revert of #114 — this half stands entirely on its own and fixes **study mode**, which is the mobile default.

## The defect

`nextChromeVisibilityState` flipped on the sign of a single scroll delta past an 8px threshold. Real reading scroll is mostly-down with constant corrections. Traced on a 412x915 device:

```
+14 +20 +26 +22 -9 -12 +18 +24 +20 -10 -14 +16 +22 +26 -11 -9 …
```

Every one of those `-9`/`-12` corrections said "bring the chrome back", so it retargeted its own 200ms transition over and over instead of settling. Tuning the threshold cannot fix it — a 12px correction is a real 12px correction.

## The fix

Accumulate **net travel toward the next flip**. A correction costs a gesture some progress instead of reversing it, and travel in the already-satisfied direction banks nothing — so the next flip always needs its own full stroke rather than unwinding a page of momentum first. Hide after 72px sustained, show after 40px; asymmetric because reaching for chrome that is gone is a deliberate act and should feel prompt.

Getting this wrong in the other direction is just as bad: my first attempt reset the accumulator on every reversal, which meant a wobbly read never hid the chrome at all. The spec asserts both — that a wobble does not move it, *and* that a mostly-downward read still gets there through its own tremor.

## Verification

- `task check` green: 911 unit tests (5 new), content validation, full generate, 5/5 e2e.
- The new spec is driven by the real traced delta sequences, not invented ones.

## Not in this PR

The 245px panes-mode problem (#113) is still open. #114 was reverted (#117) because it was broken on a real device; it needs a design that does not rest on three runtime measurements agreeing, and a look at an actual screenshot before it ships.