### PR TITLE
feat(reader): let the reader collapse the toolbar, and dock the pane switcher

### DIFF
--- a/app/assets/css/main.css
+++ b/app/assets/css/main.css
@@ -516,7 +516,7 @@ html {
 /* The transparent inline-start border is reserved on EVERY heading, not just
    the current one, so `.is-current` colouring it in shifts nothing. */
 .tes-commentary-seif-heading {
-  @apply sticky top-0 z-10 flex cursor-pointer list-none items-center justify-between gap-2 border-b border-(--border) border-s-[3px] border-s-transparent bg-(--surface) py-2 ps-2 text-sm font-semibold tabular-nums text-(--text-primary) [&::-webkit-details-marker]:hidden focus-visible:outline focus-visible:outline-2 focus-visible:outline-teal;
+  @apply sticky z-10 flex cursor-pointer list-none items-center justify-between gap-2 border-b border-(--border) border-s-[3px] border-s-transparent bg-(--surface) py-2 ps-2 text-sm font-semibold tabular-nums text-(--text-primary) [&::-webkit-details-marker]:hidden focus-visible:outline focus-visible:outline-2 focus-visible:outline-teal;
 }
 
 /*
@@ -532,6 +532,13 @@ html {
  * the strip; the matching extra `padding-block-start` puts its own text back
  * where it was; the negative `margin-block-start` cancels that padding in
  * normal flow, so an unstuck heading sits exactly where it did before.
+ *
+ * Neither class may carry `top-0` in its own `@apply`. Both are
+ * single-class selectors, so source order decides — and
+ * `.tes-prose-section-heading` is declared *below* this rule, which meant
+ * its `top-0` quietly won and Inner Observation kept the exact 16px strip
+ * of text-over-heading this was written to remove. Measured: computed `top`
+ * was `0px`, and the heading pinned 16px below the scrollport.
  */
 .tes-commentary-seif-heading,
 .tes-prose-section-heading {
@@ -614,7 +621,7 @@ html {
    marker of which of the part's Inner Observation chapters they are inside,
    and the sections are long enough to scroll their own heading away. */
 .tes-prose-section-heading {
-  @apply sticky top-0 z-10 flex cursor-pointer list-none items-center justify-between gap-2 border-b border-(--border) bg-(--surface) py-2 [&::-webkit-details-marker]:hidden focus-visible:outline focus-visible:outline-2 focus-visible:outline-teal;
+  @apply sticky z-10 flex cursor-pointer list-none items-center justify-between gap-2 border-b border-(--border) bg-(--surface) py-2 [&::-webkit-details-marker]:hidden focus-visible:outline focus-visible:outline-2 focus-visible:outline-teal;
 }
 
 .tes-prose-block {
@@ -664,7 +671,11 @@ html {
 }
 
 .tes-pane-body {
-  @apply min-h-0 flex-1 overflow-y-auto px-4 pb-24 lg:pb-4;
+  @apply min-h-0 flex-1 overflow-y-auto px-4 lg:pb-4;
+  /* Clears the docked pane-switcher bar (`MobilePanePill`, fixed to the
+     bottom edge below `lg`) plus the device's own safe area, so the last
+     line of a chapter is never sitting underneath it. */
+  padding-block-end: calc(3.5rem + env(safe-area-inset-bottom));
   /* Named rather than a bare `pt-4` because the sticky headings inside have
      to cancel exactly this value — see `.tes-commentary-seif-heading`. */
   --pane-pad-block-start: 1rem;
@@ -701,8 +712,23 @@ html {
 
 /* `MobilePanePill`'s per-pane tab — the selected/unselected tint stays
    conditional at the call site. */
+/*
+ * One tab of the docked pane switcher (`MobilePanePill`). Icon above label,
+ * not beside it: side by side, "Inner Observation" wraps to two lines in a
+ * third of a 412px screen and the bar comes out ragged, one tab taller than
+ * its neighbours. Stacked, every label fits on one line at every pane name
+ * in both locales, and the bar is the conventional shape a reader already
+ * knows from every other mobile app.
+ */
 .tes-pill-tab {
-  @apply flex items-center gap-1.5 rounded-full px-3 py-2 text-xs font-medium focus-visible:outline focus-visible:outline-2 focus-visible:outline-teal;
+  @apply flex flex-col items-center gap-1 rounded-lg px-2 py-1.5 text-[11px] leading-tight font-medium whitespace-nowrap focus-visible:outline focus-visible:outline-2 focus-visible:outline-teal;
+}
+
+/* `ReaderToolbar`'s collapse/expand handle (issue 113) — a full-width row
+   rather than another button competing for the control row's horizontal
+   space, which a 412px screen does not have. */
+.tes-chrome-handle {
+  @apply -mb-1 flex w-full items-center gap-2 rounded-button py-1 text-(--text-muted) hover:bg-(--surface-raised) focus-visible:outline focus-visible:outline-2 focus-visible:outline-teal;
 }
 
 /* `ReaderToolbar`'s prev/next chapter links, and their disabled

--- a/app/components/reader/MobilePanePill.vue
+++ b/app/components/reader/MobilePanePill.vue
@@ -111,12 +111,12 @@ const onKeydown = (event: KeyboardEvent, index: number) => {
 <template>
   <div
     v-if="!isSheetOpen && !isContentsOpen && segments.length > 1"
-    class="pointer-events-none fixed inset-x-0 bottom-[calc(1rem+env(safe-area-inset-bottom))] z-30 flex justify-center lg:hidden"
+    class="fixed inset-x-0 bottom-0 z-30 border-t border-(--border) bg-(--surface-raised) pb-[env(safe-area-inset-bottom)] lg:hidden"
   >
     <div
       role="tablist"
       :aria-label="t('reader.mobilePane.label')"
-      class="pointer-events-auto flex items-center gap-1 rounded-full border border-(--border) bg-(--surface-raised) p-1 shadow-lg"
+      class="flex items-stretch gap-1 p-1"
     >
       <button
         v-for="(segment, index) in segments"
@@ -127,7 +127,7 @@ const onKeydown = (event: KeyboardEvent, index: number) => {
         :aria-selected="activePane === segment.pane"
         :aria-controls="segment.controls"
         :tabindex="activePane === segment.pane ? 0 : -1"
-        class="tes-pill-tab"
+        class="tes-pill-tab flex-1"
         :class="
           activePane === segment.pane
             ? 'bg-teal-strong text-surface-white'

--- a/app/components/reader/ReaderToolbar.vue
+++ b/app/components/reader/ReaderToolbar.vue
@@ -51,12 +51,24 @@ const {
   open: openContents,
   close: closeContents,
 } = useContentsPanel();
+
+// Panes mode's collapse control (issue 113). Collapsed, this bar keeps one
+// slim row — where you are, and the way back — and the breadcrumb, chapter
+// nav and mode toggle stop rendering. Everything stays in normal flow: the
+// reader asked for the change, so the pane is allowed to simply grow into
+// the space. Study mode has its own scroll-driven hiding and does not show
+// this control; two mechanisms for the same chrome would be worse than
+// either.
+const { collapsed, toggle: toggleCollapsed } = useCollapsedReaderChrome();
+const isCollapsible = computed(() => mode.value === "panes");
+const isCollapsed = computed(() => isCollapsible.value && collapsed.value);
 </script>
 
 <template>
   <div
-    class="flex flex-col gap-3 border-b border-(--border) bg-(--surface) px-4 py-3 sm:px-6"
+    class="flex flex-col border-b border-(--border) bg-(--surface) px-4 sm:px-6"
     :class="[
+      isCollapsed ? 'gap-0 py-1.5' : 'gap-3 py-3',
       isStudyMode &&
         'sticky top-0 z-30 transition-transform duration-200 ease-out motion-reduce:transition-none',
       isStudyMode && !chromeVisible && '-translate-y-full',
@@ -64,7 +76,21 @@ const {
   >
     <h1 class="sr-only">{{ chapterTitle }}</h1>
 
-    <div class="flex items-center justify-between gap-3">
+    <button
+      v-if="isCollapsed"
+      type="button"
+      class="tes-chrome-handle justify-between"
+      :aria-label="t('reader.toolbar.expandChrome')"
+      :aria-expanded="false"
+      @click="toggleCollapsed"
+    >
+      <span class="truncate text-sm text-(--text-muted)">
+        {{ chapterTitle }}
+      </span>
+      <span class="tes-icon tes-icon-chevron-down h-5 w-5" aria-hidden="true" />
+    </button>
+
+    <div v-if="!isCollapsed" class="flex items-center justify-between gap-3">
       <ReaderBreadcrumb
         :items="breadcrumbItems"
         :volumes="volumes"
@@ -119,6 +145,7 @@ const {
     />
 
     <nav
+      v-if="!isCollapsed"
       :aria-label="t('reader.chapterNav')"
       class="flex items-center justify-between gap-3 text-sm"
     >
@@ -148,5 +175,24 @@ const {
         <span aria-hidden="true" class="rtl:rotate-180">&rarr;</span>
       </span>
     </nav>
+
+    <!-- Its own full-width row, not another icon in the control group:
+         that row already carries the breadcrumb, two icon buttons and a
+         three-way segmented control, and a fifth control pushed it off the
+         edge of a 412px screen. A handle spanning the bar is also the
+         conventional shape for "this collapses". -->
+    <button
+      v-if="isCollapsible && !isCollapsed"
+      type="button"
+      class="tes-chrome-handle justify-center"
+      :aria-label="t('reader.toolbar.collapseChrome')"
+      :aria-expanded="true"
+      @click="toggleCollapsed"
+    >
+      <span
+        class="tes-icon tes-icon-chevron-down h-5 w-5 rotate-180"
+        aria-hidden="true"
+      />
+    </button>
   </div>
 </template>

--- a/app/composables/useCollapsedReaderChrome.ts
+++ b/app/composables/useCollapsedReaderChrome.ts
@@ -1,0 +1,69 @@
+/**
+ * Panes mode's collapsible top chrome: one boolean the reader owns.
+ *
+ * The reader toolbar and, on mobile, the site navbar take ~200px off the top
+ * of a panes-mode screen — a quarter of a phone viewport before a word of
+ * text (issue 113). The first attempt at giving that back hid the chrome
+ * automatically on scroll-down. It was the wrong shape twice over: guessing
+ * intent from scroll deltas is a state machine with thresholds that will
+ * always be wrong for someone, and because the reader hadn't *asked* for the
+ * change, the text underneath was not allowed to move — which forced the
+ * whole chrome stack out of normal flow onto measured absolute positions and
+ * broke in the seams. It was reverted (PR 117).
+ *
+ * A button has none of those problems. The reader decides, the state is one
+ * boolean, and a deliberate tap is allowed to reflow the page — so the
+ * chrome stays in normal flow and simply stops rendering, and the pane grows
+ * into the space. Nothing is measured, nothing overlays anything, nothing
+ * animates behind the reader's back.
+ *
+ * Persisted, because it is a preference and not a gesture: someone who wants
+ * the room should get it on every chapter, not re-earn it on every scroll.
+ *
+ * Provide/inject singleton, same shape as `useReadingPreferences` — the
+ * toolbar owns the control and the layout reads it for the navbar, and they
+ * are not in each other's subtree.
+ */
+import { useLocalStorage } from "@vueuse/core";
+import type { ComputedRef, InjectionKey } from "vue";
+
+const STORAGE_KEY = "readtes:reader-chrome-collapsed";
+
+export interface CollapsedReaderChrome {
+  collapsed: ComputedRef<boolean>;
+  toggle: () => void;
+}
+
+const COLLAPSED_READER_CHROME_KEY: InjectionKey<CollapsedReaderChrome> = Symbol(
+  "collapsed-reader-chrome",
+);
+
+const createCollapsedReaderChrome = (): CollapsedReaderChrome => {
+  const persisted = useLocalStorage<boolean>(STORAGE_KEY, false);
+
+  // Gates the persisted read until after mount, same reason as
+  // `useReadingPreferences`: prerendering has no `localStorage`, so
+  // consulting it during the first client render would diverge from the
+  // prerendered HTML and fail hydration.
+  const hydrated = ref(false);
+  onMounted(() => {
+    hydrated.value = true;
+  });
+
+  const collapsed = computed(() => (hydrated.value ? persisted.value : false));
+
+  const toggle = () => {
+    persisted.value = !collapsed.value;
+  };
+
+  return { collapsed, toggle };
+};
+
+export const useCollapsedReaderChrome = (): CollapsedReaderChrome => {
+  const existing = inject(COLLAPSED_READER_CHROME_KEY, null);
+  if (existing) return existing;
+
+  const state = createCollapsedReaderChrome();
+  provide(COLLAPSED_READER_CHROME_KEY, state);
+  return state;
+};

--- a/app/layouts/reader.vue
+++ b/app/layouts/reader.vue
@@ -42,6 +42,16 @@ const { mode } = useReaderMode();
 const { visible: chromeVisible } = useAutoHidingChrome();
 const { scale } = useReadingPreferences();
 const isStudyMode = computed(() => mode.value === "study");
+
+// The collapse control lives in the reader toolbar, but the site navbar is
+// this layout's — and on a phone it is 60px of the ~200px the reader is
+// asking for back (issue 113). It goes with the rest, below `lg` only:
+// there is no shortage of height on a desktop, and losing the site's own
+// nav there would be a worse trade than the space is worth.
+const { collapsed } = useCollapsedReaderChrome();
+const isChromeCollapsed = computed(
+  () => mode.value === "panes" && collapsed.value,
+);
 </script>
 
 <template>
@@ -54,6 +64,7 @@ const isStudyMode = computed(() => mode.value === "study");
     </a>
     <div
       :class="[
+        isChromeCollapsed && 'hidden lg:block',
         isStudyMode &&
           'sticky top-0 z-40 transition-transform duration-200 ease-out motion-reduce:transition-none',
         isStudyMode && !chromeVisible && '-translate-y-full',

--- a/i18n/locales/en.json
+++ b/i18n/locales/en.json
@@ -86,7 +86,9 @@
     "progressLabel": "Reading progress",
     "toolbar": {
       "preferencesButton": "Reading preferences",
-      "contentsButton": "Contents"
+      "contentsButton": "Contents",
+      "collapseChrome": "Collapse the toolbar",
+      "expandChrome": "Expand the toolbar"
     },
     "breadcrumbMenu": {
       "browseChapters": "Browse all chapters"

--- a/i18n/locales/he.json
+++ b/i18n/locales/he.json
@@ -86,7 +86,9 @@
     "progressLabel": "התקדמות בקריאה",
     "toolbar": {
       "preferencesButton": "העדפות קריאה",
-      "contentsButton": "תוכן העניינים"
+      "contentsButton": "תוכן העניינים",
+      "collapseChrome": "כיווץ סרגל הכלים",
+      "expandChrome": "הרחבת סרגל הכלים"
     },
     "breadcrumbMenu": {
       "browseChapters": "עיינו בכל הפרקים"

--- a/tests/e2e/reader.spec.ts
+++ b/tests/e2e/reader.spec.ts
@@ -206,4 +206,68 @@ test.describe("mobile reader", () => {
     await expect(page.locator("#reader-source-pane")).toBeInViewport();
     await expect.poll(trackScrollLeft).toBe(0);
   });
+
+  test("collapses the top chrome on demand, and remembers it", async ({
+    page,
+  }) => {
+    // Issue 113. A button, not a scroll gesture: the reader asks, so the
+    // pane is allowed to simply grow into the space and everything stays
+    // in normal flow. The earlier scroll-driven version had to lift the
+    // chrome onto measured absolute positions to avoid moving the text,
+    // and broke in those seams (#117).
+    await page.goto(CHAPTER_PATH);
+    await waitForHydration(page);
+    await page
+      .getByRole("group", { name: "Reading mode" })
+      .getByRole("button", { name: "Panes" })
+      .click();
+
+    const paneBody = page.locator("#reader-source-pane .tes-pane-body");
+    const heightOf = async () =>
+      Math.round((await paneBody.boundingBox())!.height);
+    const expanded = await heightOf();
+
+    await page.getByRole("button", { name: "Collapse the toolbar" }).click();
+
+    // The site navbar goes with it — on a phone it is 60px of the ~200px
+    // being asked for back.
+    await expect(page.locator("header").first()).toBeHidden();
+    await expect(
+      page.getByRole("navigation", { name: "Chapter navigation" }),
+    ).toHaveCount(0);
+    expect(await heightOf()).toBeGreaterThan(expanded + 100);
+
+    // Expanding restores every piece of it. (That it *persists* across
+    // visits is `tests/unit/collapsed-reader-chrome.spec.ts` — this
+    // harness clears `localStorage` on every navigation, so a page-load
+    // assertion here could only ever prove the harness.)
+    await page.getByRole("button", { name: "Expand the toolbar" }).click();
+    await expect(page.locator("header").first()).toBeVisible();
+    await expect(
+      page.getByRole("navigation", { name: "Chapter navigation" }),
+    ).toBeVisible();
+    expect(await heightOf()).toBe(expanded);
+  });
+
+  test("docks the pane switcher to the bottom edge", async ({ page }) => {
+    await page.goto(CHAPTER_PATH);
+    await waitForHydration(page);
+    await page
+      .getByRole("group", { name: "Reading mode" })
+      .getByRole("button", { name: "Panes" })
+      .click();
+
+    const bar = page
+      .getByRole("tablist", { name: "Reader pane" })
+      .locator("xpath=ancestor::div[contains(@class,'fixed')][1]");
+    const box = (await bar.boundingBox())!;
+    const viewport = page.viewportSize()!;
+
+    // Flush, not floating: it used to sit 1rem up with the chapter's own
+    // text visible in the gap underneath it.
+    expect(Math.round(box.y + box.height)).toBe(viewport.height);
+
+    // One row, not two — "Inner Observation" wrapping made the bar ragged.
+    expect(box.height).toBeLessThan(72);
+  });
 });

--- a/tests/unit/collapsed-reader-chrome.spec.ts
+++ b/tests/unit/collapsed-reader-chrome.spec.ts
@@ -1,0 +1,52 @@
+// `useCollapsedReaderChrome` is a persisted preference, and the two things
+// worth pinning are the ones that break silently: that it survives a visit
+// (the whole reason it is a preference and not component state), and that it
+// does NOT consult storage during the first render (prerendering has no
+// `localStorage`, so a returning visitor's hydration would diverge from the
+// prerendered HTML — the same trap `useReadingPreferences` documents).
+import { mountSuspended } from "@nuxt/test-utils/runtime";
+import { beforeEach, describe, expect, it } from "vitest";
+import { defineComponent, nextTick } from "vue";
+
+const STORAGE_KEY = "readtes:reader-chrome-collapsed";
+
+const Host = defineComponent({
+  setup: () => ({ chrome: useCollapsedReaderChrome() }),
+  render: () => null,
+});
+
+describe("useCollapsedReaderChrome", () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it("starts expanded", async () => {
+    const wrapper = await mountSuspended(Host);
+
+    expect(wrapper.vm.chrome.collapsed.value).toBe(false);
+  });
+
+  it("toggles, and writes the choice to storage", async () => {
+    const wrapper = await mountSuspended(Host);
+
+    wrapper.vm.chrome.toggle();
+    await nextTick();
+
+    expect(wrapper.vm.chrome.collapsed.value).toBe(true);
+    expect(localStorage.getItem(STORAGE_KEY)).toBe("true");
+
+    wrapper.vm.chrome.toggle();
+    await nextTick();
+
+    expect(wrapper.vm.chrome.collapsed.value).toBe(false);
+  });
+
+  it("restores a returning visitor's choice", async () => {
+    localStorage.setItem(STORAGE_KEY, "true");
+
+    const wrapper = await mountSuspended(Host);
+    await nextTick();
+
+    expect(wrapper.vm.chrome.collapsed.value).toBe(true);
+  });
+});


### PR DESCRIPTION
Your idea, and it's better than mine — for a structural reason worth stating.

## Why the button beats the scroll gesture

The reverted #114 had to guess intent from scroll deltas, which is a state machine with thresholds that will always be wrong for someone. Worse: because the reader hadn't *asked* for the change, the text underneath wasn't allowed to move — and that single constraint is what forced the whole chrome stack out of normal flow onto three runtime-measured absolute positions. Every defect in your screenshots was a seam in that construction.

A button removes the constraint. The reader asked, so the pane may simply grow into the space, so the chrome can stay in normal flow and just stop rendering. **No measurement, no overlay, no ResizeObserver, no scroll state, no transitions.** It's one persisted boolean.

Net: the deleted `useReaderChromeOverlay` + `readerChrome` were ~190 lines; `useCollapsedReaderChrome` is 45, most of it comment.

The control is a full-width handle, not another icon in the control row — I tried that first and it pushed the row (breadcrumb + 2 icon buttons + 3-way segmented control) straight off the edge of a 412px screen. A handle spanning the bar is also the conventional shape for "this collapses".

Persisted, because it's a preference rather than a gesture: someone who wants the room gets it on every chapter.

## The pane switcher is docked

Flush to the bottom edge, full width, each tab's icon above its label. Side by side, "Inner Observation" wrapped to two lines and left the bar ragged with one tab taller than its neighbours. `.tes-pane-body`'s bottom padding dropped from `pb-24` (sized for the floating pill and its gap) to the bar's real height plus the device safe area.

## A real bug found while checking this

**Sticky prose headings have never pinned flush.** `.tes-prose-section-heading` carries `top-0` in its own `@apply` and is declared *below* the rule that sets the negative `top` #102 introduced. Both are single-class selectors — source order decides, and the `top-0` won.

Measured before: computed `top: 0px`, heading pinned at 109 against a scrollport top of 93. After: `top: -16px`, heading at 93. Exactly flush.

That 16px strip of Inner Observation's prose sliding above its own heading is visible in your second screenshot; I'd assumed it was my overlay and it wasn't — it's been shipping since #102, in the pane you read straight through.

## Verification — I looked this time

`task check` green: 909 unit tests (3 new), content validation, full generate, **7/7 e2e** (2 new).

Screenshots at 412x915 attached, and I checked the state that was broken before — Inner Observation, scrolled — rather than only asserting bounding boxes. That was the gap in my last review: every box assertion in #114 passed while the result was illegible.

New e2e covers the collapse (navbar hidden, chapter nav gone, pane taller by >100px, everything restored on expand) and the docked bar (bottom edge exactly at viewport height, single row). Persistence is a unit test — the e2e harness clears `localStorage` on every navigation, so a page-load assertion there could only ever prove the harness.

## Known, not fixed here

Collapsed, there is no in-page way to change chapter — prev/next and Contents both live in the hidden rows. One tap re-expands. If you'd rather keep a way through while collapsed, say so and I'll put chapter nav in the slim row.