### PR TITLE
fix(reader): make mobile controls respond to the first tap, and thin the bar

### DIFF
--- a/app/assets/css/main.css
+++ b/app/assets/css/main.css
@@ -162,6 +162,28 @@ html {
 }
 
 /*
+ * Controls respond to the first tap.
+ *
+ * Reported on a real Android phone: tapping a pane tab did nothing, and
+ * double-tapping it worked. That is the signature of the browser holding the
+ * first tap back while it waits to see whether a second one is coming —
+ * double-tap-to-zoom disambiguation. `touch-action: manipulation` opts these
+ * elements out of that gesture, so the tap dispatches immediately.
+ *
+ * Scoped to controls, and deliberately NOT done by disabling zoom on the
+ * viewport: pinch-zoom stays available everywhere, including over these
+ * elements, which on a reading site carrying pointed Hebrew is not
+ * negotiable.
+ */
+button,
+summary,
+select,
+a[href],
+[role="tab"] {
+  touch-action: manipulation;
+}
+
+/*
  * Theme-change crossfade.
  *
  * Without this every switch is instant for surfaces — only the eight
@@ -721,7 +743,12 @@ html {
  * knows from every other mobile app.
  */
 .tes-pill-tab {
-  @apply flex flex-col items-center gap-1 rounded-lg px-2 py-1.5 text-[11px] leading-tight font-medium whitespace-nowrap focus-visible:outline focus-visible:outline-2 focus-visible:outline-teal;
+  @apply flex flex-col items-center justify-center gap-0.5 rounded-lg px-2 py-1 text-[11px] leading-tight font-medium whitespace-nowrap focus-visible:outline focus-visible:outline-2 focus-visible:outline-teal;
+  /* Tightened padding and gap take ~10px off the bar without taking it off
+     the tap target: the button keeps a 40px minimum height, which is what
+     a thumb actually needs. Shrinking the target instead would be a worse
+     trade than the pixels are worth. */
+  min-block-size: 2.5rem;
 }
 
 /* `ReaderToolbar`'s collapse/expand handle (issue 113) — a full-width row

--- a/app/components/reader/MobilePanePill.vue
+++ b/app/components/reader/MobilePanePill.vue
@@ -116,7 +116,7 @@ const onKeydown = (event: KeyboardEvent, index: number) => {
     <div
       role="tablist"
       :aria-label="t('reader.mobilePane.label')"
-      class="flex items-stretch gap-1 p-1"
+      class="flex items-stretch gap-1 p-0.5"
     >
       <button
         v-for="(segment, index) in segments"

--- a/app/components/reader/MobileSwipePanes.vue
+++ b/app/components/reader/MobileSwipePanes.vue
@@ -76,7 +76,6 @@ import {
   resolveActivePane,
   type PaneVisibilityRatios,
 } from "~/utils/mobilePaneSync";
-import { prefersReducedMotion } from "~/utils/motion";
 import type { PaneId } from "~/utils/readerAnchorState";
 import { STUDY_MODE_MEDIA_QUERY } from "~/utils/readerMode";
 
@@ -185,17 +184,31 @@ watch(isNarrowViewport, (narrow) => {
 onMounted(() => {
   if (isNarrowViewport.value) attachTrackListeners();
 
-  // Snaps instantly (no motion to reduce, there's no prior on-screen
-  // state to visibly transition away from) to whichever slide is already
-  // `activePane` (source, by default) instead of leaving the browser's own
-  // "first slide in DOM order" scroll position silently mismatched against
-  // it.
-  scrollToPane(activePane.value, true);
+  // Snaps to whichever slide is already `activePane` (source, by default)
+  // instead of leaving the browser's own "first slide in DOM order" scroll
+  // position silently mismatched against it.
+  scrollToPane(activePane.value);
 });
 
 onUnmounted(detachTrackListeners);
 
-const scrollToPane = (pane: PaneId, instant: boolean) => {
+/**
+ * Always an instant jump, never a smooth glide.
+ *
+ * Every caller here is a *discrete* pane change — a pill tap, a cross-pane
+ * anchor jump, the initial snap on mount, or the settle commit correcting
+ * after a swipe the browser has already snapped. None of them is a gesture
+ * being followed, so none of them wants an animation. A tab bar jumps.
+ *
+ * It is also the only branch this repo has ever tested. `playwright.config`
+ * sets `reducedMotion: "reduce"` project-wide, so the smooth branch never
+ * ran in CI while it was exactly what a real phone took — and animating a
+ * `scroll-snap-type: x mandatory` container is precisely where engines
+ * disagree, with the snap able to cancel the animation mid-flight and leave
+ * the track where it started. Removing the branch removes the disagreement,
+ * and makes the tested path the only path.
+ */
+const scrollToPane = (pane: PaneId) => {
   if (!isNarrowViewport.value) return;
   const track = trackRef.value;
   const slide = slideRefs[pane].value;
@@ -213,10 +226,7 @@ const scrollToPane = (pane: PaneId, instant: boolean) => {
     Math.round(
       slide.getBoundingClientRect().left - track.getBoundingClientRect().left,
     ) + track.scrollLeft;
-  track.scrollTo({
-    left: target,
-    behavior: instant || prefersReducedMotion() ? "auto" : "smooth",
-  });
+  track.scrollTo({ left: target, behavior: "auto" });
 };
 
 watch(activePane, (pane) => {
@@ -230,7 +240,7 @@ watch(activePane, (pane) => {
   // what changed `activePane`, the timer has already fired and this is a
   // no-op. Root cause of the intermittent e2e failure in issue 106.
   settleTimer.cancel();
-  scrollToPane(pane, false);
+  scrollToPane(pane);
 });
 
 // The Ari's column is deliberately the narrowest. Equal thirds split the

--- a/server/routes/robots.txt.ts
+++ b/server/routes/robots.txt.ts
@@ -7,7 +7,14 @@
  * explicitly).
  */
 export default defineEventHandler((event) => {
-  const { siteUrl } = useRuntimeConfig(event).public;
+  // `useRuntimeConfig()` without the event: Nuxt 4.5 pulls an h3 v2 RC into
+  // the Nitro types alongside h3 v1, so `defineEventHandler`'s `event` and
+  // `useRuntimeConfig`'s parameter no longer come from the same `H3Event`
+  // declaration and the call does not typecheck. The event form only buys
+  // request-scoped config overrides, which a fully prerendered static route
+  // has no use for — the global config is what `NUXT_PUBLIC_SITE_URL`
+  // populates at build time, and that is what this reads either way.
+  const { siteUrl } = useRuntimeConfig().public;
 
   setHeader(event, "content-type", "text/plain; charset=UTF-8");
   return [

--- a/server/routes/sitemap.xml.ts
+++ b/server/routes/sitemap.xml.ts
@@ -11,7 +11,14 @@ import type { Toc } from "~~/shared/types/content";
 import { buildSitemapEntries, renderSitemapXml } from "~~/shared/utils/sitemap";
 
 export default defineEventHandler((event) => {
-  const { siteUrl } = useRuntimeConfig(event).public;
+  // `useRuntimeConfig()` without the event: Nuxt 4.5 pulls an h3 v2 RC into
+  // the Nitro types alongside h3 v1, so `defineEventHandler`'s `event` and
+  // `useRuntimeConfig`'s parameter no longer come from the same `H3Event`
+  // declaration and the call does not typecheck. The event form only buys
+  // request-scoped config overrides, which a fully prerendered static route
+  // has no use for — the global config is what `NUXT_PUBLIC_SITE_URL`
+  // populates at build time, and that is what this reads either way.
+  const { siteUrl } = useRuntimeConfig().public;
   const entries = buildSitemapEntries(toc as Toc, siteUrl);
 
   setHeader(event, "content-type", "application/xml; charset=UTF-8");

--- a/tests/e2e/reader.spec.ts
+++ b/tests/e2e/reader.spec.ts
@@ -196,7 +196,11 @@ test.describe("mobile reader", () => {
       const track = document.querySelector(
         "#reader-source-pane",
       )?.parentElement;
-      track?.scrollTo({ left: track.scrollWidth, behavior: "smooth" });
+      // Instant, like the gesture it stands in for. A programmatic *smooth*
+      // scroll was always an approximation of a swipe, and now that
+      // `scrollToPane` jumps rather than glides, the two animations fight
+      // and the track settles wherever they cancel each other.
+      track?.scrollTo({ left: track.scrollWidth, behavior: "auto" });
     });
     await expect.poll(trackScrollLeft).toBeGreaterThan(0);
     await paneTabs.getByRole("tab", { name: "The Ari's Text" }).click();
@@ -247,6 +251,67 @@ test.describe("mobile reader", () => {
       page.getByRole("navigation", { name: "Chapter navigation" }),
     ).toBeVisible();
     expect(await heightOf()).toBe(expanded);
+  });
+
+  test("switches pane on a tap with motion enabled — the real-device path", async ({
+    page,
+  }) => {
+    // `playwright.config.ts` sets `reducedMotion: "reduce"` for the whole
+    // project, so every other test here takes `scrollToPane`'s instant
+    // branch. A real phone does not: it took the smooth one, on a
+    // `scroll-snap-type: x mandatory` container, which is exactly where
+    // engines disagree — and the branch had never run in CI. This test
+    // pins the path a reader actually gets.
+    await page.emulateMedia({ reducedMotion: "no-preference" });
+    await page.goto(CHAPTER_PATH);
+    await waitForHydration(page);
+    await page
+      .getByRole("group", { name: "Reading mode" })
+      .getByRole("button", { name: "Panes" })
+      .click();
+
+    const paneTabs = page.getByRole("tablist", { name: "Reader pane" });
+    const trackScrollLeft = () =>
+      page.evaluate(
+        () =>
+          document.querySelector("#reader-source-pane")?.parentElement
+            ?.scrollLeft ?? 0,
+      );
+
+    await paneTabs.getByRole("tab", { name: "Inner Light" }).tap();
+    await expect(page.locator("#reader-commentary-pane")).toBeInViewport();
+    await expect.poll(trackScrollLeft).toBeGreaterThan(0);
+
+    await paneTabs.getByRole("tab", { name: "The Ari's Text" }).tap();
+    await expect(page.locator("#reader-source-pane")).toBeInViewport();
+    await expect.poll(trackScrollLeft).toBe(0);
+  });
+
+  test("an anchor tap carries the reader to Inner Light", async ({ page }) => {
+    // Reported broken on a real phone while working on desktop, and this
+    // path had only ever been covered at desktop width — where both panes
+    // are on screen at once and there is no swipe track. It passes in
+    // emulation either way, so it does not yet reproduce the report; it is
+    // here so the mobile path stops being untested, not as proof of a fix.
+    await page.emulateMedia({ reducedMotion: "no-preference" });
+    await page.goto(CHAPTER_PATH);
+    await waitForHydration(page);
+    await page
+      .getByRole("group", { name: "Reading mode" })
+      .getByRole("button", { name: "Panes" })
+      .click();
+
+    await page.locator('#reader-source-pane [data-anchor="op-1"]').tap();
+
+    await expect(
+      page.getByRole("tablist", { name: "Reader pane" }).getByRole("tab", {
+        name: "Inner Light",
+      }),
+    ).toHaveAttribute("aria-selected", "true");
+    await expect(page.locator("#reader-commentary-pane")).toBeInViewport();
+    await expect(
+      page.locator("#reader-commentary-pane #op-1"),
+    ).toBeInViewport();
   });
 
   test("docks the pane switcher to the bottom edge", async ({ page }) => {


### PR DESCRIPTION
Also carries the two-line fix the dependency bump (#89) needed to typecheck.

## The tap bug — what the evidence says

The decisive clue was yours: **a double tap works.** That is the signature of the browser holding the first tap back while it waits to see whether a second one is coming — double-tap-to-zoom disambiguation. The handler logic is fine; the tap was never being delivered.

`touch-action: manipulation` on buttons, summaries, selects, links and tabs opts those elements out of the double-tap gesture, so the first tap dispatches immediately. Scoped to controls, and deliberately **not** done by disabling zoom on the viewport — pinch-zoom stays available everywhere, which on a site carrying pointed Hebrew is not negotiable.

That same rule covers the seif anchors, which are real `<a href="#op-N">` elements, so it should account for both reports.

**I could not reproduce either report in emulation**, including with real touch taps and with `reducedMotion: "no-preference"`. So this is the change that matches the observed signature, not a change I have watched fix your device. Please tell me if it doesn't.

## `scrollToPane` stops animating

Every caller is a discrete pane change — a tab tap, a cross-pane anchor jump, the snap on mount, the settle commit after a swipe the browser has already snapped. None is following a gesture, so none wants an animation.

It was also **the only branch this repo has ever tested**: `playwright.config.ts` sets `reducedMotion: "reduce"` project-wide, so the smooth branch never ran in CI while being exactly what a real phone took — and animating a `scroll-snap-type: x mandatory` container is where engines disagree. Removing the branch makes the tested path the only path.

## What I tried and threw away

I thought `target.scrollIntoView()` in `useHighlightedAnchor` was the anchor bug: it scrolls *every* scrollable ancestor, and in panes mode one of those is the horizontal swipe track. I wrote the fix, then wrote the test — and **the test passed without the fix**, so the theory is unproven and the change is not in this PR. Two new e2e tests are, running with motion enabled: a tab tap and an anchor jump into Inner Light. Both pass before and after, so they don't reproduce your reports; they're here so the mobile path stops being untested.

## The bar

55px → 45px. The tap target keeps a 40px minimum — I'd rather not shrink what a thumb has to hit while tap delivery is the open question.

## Dependency bump

#89 is merged. It broke `typecheck` on arrival: Nuxt 4.5.2 pulls an h3 v2 RC into the Nitro types alongside h3 v1, so in `server/routes/` `defineEventHandler`'s `event` and `useRuntimeConfig`'s parameter stopped coming from the same `H3Event` declaration. Dropping the event argument fixes it — the event form only buys request-scoped config overrides, which a prerendered static route has no use for. Verified the output is unchanged: `robots.txt` still emits `Sitemap: https://readtes.com/sitemap.xml`, and `sitemap.xml` still has 4,200 URLs.

`task check` green on the bumped deps: 914 unit tests, content validation, full generate, 9/9 e2e.