### PR TITLE
fix(import): align KabbalahMedia Q&A per answer, and never delete on a refusal

### DIFF
--- a/.agents/skills/tes-import-kabbalahmedia/SKILL.md
+++ b/.agents/skills/tes-import-kabbalahmedia/SKILL.md
@@ -23,9 +23,26 @@ fail before any network request.
   and commentary are written only when the relevant alignment is verified.
 - **Safe boundaries**: whole-part Ohr Pnimi/commentary is intentionally not
   written — there is no reliable Hebrew/Sefaria commentary target for it.
-  Inner Observation and unmapped Cause/Consequence-style leaves are reported
-  and skipped, never guessed. Parts 9–15 have no non-Hebrew KabbalahMedia
-  files and remain explicit coverage absences.
+  Inner Observation is reported and skipped, never guessed. Parts 9–15 have
+  no non-Hebrew KabbalahMedia files and remain explicit coverage absences.
+- **A refusal never deletes.** The stale-output sweep removes committed
+  KabbalahMedia files this run did not produce — but "did not produce" also
+  covers every refusal (an alignment it could not verify, a dialect it does
+  not parse, a language whose file was missing today), and treating those as
+  stale deleted committed English whenever one happened (issue #111). The
+  sweep now skips any chapter for which this run recorded a non-`imported`
+  outcome, and says so.
+- **Q&A answers align per answer, not per chapter or per item.** Issue #91
+  folded every answer of a kind into one chapter whose items carry the
+  answer number as `n`, with the rare split answer sharing an `n`. The
+  importer aligns a document's blocks against
+  `firstSegmentPerAnswer` (`scripts/lib/qa-consolidation.ts`) — counting
+  chapters instead (always 1 post-#91) made every part's Q&A unimportable.
+- **Cause and Consequence** is Bnei Baruch's name for Sefaria's Cause and
+  Effect. The Q&A tables map to `questions-cause-effect`/
+  `answers-cause-effect`; the _essay_ of that name is Sefaria's
+  `Histaklut Penimit 2`, already in the corpus as `inner-observation-02`,
+  and carries a role of its own so it is reported rather than re-imported.
 - **Output and validation**: a non-dry run updates layer files,
   `versions.json`, `toc.json`, and derived ToC splits, then runs
   `validateContent`. Only `--all` rewrites the KabbalahMedia-owned section of

--- a/content/COVERAGE.md
+++ b/content/COVERAGE.md
@@ -2894,14 +2894,15 @@ skipped, not force-imported.
 
 | Version | Language (KM code) | Chapters imported | Source segments | Commentary items |
 | --- | --- | --- | --- | --- |
-| de-bb | Bnei Baruch (KabbalahMedia) — Deutsch (`de`) | 0/5148 | 0 | 0 |
-| en-bb | Bnei Baruch (KabbalahMedia) (`en`) | 737/5148 | 1406 | 51 |
-| es-bb | Bnei Baruch (KabbalahMedia) — Español (`es`) | 0/5148 | 0 | 0 |
-| fr-bb | Bnei Baruch (KabbalahMedia) — Français (`fr`) | 0/5148 | 0 | 0 |
-| pt-bb | Bnei Baruch (KabbalahMedia) — Português (`pt`) | 0/5148 | 0 | 0 |
-| ru-bb | Bnei Baruch (KabbalahMedia) — Русский (`ru`) | 0/5148 | 0 | 0 |
-| tr-bb | Bnei Baruch (KabbalahMedia) — Türkçe (`tr`) | 0/5148 | 0 | 0 |
-| uk-bb | Bnei Baruch (KabbalahMedia) — Українська (`ua`) | 0/5148 | 0 | 0 |
+| de-bb | Bnei Baruch (KabbalahMedia) — Deutsch (`de`) | 0/2090 | 0 | 0 |
+| en-bb | Bnei Baruch (KabbalahMedia) (`en`) | 84/2090 | 1474 | 51 |
+| es-bb | Bnei Baruch (KabbalahMedia) — Español (`es`) | 0/2090 | 0 | 0 |
+| fr-bb | Bnei Baruch (KabbalahMedia) — Français (`fr`) | 0/2090 | 0 | 0 |
+| he-bb | Bnei Baruch (KabbalahMedia) — עברית (`he`) | 2/2090 | 10 | 34 |
+| pt-bb | Bnei Baruch (KabbalahMedia) — Português (`pt`) | 0/2090 | 0 | 0 |
+| ru-bb | Bnei Baruch (KabbalahMedia) — Русский (`ru`) | 0/2090 | 0 | 0 |
+| tr-bb | Bnei Baruch (KabbalahMedia) — Türkçe (`tr`) | 0/2090 | 0 | 0 |
+| uk-bb | Bnei Baruch (KabbalahMedia) — Українська (`ua`) | 0/2090 | 0 | 0 |
 
 ### Per part x language
 
@@ -2910,181 +2911,201 @@ skipped, not force-imported.
 usable translation for it in that language (expected for Parts 9-15,
 which have no official non-Hebrew translation on KabbalahMedia at all).
 
-| Part | de-bb | en-bb | es-bb | fr-bb | pt-bb | ru-bb | tr-bb | uk-bb |
-| --- | --- | --- | --- | --- | --- | --- | --- | --- |
-| part-01 | 0/119 | 54/119 | 0/119 | 0/119 | 0/119 | 0/119 | 0/119 | 0/119 |
-| part-02 | 0/186 | 174/186 | 0/186 | 0/186 | 0/186 | 0/186 | 0/186 | 0/186 |
-| part-03 | 0/268 | 104/268 | 0/268 | 0/268 | 0/268 | 0/268 | 0/268 | 0/268 |
-| part-04 | 0/137 | 0/137 | 0/137 | 0/137 | 0/137 | 0/137 | 0/137 | 0/137 |
-| part-05 | 0/266 | 266/266 | 0/266 | 0/266 | 0/266 | 0/266 | 0/266 | 0/266 |
-| part-06 | 0/195 | 139/195 | 0/195 | 0/195 | 0/195 | 0/195 | 0/195 | 0/195 |
-| part-07 | 0/231 | 0/231 | 0/231 | 0/231 | 0/231 | 0/231 | 0/231 | 0/231 |
-| part-08 | 0/245 | 0/245 | 0/245 | 0/245 | 0/245 | 0/245 | 0/245 | 0/245 |
-| part-09 | 0/295 | 0/295 | 0/295 | 0/295 | 0/295 | 0/295 | 0/295 | 0/295 |
-| part-10 | 0/344 | 0/344 | 0/344 | 0/344 | 0/344 | 0/344 | 0/344 | 0/344 |
-| part-11 | 0/346 | 0/346 | 0/346 | 0/346 | 0/346 | 0/346 | 0/346 | 0/346 |
-| part-12 | 0/555 | 0/555 | 0/555 | 0/555 | 0/555 | 0/555 | 0/555 | 0/555 |
-| part-13 | 0/380 | 0/380 | 0/380 | 0/380 | 0/380 | 0/380 | 0/380 | 0/380 |
-| part-14 | 0/479 | 0/479 | 0/479 | 0/479 | 0/479 | 0/479 | 0/479 | 0/479 |
-| part-15 | 0/529 | 0/529 | 0/529 | 0/529 | 0/529 | 0/529 | 0/529 | 0/529 |
-| part-16 | 0/573 | 0/573 | 0/573 | 0/573 | 0/573 | 0/573 | 0/573 | 0/573 |
+| Part | de-bb | en-bb | es-bb | fr-bb | he-bb | pt-bb | ru-bb | tr-bb | uk-bb |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| part-01 | 0/16 | 4/16 | 0/16 | 0/16 | 2/16 | 0/16 | 0/16 | 0/16 | 0/16 |
+| part-02 | 0/16 | 4/16 | 0/16 | 0/16 | 0/16 | 0/16 | 0/16 | 0/16 | 0/16 |
+| part-03 | 0/34 | 4/34 | 0/34 | 0/34 | 0/34 | 0/34 | 0/34 | 0/34 | 0/34 |
+| part-04 | 0/16 | 0/16 | 0/16 | 0/16 | 0/16 | 0/16 | 0/16 | 0/16 | 0/16 |
+| part-05 | 0/66 | 66/66 | 0/66 | 0/66 | 0/66 | 0/66 | 0/66 | 0/66 | 0/66 |
+| part-06 | 0/62 | 6/62 | 0/62 | 0/62 | 0/62 | 0/62 | 0/62 | 0/62 | 0/62 |
+| part-07 | 0/79 | 0/79 | 0/79 | 0/79 | 0/79 | 0/79 | 0/79 | 0/79 | 0/79 |
+| part-08 | 0/99 | 0/99 | 0/99 | 0/99 | 0/99 | 0/99 | 0/99 | 0/99 | 0/99 |
+| part-09 | 0/114 | 0/114 | 0/114 | 0/114 | 0/114 | 0/114 | 0/114 | 0/114 | 0/114 |
+| part-10 | 0/164 | 0/164 | 0/164 | 0/164 | 0/164 | 0/164 | 0/164 | 0/164 | 0/164 |
+| part-11 | 0/160 | 0/160 | 0/160 | 0/160 | 0/160 | 0/160 | 0/160 | 0/160 | 0/160 |
+| part-12 | 0/298 | 0/298 | 0/298 | 0/298 | 0/298 | 0/298 | 0/298 | 0/298 | 0/298 |
+| part-13 | 0/225 | 0/225 | 0/225 | 0/225 | 0/225 | 0/225 | 0/225 | 0/225 | 0/225 |
+| part-14 | 0/232 | 0/232 | 0/232 | 0/232 | 0/232 | 0/232 | 0/232 | 0/232 | 0/232 |
+| part-15 | 0/233 | 0/233 | 0/233 | 0/233 | 0/233 | 0/233 | 0/233 | 0/233 | 0/233 |
+| part-16 | 0/276 | 0/276 | 0/276 | 0/276 | 0/276 | 0/276 | 0/276 | 0/276 | 0/276 |
 
 ### Skipped chapters
 
 | Version | Part | Status | Chapters skipped | Reason |
 | --- | --- | --- | --- | --- |
-| de-bb | part-01 | structure-unsupported | 119 | document structure not yet supported by this importer |
-| de-bb | part-02 | no-file-for-language | 186 | no docx file for this language |
-| de-bb | part-03 | no-file-for-language | 268 | no docx file for this language |
-| de-bb | part-04 | no-file-for-language | 137 | no docx file for this language |
-| de-bb | part-05 | no-file-for-language | 266 | no docx file for this language |
-| de-bb | part-06 | no-file-for-language | 195 | no docx file for this language |
-| de-bb | part-07 | no-file-for-language | 231 | no docx file for this language |
-| de-bb | part-08 | no-file-for-language | 245 | no docx file for this language |
-| de-bb | part-09 | no-file-for-language | 295 | no docx file for this language |
-| de-bb | part-10 | no-file-for-language | 344 | no docx file for this language |
-| de-bb | part-11 | no-file-for-language | 346 | no docx file for this language |
-| de-bb | part-12 | no-file-for-language | 555 | no docx file for this language |
-| de-bb | part-13 | no-file-for-language | 380 | no docx file for this language |
-| de-bb | part-14 | no-file-for-language | 479 | no docx file for this language |
-| de-bb | part-15 | no-file-for-language | 529 | no docx file for this language |
-| de-bb | part-16 | no-file-for-language | 573 | no docx file for this language |
+| de-bb | part-01 | structure-unsupported | 16 | document structure not yet supported by this importer |
+| de-bb | part-02 | no-file-for-language | 16 | no docx file for this language |
+| de-bb | part-03 | no-file-for-language | 34 | no docx file for this language |
+| de-bb | part-04 | no-file-for-language | 16 | no docx file for this language |
+| de-bb | part-05 | no-file-for-language | 66 | no docx file for this language |
+| de-bb | part-06 | no-file-for-language | 62 | no docx file for this language |
+| de-bb | part-07 | no-file-for-language | 79 | no docx file for this language |
+| de-bb | part-08 | no-file-for-language | 99 | no docx file for this language |
+| de-bb | part-09 | no-file-for-language | 114 | no docx file for this language |
+| de-bb | part-10 | no-file-for-language | 164 | no docx file for this language |
+| de-bb | part-11 | no-file-for-language | 160 | no docx file for this language |
+| de-bb | part-12 | no-file-for-language | 298 | no docx file for this language |
+| de-bb | part-13 | no-file-for-language | 225 | no docx file for this language |
+| de-bb | part-14 | no-file-for-language | 232 | no docx file for this language |
+| de-bb | part-15 | no-file-for-language | 233 | no docx file for this language |
+| de-bb | part-16 | no-file-for-language | 276 | no docx file for this language |
 | en-bb | part-01 | structure-unsupported | 10 | document structure not yet supported by this importer |
-| en-bb | part-01 | unmatched | 55 | document parsed, but no item at this chapter's position — count mismatch against the Hebrew ground truth |
+| en-bb | part-01 | unmatched | 2 | document parsed, but no item at this chapter's position — count mismatch against the Hebrew ground truth |
 | en-bb | part-02 | structure-unsupported | 10 | document structure not yet supported by this importer |
 | en-bb | part-02 | unmatched | 2 | document parsed, but no item at this chapter's position — count mismatch against the Hebrew ground truth |
-| en-bb | part-03 | structure-unsupported | 163 | document structure not yet supported by this importer |
+| en-bb | part-03 | structure-unsupported | 29 | document structure not yet supported by this importer |
 | en-bb | part-03 | unmatched | 1 | document parsed, but no item at this chapter's position — count mismatch against the Hebrew ground truth |
-| en-bb | part-04 | no-file-for-language | 125 | no docx file for this language |
+| en-bb | part-04 | no-file-for-language | 4 | no docx file for this language |
 | en-bb | part-04 | structure-unsupported | 11 | document structure not yet supported by this importer |
 | en-bb | part-04 | unmatched | 1 | document parsed, but no item at this chapter's position — count mismatch against the Hebrew ground truth |
 | en-bb | part-06 | structure-unsupported | 56 | document structure not yet supported by this importer |
-| en-bb | part-07 | no-file-for-language | 65 | no docx file for this language |
 | en-bb | part-07 | structure-unsupported | 75 | document structure not yet supported by this importer |
-| en-bb | part-07 | unmatched | 91 | document parsed, but no item at this chapter's position — count mismatch against the Hebrew ground truth |
-| en-bb | part-08 | no-file-for-language | 151 | no docx file for this language |
+| en-bb | part-07 | unmatched | 4 | document parsed, but no item at this chapter's position — count mismatch against the Hebrew ground truth |
+| en-bb | part-08 | no-file-for-language | 5 | no docx file for this language |
 | en-bb | part-08 | structure-unsupported | 94 | document structure not yet supported by this importer |
-| en-bb | part-09 | no-file-for-language | 295 | no docx file for this language |
-| en-bb | part-10 | no-file-for-language | 344 | no docx file for this language |
-| en-bb | part-11 | no-file-for-language | 346 | no docx file for this language |
-| en-bb | part-12 | no-file-for-language | 555 | no docx file for this language |
-| en-bb | part-13 | no-file-for-language | 380 | no docx file for this language |
-| en-bb | part-14 | no-file-for-language | 479 | no docx file for this language |
-| en-bb | part-15 | no-file-for-language | 529 | no docx file for this language |
-| en-bb | part-16 | no-file-for-language | 301 | no docx file for this language |
+| en-bb | part-09 | no-file-for-language | 114 | no docx file for this language |
+| en-bb | part-10 | no-file-for-language | 164 | no docx file for this language |
+| en-bb | part-11 | no-file-for-language | 160 | no docx file for this language |
+| en-bb | part-12 | no-file-for-language | 298 | no docx file for this language |
+| en-bb | part-13 | no-file-for-language | 225 | no docx file for this language |
+| en-bb | part-14 | no-file-for-language | 232 | no docx file for this language |
+| en-bb | part-15 | no-file-for-language | 233 | no docx file for this language |
+| en-bb | part-16 | no-file-for-language | 4 | no docx file for this language |
 | en-bb | part-16 | structure-unsupported | 272 | document structure not yet supported by this importer |
-| es-bb | part-01 | structure-unsupported | 119 | document structure not yet supported by this importer |
-| es-bb | part-02 | no-file-for-language | 186 | no docx file for this language |
-| es-bb | part-03 | no-file-for-language | 268 | no docx file for this language |
-| es-bb | part-04 | no-file-for-language | 137 | no docx file for this language |
-| es-bb | part-05 | no-file-for-language | 266 | no docx file for this language |
-| es-bb | part-06 | no-file-for-language | 141 | no docx file for this language |
+| es-bb | part-01 | structure-unsupported | 16 | document structure not yet supported by this importer |
+| es-bb | part-02 | no-file-for-language | 16 | no docx file for this language |
+| es-bb | part-03 | no-file-for-language | 34 | no docx file for this language |
+| es-bb | part-04 | no-file-for-language | 16 | no docx file for this language |
+| es-bb | part-05 | no-file-for-language | 66 | no docx file for this language |
+| es-bb | part-06 | no-file-for-language | 8 | no docx file for this language |
 | es-bb | part-06 | structure-unsupported | 54 | document structure not yet supported by this importer |
-| es-bb | part-07 | no-file-for-language | 231 | no docx file for this language |
-| es-bb | part-08 | no-file-for-language | 245 | no docx file for this language |
-| es-bb | part-09 | no-file-for-language | 295 | no docx file for this language |
-| es-bb | part-10 | no-file-for-language | 344 | no docx file for this language |
-| es-bb | part-11 | no-file-for-language | 346 | no docx file for this language |
-| es-bb | part-12 | no-file-for-language | 555 | no docx file for this language |
-| es-bb | part-13 | no-file-for-language | 380 | no docx file for this language |
-| es-bb | part-14 | no-file-for-language | 479 | no docx file for this language |
-| es-bb | part-15 | no-file-for-language | 529 | no docx file for this language |
-| es-bb | part-16 | no-file-for-language | 573 | no docx file for this language |
-| fr-bb | part-01 | no-file-for-language | 119 | no docx file for this language |
-| fr-bb | part-02 | no-file-for-language | 186 | no docx file for this language |
-| fr-bb | part-03 | no-file-for-language | 268 | no docx file for this language |
-| fr-bb | part-04 | no-file-for-language | 137 | no docx file for this language |
-| fr-bb | part-05 | no-file-for-language | 266 | no docx file for this language |
-| fr-bb | part-06 | no-file-for-language | 139 | no docx file for this language |
+| es-bb | part-07 | no-file-for-language | 79 | no docx file for this language |
+| es-bb | part-08 | no-file-for-language | 99 | no docx file for this language |
+| es-bb | part-09 | no-file-for-language | 114 | no docx file for this language |
+| es-bb | part-10 | no-file-for-language | 164 | no docx file for this language |
+| es-bb | part-11 | no-file-for-language | 160 | no docx file for this language |
+| es-bb | part-12 | no-file-for-language | 298 | no docx file for this language |
+| es-bb | part-13 | no-file-for-language | 225 | no docx file for this language |
+| es-bb | part-14 | no-file-for-language | 232 | no docx file for this language |
+| es-bb | part-15 | no-file-for-language | 233 | no docx file for this language |
+| es-bb | part-16 | no-file-for-language | 276 | no docx file for this language |
+| fr-bb | part-01 | no-file-for-language | 16 | no docx file for this language |
+| fr-bb | part-02 | no-file-for-language | 16 | no docx file for this language |
+| fr-bb | part-03 | no-file-for-language | 34 | no docx file for this language |
+| fr-bb | part-04 | no-file-for-language | 16 | no docx file for this language |
+| fr-bb | part-05 | no-file-for-language | 66 | no docx file for this language |
+| fr-bb | part-06 | no-file-for-language | 6 | no docx file for this language |
 | fr-bb | part-06 | structure-unsupported | 56 | document structure not yet supported by this importer |
-| fr-bb | part-07 | no-file-for-language | 231 | no docx file for this language |
-| fr-bb | part-08 | no-file-for-language | 245 | no docx file for this language |
-| fr-bb | part-09 | no-file-for-language | 295 | no docx file for this language |
-| fr-bb | part-10 | no-file-for-language | 344 | no docx file for this language |
-| fr-bb | part-11 | no-file-for-language | 346 | no docx file for this language |
-| fr-bb | part-12 | no-file-for-language | 555 | no docx file for this language |
-| fr-bb | part-13 | no-file-for-language | 380 | no docx file for this language |
-| fr-bb | part-14 | no-file-for-language | 479 | no docx file for this language |
-| fr-bb | part-15 | no-file-for-language | 529 | no docx file for this language |
-| fr-bb | part-16 | no-file-for-language | 573 | no docx file for this language |
-| pt-bb | part-01 | no-file-for-language | 109 | no docx file for this language |
+| fr-bb | part-07 | no-file-for-language | 79 | no docx file for this language |
+| fr-bb | part-08 | no-file-for-language | 99 | no docx file for this language |
+| fr-bb | part-09 | no-file-for-language | 114 | no docx file for this language |
+| fr-bb | part-10 | no-file-for-language | 164 | no docx file for this language |
+| fr-bb | part-11 | no-file-for-language | 160 | no docx file for this language |
+| fr-bb | part-12 | no-file-for-language | 298 | no docx file for this language |
+| fr-bb | part-13 | no-file-for-language | 225 | no docx file for this language |
+| fr-bb | part-14 | no-file-for-language | 232 | no docx file for this language |
+| fr-bb | part-15 | no-file-for-language | 233 | no docx file for this language |
+| fr-bb | part-16 | no-file-for-language | 276 | no docx file for this language |
+| he-bb | part-01 | no-file-for-language | 14 | no docx file for this language |
+| he-bb | part-02 | no-file-for-language | 14 | no docx file for this language |
+| he-bb | part-02 | unmatched | 2 | document parsed, but no item at this chapter's position — count mismatch against the Hebrew ground truth |
+| he-bb | part-03 | no-file-for-language | 19 | no docx file for this language |
+| he-bb | part-03 | structure-unsupported | 15 | document structure not yet supported by this importer |
+| he-bb | part-04 | no-file-for-language | 10 | no docx file for this language |
+| he-bb | part-04 | unmatched | 6 | document parsed, but no item at this chapter's position — count mismatch against the Hebrew ground truth |
+| he-bb | part-05 | no-file-for-language | 4 | no docx file for this language |
+| he-bb | part-05 | structure-unsupported | 62 | document structure not yet supported by this importer |
+| he-bb | part-06 | no-file-for-language | 62 | no docx file for this language |
+| he-bb | part-07 | no-file-for-language | 79 | no docx file for this language |
+| he-bb | part-08 | no-file-for-language | 99 | no docx file for this language |
+| he-bb | part-09 | no-file-for-language | 114 | no docx file for this language |
+| he-bb | part-10 | no-file-for-language | 164 | no docx file for this language |
+| he-bb | part-11 | no-file-for-language | 160 | no docx file for this language |
+| he-bb | part-12 | no-file-for-language | 298 | no docx file for this language |
+| he-bb | part-13 | no-file-for-language | 225 | no docx file for this language |
+| he-bb | part-14 | no-file-for-language | 232 | no docx file for this language |
+| he-bb | part-15 | no-file-for-language | 233 | no docx file for this language |
+| he-bb | part-16 | no-file-for-language | 276 | no docx file for this language |
+| pt-bb | part-01 | no-file-for-language | 6 | no docx file for this language |
 | pt-bb | part-01 | structure-unsupported | 10 | document structure not yet supported by this importer |
-| pt-bb | part-02 | no-file-for-language | 186 | no docx file for this language |
-| pt-bb | part-03 | no-file-for-language | 268 | no docx file for this language |
-| pt-bb | part-04 | no-file-for-language | 137 | no docx file for this language |
-| pt-bb | part-05 | no-file-for-language | 266 | no docx file for this language |
-| pt-bb | part-06 | no-file-for-language | 195 | no docx file for this language |
-| pt-bb | part-07 | no-file-for-language | 231 | no docx file for this language |
-| pt-bb | part-08 | no-file-for-language | 245 | no docx file for this language |
-| pt-bb | part-09 | no-file-for-language | 295 | no docx file for this language |
-| pt-bb | part-10 | no-file-for-language | 344 | no docx file for this language |
-| pt-bb | part-11 | no-file-for-language | 346 | no docx file for this language |
-| pt-bb | part-12 | no-file-for-language | 555 | no docx file for this language |
-| pt-bb | part-13 | no-file-for-language | 380 | no docx file for this language |
-| pt-bb | part-14 | no-file-for-language | 479 | no docx file for this language |
-| pt-bb | part-15 | no-file-for-language | 529 | no docx file for this language |
-| pt-bb | part-16 | no-file-for-language | 573 | no docx file for this language |
-| ru-bb | part-01 | structure-unsupported | 119 | document structure not yet supported by this importer |
-| ru-bb | part-02 | structure-unsupported | 184 | document structure not yet supported by this importer |
+| pt-bb | part-02 | no-file-for-language | 16 | no docx file for this language |
+| pt-bb | part-03 | no-file-for-language | 34 | no docx file for this language |
+| pt-bb | part-04 | no-file-for-language | 16 | no docx file for this language |
+| pt-bb | part-05 | no-file-for-language | 66 | no docx file for this language |
+| pt-bb | part-06 | no-file-for-language | 62 | no docx file for this language |
+| pt-bb | part-07 | no-file-for-language | 79 | no docx file for this language |
+| pt-bb | part-08 | no-file-for-language | 99 | no docx file for this language |
+| pt-bb | part-09 | no-file-for-language | 114 | no docx file for this language |
+| pt-bb | part-10 | no-file-for-language | 164 | no docx file for this language |
+| pt-bb | part-11 | no-file-for-language | 160 | no docx file for this language |
+| pt-bb | part-12 | no-file-for-language | 298 | no docx file for this language |
+| pt-bb | part-13 | no-file-for-language | 225 | no docx file for this language |
+| pt-bb | part-14 | no-file-for-language | 232 | no docx file for this language |
+| pt-bb | part-15 | no-file-for-language | 233 | no docx file for this language |
+| pt-bb | part-16 | no-file-for-language | 276 | no docx file for this language |
+| ru-bb | part-01 | structure-unsupported | 16 | document structure not yet supported by this importer |
+| ru-bb | part-02 | structure-unsupported | 14 | document structure not yet supported by this importer |
 | ru-bb | part-02 | unmatched | 2 | document parsed, but no item at this chapter's position — count mismatch against the Hebrew ground truth |
-| ru-bb | part-03 | structure-unsupported | 267 | document structure not yet supported by this importer |
+| ru-bb | part-03 | structure-unsupported | 33 | document structure not yet supported by this importer |
 | ru-bb | part-03 | unmatched | 1 | document parsed, but no item at this chapter's position — count mismatch against the Hebrew ground truth |
-| ru-bb | part-04 | structure-unsupported | 136 | document structure not yet supported by this importer |
+| ru-bb | part-04 | structure-unsupported | 15 | document structure not yet supported by this importer |
 | ru-bb | part-04 | unmatched | 1 | document parsed, but no item at this chapter's position — count mismatch against the Hebrew ground truth |
-| ru-bb | part-05 | no-file-for-language | 266 | no docx file for this language |
-| ru-bb | part-06 | no-file-for-language | 139 | no docx file for this language |
-| ru-bb | part-06 | structure-unsupported | 56 | document structure not yet supported by this importer |
-| ru-bb | part-07 | no-file-for-language | 231 | no docx file for this language |
-| ru-bb | part-08 | no-file-for-language | 151 | no docx file for this language |
+| ru-bb | part-05 | no-file-for-language | 66 | no docx file for this language |
+| ru-bb | part-06 | no-file-for-language | 4 | no docx file for this language |
+| ru-bb | part-06 | structure-unsupported | 58 | document structure not yet supported by this importer |
+| ru-bb | part-07 | no-file-for-language | 79 | no docx file for this language |
+| ru-bb | part-08 | no-file-for-language | 5 | no docx file for this language |
 | ru-bb | part-08 | structure-unsupported | 94 | document structure not yet supported by this importer |
-| ru-bb | part-09 | no-file-for-language | 295 | no docx file for this language |
-| ru-bb | part-10 | no-file-for-language | 344 | no docx file for this language |
-| ru-bb | part-11 | no-file-for-language | 346 | no docx file for this language |
-| ru-bb | part-12 | no-file-for-language | 555 | no docx file for this language |
-| ru-bb | part-13 | no-file-for-language | 380 | no docx file for this language |
-| ru-bb | part-14 | no-file-for-language | 479 | no docx file for this language |
-| ru-bb | part-15 | no-file-for-language | 529 | no docx file for this language |
-| ru-bb | part-16 | no-file-for-language | 573 | no docx file for this language |
-| tr-bb | part-01 | structure-unsupported | 119 | document structure not yet supported by this importer |
-| tr-bb | part-02 | structure-unsupported | 184 | document structure not yet supported by this importer |
+| ru-bb | part-09 | no-file-for-language | 114 | no docx file for this language |
+| ru-bb | part-10 | no-file-for-language | 164 | no docx file for this language |
+| ru-bb | part-11 | no-file-for-language | 160 | no docx file for this language |
+| ru-bb | part-12 | no-file-for-language | 298 | no docx file for this language |
+| ru-bb | part-13 | no-file-for-language | 225 | no docx file for this language |
+| ru-bb | part-14 | no-file-for-language | 232 | no docx file for this language |
+| ru-bb | part-15 | no-file-for-language | 233 | no docx file for this language |
+| ru-bb | part-16 | no-file-for-language | 276 | no docx file for this language |
+| tr-bb | part-01 | structure-unsupported | 16 | document structure not yet supported by this importer |
+| tr-bb | part-02 | structure-unsupported | 14 | document structure not yet supported by this importer |
 | tr-bb | part-02 | unmatched | 2 | document parsed, but no item at this chapter's position — count mismatch against the Hebrew ground truth |
-| tr-bb | part-03 | no-file-for-language | 238 | no docx file for this language |
+| tr-bb | part-03 | no-file-for-language | 4 | no docx file for this language |
 | tr-bb | part-03 | structure-unsupported | 29 | document structure not yet supported by this importer |
 | tr-bb | part-03 | unmatched | 1 | document parsed, but no item at this chapter's position — count mismatch against the Hebrew ground truth |
-| tr-bb | part-04 | no-file-for-language | 137 | no docx file for this language |
-| tr-bb | part-05 | no-file-for-language | 266 | no docx file for this language |
-| tr-bb | part-06 | no-file-for-language | 195 | no docx file for this language |
-| tr-bb | part-07 | no-file-for-language | 231 | no docx file for this language |
-| tr-bb | part-08 | no-file-for-language | 245 | no docx file for this language |
-| tr-bb | part-09 | no-file-for-language | 295 | no docx file for this language |
-| tr-bb | part-10 | no-file-for-language | 344 | no docx file for this language |
-| tr-bb | part-11 | no-file-for-language | 346 | no docx file for this language |
-| tr-bb | part-12 | no-file-for-language | 555 | no docx file for this language |
-| tr-bb | part-13 | no-file-for-language | 380 | no docx file for this language |
-| tr-bb | part-14 | no-file-for-language | 479 | no docx file for this language |
-| tr-bb | part-15 | no-file-for-language | 529 | no docx file for this language |
-| tr-bb | part-16 | no-file-for-language | 573 | no docx file for this language |
-| uk-bb | part-01 | structure-unsupported | 119 | document structure not yet supported by this importer |
-| uk-bb | part-02 | no-file-for-language | 103 | no docx file for this language |
-| uk-bb | part-02 | structure-unsupported | 81 | document structure not yet supported by this importer |
+| tr-bb | part-04 | no-file-for-language | 16 | no docx file for this language |
+| tr-bb | part-05 | no-file-for-language | 66 | no docx file for this language |
+| tr-bb | part-06 | no-file-for-language | 62 | no docx file for this language |
+| tr-bb | part-07 | no-file-for-language | 79 | no docx file for this language |
+| tr-bb | part-08 | no-file-for-language | 99 | no docx file for this language |
+| tr-bb | part-09 | no-file-for-language | 114 | no docx file for this language |
+| tr-bb | part-10 | no-file-for-language | 164 | no docx file for this language |
+| tr-bb | part-11 | no-file-for-language | 160 | no docx file for this language |
+| tr-bb | part-12 | no-file-for-language | 298 | no docx file for this language |
+| tr-bb | part-13 | no-file-for-language | 225 | no docx file for this language |
+| tr-bb | part-14 | no-file-for-language | 232 | no docx file for this language |
+| tr-bb | part-15 | no-file-for-language | 233 | no docx file for this language |
+| tr-bb | part-16 | no-file-for-language | 276 | no docx file for this language |
+| uk-bb | part-01 | structure-unsupported | 16 | document structure not yet supported by this importer |
+| uk-bb | part-02 | no-file-for-language | 2 | no docx file for this language |
+| uk-bb | part-02 | structure-unsupported | 12 | document structure not yet supported by this importer |
 | uk-bb | part-02 | unmatched | 2 | document parsed, but no item at this chapter's position — count mismatch against the Hebrew ground truth |
-| uk-bb | part-03 | structure-unsupported | 267 | document structure not yet supported by this importer |
+| uk-bb | part-03 | structure-unsupported | 33 | document structure not yet supported by this importer |
 | uk-bb | part-03 | unmatched | 1 | document parsed, but no item at this chapter's position — count mismatch against the Hebrew ground truth |
-| uk-bb | part-04 | structure-unsupported | 136 | document structure not yet supported by this importer |
+| uk-bb | part-04 | structure-unsupported | 15 | document structure not yet supported by this importer |
 | uk-bb | part-04 | unmatched | 1 | document parsed, but no item at this chapter's position — count mismatch against the Hebrew ground truth |
-| uk-bb | part-05 | no-file-for-language | 161 | no docx file for this language |
-| uk-bb | part-05 | structure-unsupported | 105 | document structure not yet supported by this importer |
-| uk-bb | part-06 | structure-unsupported | 195 | document structure not yet supported by this importer |
-| uk-bb | part-07 | no-file-for-language | 231 | no docx file for this language |
-| uk-bb | part-08 | no-file-for-language | 245 | no docx file for this language |
-| uk-bb | part-09 | no-file-for-language | 295 | no docx file for this language |
-| uk-bb | part-10 | no-file-for-language | 344 | no docx file for this language |
-| uk-bb | part-11 | no-file-for-language | 346 | no docx file for this language |
-| uk-bb | part-12 | no-file-for-language | 555 | no docx file for this language |
-| uk-bb | part-13 | no-file-for-language | 380 | no docx file for this language |
-| uk-bb | part-14 | no-file-for-language | 479 | no docx file for this language |
-| uk-bb | part-15 | no-file-for-language | 529 | no docx file for this language |
-| uk-bb | part-16 | no-file-for-language | 573 | no docx file for this language |
+| uk-bb | part-05 | no-file-for-language | 2 | no docx file for this language |
+| uk-bb | part-05 | structure-unsupported | 64 | document structure not yet supported by this importer |
+| uk-bb | part-06 | no-file-for-language | 2 | no docx file for this language |
+| uk-bb | part-06 | structure-unsupported | 60 | document structure not yet supported by this importer |
+| uk-bb | part-07 | no-file-for-language | 79 | no docx file for this language |
+| uk-bb | part-08 | no-file-for-language | 99 | no docx file for this language |
+| uk-bb | part-09 | no-file-for-language | 114 | no docx file for this language |
+| uk-bb | part-10 | no-file-for-language | 164 | no docx file for this language |
+| uk-bb | part-11 | no-file-for-language | 160 | no docx file for this language |
+| uk-bb | part-12 | no-file-for-language | 298 | no docx file for this language |
+| uk-bb | part-13 | no-file-for-language | 225 | no docx file for this language |
+| uk-bb | part-14 | no-file-for-language | 232 | no docx file for this language |
+| uk-bb | part-15 | no-file-for-language | 233 | no docx file for this language |
+| uk-bb | part-16 | no-file-for-language | 276 | no docx file for this language |
 
 **Warnings:**
 - **de-bb**: part-01 Q&A candidate YR9r5s6q/GG3GRnUr: no h6 question blocks
@@ -3103,6 +3124,8 @@ which have no official non-Hebrew translation on KabbalahMedia at all).
 - **en-bb**: part-07 whole-part candidate FWrR48Bb/PL8hC6VQ: no numbered h5 source items
 - **en-bb**: part-07 Q&A candidate dgNJLnA7/dLixUtOX: pair count 89 does not match Hebrew questions (90) and answer chapters (90)
 - **en-bb**: part-07 Q&A candidate P5q0Zmm6/PbrNcKpJ: pair count 89 does not match Hebrew questions (90) and answer chapters (90)
+- **en-bb**: part-07 Q&A candidate hdywOExs/fwz3gg4T: at least one answer is empty
+- **en-bb**: part-07 Q&A candidate wOz46Ac9/qwfKdRMI: at least one answer is empty
 - **en-bb**: part-08 whole-part candidate Pscnn3pP/GasR6FdS: no numbered h5 source items
 - **en-bb**: part-16 whole-part candidate mW6eON0z/XVunfM89: no numbered h5 source items
 - **es-bb**: part-01 Q&A candidate YR9r5s6q/bHSPTyoc: no h6 question blocks
@@ -3111,6 +3134,16 @@ which have no official non-Hebrew translation on KabbalahMedia at all).
 - **es-bb**: part-01 Q&A candidate nnGQFc43/1zxBqmSG: no h6 question blocks
 - **es-bb**: part-06 whole-part candidate DztxuIK7/OARhj9ck: no numbered h5 source items
 - **fr-bb**: part-06 whole-part candidate DztxuIK7/3XcQaHXJ: no numbered h5 source items
+- **he-bb**: part-02/chapter-01 Hebrew whole-part: consumed 5/11 topic headings before this chapter ended
+- **he-bb**: part-02/chapter-02 Hebrew whole-part: consumed 3/7 topic headings before this chapter ended
+- **he-bb**: part-03 Hebrew whole-part: found 4 chapter heading(s), expected 15
+- **he-bb**: part-04/chapter-01 Hebrew whole-part: consumed 1/11 topic headings before this chapter ended
+- **he-bb**: part-04/chapter-02 Hebrew whole-part: consumed 8/10 topic headings before this chapter ended
+- **he-bb**: part-04/chapter-03 Hebrew whole-part: text before this chapter's first seif topic heading at block 176: "כשיסוד עולה מניח רשימה במקומו להאיר למלכ"
+- **he-bb**: part-04/chapter-04 Hebrew whole-part: consumed 1/8 topic headings before this chapter ended
+- **he-bb**: part-04/chapter-05 Hebrew whole-part: text before this chapter's first seif topic heading at block 366: "באורות עקודים יש י"ס פנימיות וי"ס מקיפות"
+- **he-bb**: part-04/chapter-06 Hebrew whole-part: text before this chapter's first seif topic heading at block 442: "בהתפשטות א' דעקודים לא יצאו האורות שלמים"
+- **he-bb**: part-05 Hebrew whole-part: found 0 chapter heading(s), expected 62
 - **ru-bb**: part-01 Q&A candidate YR9r5s6q/DgOTzKGq: no h6 question blocks
 - **ru-bb**: part-01 Q&A candidate EiUPsO0e/93HN4Yqz: no h6 question blocks
 - **ru-bb**: part-01 Q&A candidate QCnCAagn/Ttxyqldm: no h6 question blocks
@@ -3132,6 +3165,7 @@ which have no official non-Hebrew translation on KabbalahMedia at all).
 - **ru-bb**: part-04 Q&A candidate sL3XV5Dr/dZTnwfLY: no h6 question blocks
 - **ru-bb**: part-04 Q&A candidate 1t0TL11u/GMyqDV1J: no h6 question blocks
 - **ru-bb**: part-06 whole-part candidate DztxuIK7/AoBmRybu: no numbered h5 source items
+- **ru-bb**: part-06 Q&A candidate KGNYqv7h/RNERyfru: no h6 question blocks
 - **ru-bb**: part-08 whole-part candidate Pscnn3pP/xZMvq2Fj: no numbered h5 source items
 - **tr-bb**: part-01 Q&A candidate YR9r5s6q/Nh6O9nlf: no h6 question blocks
 - **tr-bb**: part-01 Q&A candidate EiUPsO0e/HC7CHDmm: no h6 question blocks

--- a/content/parts/part-06/chapters/answers-cause-effect-01/source.en-bb.json
+++ b/content/parts/part-06/chapters/answers-cause-effect-01/source.en-bb.json
@@ -1,0 +1,212 @@
+{
+  "chapterId": "part-06/answers-cause-effect-01",
+  "layer": "source",
+  "versionId": "en-bb",
+  "sefariaRef": "Talmud Eser HaSefirot, Section VI, List of Answers on Cause and Effect",
+  "items": [
+    {
+      "n": 1,
+      "sefariaRef": "Talmud Eser HaSefirot, Section VI, List of Answers on Cause and Effect 138:1",
+      "html": "Three actions eventuate from it: The first is the departure of the light from all four phases. The second is that a place was made for the worlds. The third is the vessels of the ten Sefirot of circles. (Inner Observation, Item 4)",
+      "anchors": []
+    },
+    {
+      "n": 2,
+      "sefariaRef": "Talmud Eser HaSefirot, Section VI, List of Answers on Cause and Effect 139:1",
+      "html": "1. The light of the line of Ein Sof on only three phases. 2. The correction of the screen that limits and detains the light from expanding in phase four. (Inner Observation, Item 5)",
+      "anchors": []
+    },
+    {
+      "n": 3,
+      "sefariaRef": "Talmud Eser HaSefirot, Section VI, List of Answers on Cause and Effect 140:1",
+      "html": "1. The coupling by striking with the upper light. 2. Pushing back the light that belongs to phase four, called reflected light. (Inner Observation, Item 6)",
+      "anchors": []
+    },
+    {
+      "n": 4,
+      "sefariaRef": "Talmud Eser HaSefirot, Section VI, List of Answers on Cause and Effect 141:1",
+      "html": "1. Potential and actual reception of the upper light, called Rosh and Guf. 2. Rejection of the upper light from phase four that manifests de facto in the screen of Tabur, which expands into ten forces of Sium, called the ten Sefirot of NHY, or the ten Sefirot of Sof. (Ibid., Item 9)",
+      "anchors": []
+    },
+    {
+      "n": 5,
+      "sefariaRef": "Talmud Eser HaSefirot, Section VI, List of Answers on Cause and Effect 142:1",
+      "html": "The clash of surrounding light and inner light with one another. (Ibid., Item 12)",
+      "anchors": []
+    },
+    {
+      "n": 6,
+      "sefariaRef": "Talmud Eser HaSefirot, Section VI, List of Answers on Cause and Effect 143:1",
+      "html": "1. The refinement of the screen until it equalizes with the phase of Malchut of the Rosh for renewal in the coupling of Rosh. 2. The incorporation of the screen in the records of the ten Sefirot of the Guf as it ascends. 3. The concealment of the record of extension from the last phase. (Ibid., Items 12, 13, 18)",
+      "anchors": []
+    },
+    {
+      "n": 7,
+      "sefariaRef": "Talmud Eser HaSefirot, Section VI, List of Answers on Cause and Effect 144:1",
+      "html": "1. The concealment of the light of Keter and the diminution of the level up to Hochma. 2. Two upper records that became male and female. (Ibid., Items 14, 19)",
+      "anchors": []
+    },
+    {
+      "n": 8,
+      "sefariaRef": "Talmud Eser HaSefirot, Section VI, List of Answers on Cause and Effect 145:1",
+      "html": "1. The ascent of Malchut of the Rosh to Hotem of the Rosh, which is phase three. 2. The coupling was made there on phase four of clothing, meaning on the phase of male, extending the level of Keter there, which is not in the phase of expansion for the vessels. 3. The coupling on phase three was made there, meaning on the phase of female, extending the level of Hochma, which has expansion from above downward to the phase of the vessels. (Ibid., Item 15)",
+      "anchors": []
+    },
+    {
+      "n": 9,
+      "sefariaRef": "Talmud Eser HaSefirot, Section VI, List of Answers on Cause and Effect 146:1",
+      "html": "1. The renewal of the coarseness in the screen and the records until they are suitable for a coupling by striking with the upper light. 2. The revelation of the coarseness of Guf in the screen and the records. (Ibid., Items 16, 17)",
+      "anchors": []
+    },
+    {
+      "n": 10,
+      "sefariaRef": "Talmud Eser HaSefirot, Section VI, List of Answers on Cause and Effect 147:1",
+      "html": "1. Their exit from the Rosh and their arriving at their corresponding phase in the externality of the Guf of Partzuf Galgalta, meaning in phase three of the Guf, called Chazeh. 2. That two couplings are made there in the place of Chazeh of Galgalta of the male and the female, according to their property in the Rosh. (Ibid., Item 19)",
+      "anchors": []
+    },
+    {
+      "n": 11,
+      "sefariaRef": "Talmud Eser HaSefirot, Section VI, List of Answers on Cause and Effect 148:1",
+      "html": "1. That the ten Sefirot of Rosh come out from the Chazeh upward to the Peh of Partzuf Galgalta on the level of Hochma. 2. The ten Sefirot from the Chazeh downward to the phase of clothing, called Guf. 3. The ten Sefirot of Sium that expand from the screen of Tabur downward, which end above the Tabur of Partzuf Galgalta. This expansion of Rosh-Toch-Sof is called Partzuf AB of AK. (Ibid., Items 20, 21, 22)",
+      "anchors": []
+    },
+    {
+      "n": 12,
+      "sefariaRef": "Talmud Eser HaSefirot, Section VI, List of Answers on Cause and Effect 149:1",
+      "html": "The clash of surrounding light and inner light with one another. (Ibid., Item 12)",
+      "anchors": []
+    },
+    {
+      "n": 13,
+      "sefariaRef": "Talmud Eser HaSefirot, Section VI, List of Answers on Cause and Effect 150:1",
+      "html": "The first is the refinement of the screen until it equalizes with Malchut of the Rosh for renewal in the coupling of the Rosh. The second is the incorporation of the screen through its ascent in the records of the ten Sefirot of the Guf. The third is concealing of the record of extension from the last phase. (Ibid., Items 12, 13, 18)",
+      "anchors": []
+    },
+    {
+      "n": 14,
+      "sefariaRef": "Talmud Eser HaSefirot, Section VI, List of Answers on Cause and Effect 151:1",
+      "html": "The first is the concealing of the light of Hochma and the diminution of the level up to Bina. The second is two upper records that became male and female. (Ibid., Items 14, 24)",
+      "anchors": []
+    },
+    {
+      "n": 15,
+      "sefariaRef": "Talmud Eser HaSefirot, Section VI, List of Answers on Cause and Effect 152:1",
+      "html": "The first is the ascent of Malchut of the Rosh to the Ozen, which is phase two of the Rosh. The second is that the coupling on phase three of clothing was made there, meaning on the phase of male, extending the level of Hochma, which is not in the phase of expansion for the vessels. The third is the second coupling that was made there on phase two, which is the phase of female, which draws the level of Bina, and has expansion to the phase of the vessels. (Ibid., Item 15)",
+      "anchors": []
+    },
+    {
+      "n": 16,
+      "sefariaRef": "Talmud Eser HaSefirot, Section VI, List of Answers on Cause and Effect 153:1",
+      "html": "The first is the renewal of the coarseness in the screen and the records until they are suitable for a coupling by striking with the upper light. The second is the disclosure of the coarseness of the Guf in the screen and the records. (Ibid., Items 16, 17)",
+      "anchors": []
+    },
+    {
+      "n": 17,
+      "sefariaRef": "Talmud Eser HaSefirot, Section VI, List of Answers on Cause and Effect 154:1",
+      "html": "The first is their exit from the Rosh and their arriving at their corresponding phase in the externality of the Guf of Partzuf AB, meaning in phase two of AB, called Chazeh. The second is that they return and make two couplings there in the place of Chazeh of AB, like the attribute of the two couplings that they made by the incorporation in the coupling of the Rosh of AB. (Ibid., Items 19, 24)",
+      "anchors": []
+    },
+    {
+      "n": 18,
+      "sefariaRef": "Talmud Eser HaSefirot, Section VI, List of Answers on Cause and Effect 155:1",
+      "html": "The first is that the ten Sefirot of Rosh came out from the Chazeh and above up to the Peh of Partzuf AB on the level of Bina, which is in the phase of female, from whom there are the vessels of the Partzuf. However, there is also the level of Hochma there from the phase of male, who has no expansion to the vessels. The second is the ten Sefirot from the Chazeh of AB downward, which expand in the vessel of Keter of the Guf to the Tabur of Partzuf Galgalta. It reaches the Sium Raglayim of Partzuf AB, where this expansion stops because there is light of the level of male there, which is Hochma. The third is the expansion of the nine lower Sefirot from Tabur down to the Sium Raglayim of Galgalta of AK, called dots of SAG. The fourth is the ten Sefirot of Sium that expand by the screen of Tabur, called the ten Sefirot of NHY, or ten Sefirot of the Sof of the Partzuf. This expansion of Rosh-Toch-Sof is called Partzuf SAG of AK.",
+      "anchors": []
+    },
+    {
+      "n": 19,
+      "sefariaRef": "Talmud Eser HaSefirot, Section VI, List of Answers on Cause and Effect 156:1",
+      "html": "The clash of surrounding light and inner light with one another.",
+      "anchors": []
+    },
+    {
+      "n": 20,
+      "sefariaRef": "Talmud Eser HaSefirot, Section VI, List of Answers on Cause and Effect 157:1",
+      "html": "The refinement of the screen until it equalizes with Malchut of the Rosh to receive renewal from the coupling of the Rosh. The second is the incorporation of the screen in two kinds of records: records that are not connected with the records of NHY of Galgalta, called tastes, and records that are connected with the NHY of Galgalta, called dots, where the two Heys, the bottom Hey and the first Hey, are connected. The third is the concealing of the records of extension from the last phase. (Ibid., Items 12, 13, 18, 25)",
+      "anchors": []
+    },
+    {
+      "n": 21,
+      "sefariaRef": "Talmud Eser HaSefirot, Section VI, List of Answers on Cause and Effect 158:1",
+      "html": "The diminution of the level to phase one. The second is the two upper records that became male and female. (Ibid., Items 14, 15)",
+      "anchors": []
+    },
+    {
+      "n": 22,
+      "sefariaRef": "Talmud Eser HaSefirot, Section VI, List of Answers on Cause and Effect 159:1",
+      "html": "The ascent of Malchut of the Rosh to the Nikvey Einayim. The second is that the coupling on phase two of clothing was made there, meaning on the phase of male that the level of Bina is extended on, which is not the phase of expansion to the vessels. This is performed over the above two kinds of the records: tastes and dots. The third is the coupling that was made there in the phase of female, meaning on phase one, which the level of ZA is extended on. However, she has expansion to the vessels, and this is done on two kinds of records, too: tastes and dots. (Ibid., Items 15, 30)",
+      "anchors": []
+    },
+    {
+      "n": 23,
+      "sefariaRef": "Talmud Eser HaSefirot, Section VI, List of Answers on Cause and Effect 160:1",
+      "html": "The first is the renewal of the coarseness in the screen and the records that rose from the Guf of SAG until they are suitable for a coupling by striking with the upper light. The second is the exit of the Dikna as bottom Hey in the Einayim and YHV in the AHP. The third is the disclosure of the coarseness of the Guf in the screen and the records. (Ibid., Items 16, 17, and Inner Light, Item 2)",
+      "anchors": []
+    },
+    {
+      "n": 24,
+      "sefariaRef": "Talmud Eser HaSefirot, Section VI, List of Answers on Cause and Effect 161:1",
+      "html": "Their exit from the Rosh and their coming to the corresponding phase in the externality of the Guf of SAG. (Inner Observation, Item 19)",
+      "anchors": []
+    },
+    {
+      "n": 25,
+      "sefariaRef": "Talmud Eser HaSefirot, Section VI, List of Answers on Cause and Effect 162:1",
+      "html": "1. It elicited three Roshim as it came to three places in the Guf: in the Chazeh, in the Tabur, and in the Sium of the Guf. From the Chazeh to the Peh of SAG, it elicited the ten Sefirot of Rosh of the upper MA and BON, and its ten Sefirot of the Guf end at the Tabur. From the Tabur to the Chazeh of SAG, it elicited the ten Sefirot of Rosh called YESHSUT, or the first Rosh of Nekudim. From the Sium of the Guf, meaning Tifferet of AK to the Tabur, it elicits the GAR of Nekudim. From the Sium of the Guf downward, emerged the Guf of Nekudim, which are the lower seven of Nekudim. In all of them, there are male and female. The level of male is up to Bina, and the level of female is the level of ZA. (Ibid., Items 20, 21,22, 24, 30)",
+      "anchors": []
+    },
+    {
+      "n": 26,
+      "sefariaRef": "Talmud Eser HaSefirot, Section VI, List of Answers on Cause and Effect 163:1",
+      "html": "The diminution of Atzilut on Keter and Hochma alone, and AHP of every degree, are considered the Beria of that degree. Second: A new boundary of the Sium of the line of Ein Sof that rose from Malchut of NHY of AK to Bina of NHY of AK, and the emergence of the three Sefirot Bina, ZA, and Malchut of NHY of AK below the point of restriction. This is called the second restriction. Third: These three Sefirot below the point of restriction became the place for the three worlds BYA: The world of Beria was made in the place of Bina, the world of Yetzira in the place of ZA, and the world of Assiya in the place of Malchut. Fourth: the correction of the Parsa. (Ibid., Items 33, 34)",
+      "anchors": []
+    },
+    {
+      "n": 27,
+      "sefariaRef": "Talmud Eser HaSefirot, Section VI, List of Answers on Cause and Effect 164:1",
+      "html": "Because of the yearning for greater adhesion, meaning for equivalence of form with the upper light, Malchut of Ein Sof restricted the phase of Gadlut of the will to receive. In other words, she did not want to receive in phase four. Since phase four was the entire vessel of reception for the upper light, the light departed from all four phases and there became a vacant place for the worlds. From the departure of light from all four phases comes the correction of the screen on phase four in order to draw the light on the first three phases, without expanding to phase four. From the screen established on phase four comes the coupling by striking with the upper light, which returns all the parts of the light that fit coming into phase four, to its posterior, called reflected light. Two actions stem from the coupling by striking and the reflected light that ascended: 1. The potential and actual reception of the upper light, called Rosh and Guf, down to Tabur. 2. The force of rejection on the ten Sefirot of upper light called the “screen of Tabur,” from which the ten forces of Sium expand, which are called the “ten Sefirot of Sof,” or the “ten Sefirot NHY.” From the screen of Tabur, the clash of surrounding light with inner light on one another is extended. Three actions stem from the clash of the surrounding light with inner light on one another: 1. The refinement of the screen and its coming for renewal in the coupling in the Rosh, because of which, all the lights of Guf departed. 2. The incorporation of the screen in the records of the Guf during its ascent. 3. The disappearing of the record of extension from the last phase. Two actions stem from the concealment of the record of extension from the last phase: 1. The concealment of the light of Keter and the diminution of the level down to Hochma. 2. The two upper records became male and female. Three actions stem from the two records male and female: 1. The ascent of Malchut of the Rosh to the Hotem, which is phase three of the Rosh. 2. The coupling that was made there on phase four of the phase of clothing, meaning on the phase of male, and the level of Keter that is extended there. It does not expand to the vessels. 3. The second coupling that was made there on phase three, meaning on the phase of female, extending the level of Hochma there, from which there is expansion to the vessels. The renewal of the coarseness in the screen and the records stems from the two couplings of ZON that were made in their incorporation in the Rosh of Galgalta, until they became fitting for a coupling by striking with the upper light. The second is the manifestation of the coarseness of Guf in the screen and the records. Their emergence from the Rosh, and their coming to their corresponding phase in the externality of the Guf of Partzuf Galgalta, which is phase three of the Guf, called Chazeh, are extended from the disclosure of the coarseness. The second is that here, in the place of the Chazeh, they made those two couplings that were made on their phase in the Rosh. Three actions stem from the two couplings made by the male and the female at the place of the Chazeh: 1. The elicitation of the ten Sefirot of the Rosh from the Chazeh upward to the Peh of Partzuf Galgalta at the level of Hochma. 2. The expansion of the ten Sefirot from the Chazeh downward, called Guf, to the screen of its own Tabur. 3. The ten Sefirot of Sium that expanded from the screen of Tabur, and ended above the Tabur of Partzuf Galgalta. This expansion of Rosh-Toch-Sof is called Partzuf AB of AK. The clash of the surrounding light and inner light with one another is extended from the screen of Tabur of AB (Inner Observation, Item 12). Three actions stem from the clash of surrounding light and inner light: 1. The refinement of the screen to equalize with Malchut of the Rosh, in order to be renewed in a coupling that the lights of Guf depart with. 2. The incorporation of the screen with records of the ten Sefirot of Guf during its ascent. 3. The disappearance of the record of extension from the last phase. From the disappearance of the last phase of extension stems the concealment of the light of Hochma and the diminution of the level up to Bina. The second is that the two upper records were turned into male and female. The ascent of Malchut of the Rosh to the Ozen is extended from the two records of male and female. The second is that the coupling was made on phase three of clothing there, which is the phase of male. It draws the ten Sefirot in the level of Hochma there, but it has no expansion to the vessels. The third is a second coupling that was made there on phase two, which is the phase of female. It draws the level of Bina, which expands to the vessels. From the two couplings made in the Rosh in the phase of male and female extend 1. The renewal of the coarseness in the screen and records until they are suitable for a coupling by striking with the upper light, 2. The manifestation of the coarseness in the screen and records. Their exit from the Rosh and their coming to their corresponding phase in the Guf of AB, meaning in phase two, called Chazeh, stem from the manifestation of the coarseness of Guf in the screen and records. Two: They make another two couplings there in the Chazeh of AB, like their attribute, which they made in the Rosh. Four actions stem from the two couplings of male and female made in the Chazeh of AB: 1. Ten Sefirot of Rosh emerge from the Chazeh up to the Peh of Partzuf AB on the level of Bina, which is the phase of female, from which there is an expansion to the vessels of the Partzuf. However, there is also the level of Hochma there, which is the male of the Partzuf, which has no expansion to the vessels. 2. The ten Sefirot from the Chazeh of AB downward that expand in the vessels of Keter of the Guf to the Tabur of Partzuf Galgalta, where that expansion stops. 3. The expansion of the nine lower Sefirot down to the Sium Raglayim of Galgalta of AK, called dots of SAG. 4. The screen of Tabur from which the ten Sefirot of Sium expand. This expansion of Rosh-Toch-Sof is called Partzuf SAG of AK. The clash of surrounding light and inner light is extended from the screen of Tabur of SAG. The refinement of the screen until it equalizes with Malchut of Rosh is extended from the clash of surrounding light and inner light to receive renewal from the coupling of Rosh there. The second is the incorporation of the screen in two kinds of records: records that are not connected to the records of NHY of the inner AK, and records that are connected to the records of the inner NHY, called dots. In those, the two Heys are connected together: the first Hey and the bottom Hey. The third is the concealment of the record of extension from the last phase. The diminution of the level to phase one is extended from the concealment of the last phase of extension. The second is the turning of the two records into male and female. The ascent of Malchut of Rosh to Nikvey Einayim is extended from the two records that became male and female. The second is the coupling that was made there on phase two of clothing, which is the phase of male, extending the level of Bina, from which there is no expansion to the vessels. Hence, the coupling is made both on the records of tastes and on the records of dots. The third is the second coupling that created the phase of female there, which is on phase one, over which the level of ZA is extended. There is expansion to the vessels from it, and that coupling, too, was made both on the records of tastes and on the records of dots. Three actions stem from the incorporation of the records in the couplings of the Rosh in the Nikvey Einayim: 1. The renewal of the coarseness in the screen and the records that rose from the Guf of SAG and became suitable for a coupling by striking. 2. The elicitation of the Dikna in the form of bottom Hey in the Einayim, and YHV in the AHP. 3. The manifestation of the coarseness of the Guf in the screen and the records. Three Roshim are extended from the descent of the screen to its corresponding phase in the externality of the Guf, as it comes to three places in the Guf: Chazeh, Tabur, and the Sium of the Guf, meaning the Sium Tifferet of AK. From the Chazeh to the Peh of SAG, it elicits the ten Sefirot of the Rosh of the upper MA and BON, and his Guf ends above the Tabur of the inner AK. From Tabur to the Chazeh of SAG, the ten Sefirot of the Rosh of YESHSUT, which is the first Rosh of Nekudim. It elicits a second Rosh from the Sium of the Guf up to Tabur, called GAR of Nekudim, and from the Sium of the Guf downward emerged the Guf of Nekudim, which are the ZAT of Nekudim. All of them contain male and female: The level of male is up to Bina, and the level of female is up to ZA. The second is the departure of the AHP from all the degrees. Four actions are extended from the departure of the AHP from all the degrees: 1. The diminution of Atzilut only on Keter and Hochma, since the AHP of the degree departed from it, and are considered its Beria. 2. The correction of the Parsa. 3. A new boundary for the Sium of the line of Ein Sof in the place of Bina of NHY of AK, where Bina, ZA, and Malchut of the NHY of AK are below the point of the Sium of the line of Ein Sof. This is called the second restriction. 4. The three Sefirot of NHY of AK that departed below the point of the second restriction became the place for the three separated worlds called BYA. Bina became the place of the world of Beria; ZA, the place of the world of Yetzira; Malchut, for the world of Assiya.",
+      "anchors": []
+    },
+    {
+      "n": 28,
+      "sefariaRef": "Talmud Eser HaSefirot, Section VI, List of Answers on Cause and Effect 165:1",
+      "html": "1. The place where the restriction took place. 2. The records that remained after the restriction. 3. The ten Sefirot of circles. 4. The screen in the vessel of Malchut. 5. The extension of light once more. 6. The coupling by striking with the upper light. 7. The reflected light that became a garment and a vessel for the upper light. 8. The ten Sefirot of straightness from below upward, which are the beginning of the line. 9. The expansion of Malchut of the Rosh from above downward in the ten Sefirot from her and within her down to Tabur, which are the Toch of the line. 10. The expansion of the screen of Tabur in the ten Sefirot of Sium, where from Malchut of the Sium downward, it is darkness and not light.",
+      "anchors": []
+    },
+    {
+      "n": 29,
+      "sefariaRef": "Talmud Eser HaSefirot, Section VI, List of Answers on Cause and Effect 166:1",
+      "html": "Four actions were extended by the departure of light on all four phases: the place for the worlds; the records, which are the ten Sefirot of circles; the awakening for the extension of light once more; the correction of the screen. The screen causes two actions: a coupling by striking and raising reflected light. The coupling by striking and the reflected light cause four actions: Rosh-Toch-Sof, and the point of restriction that ends the line.",
+      "anchors": []
+    },
+    {
+      "n": 30,
+      "sefariaRef": "Talmud Eser HaSefirot, Section VI, List of Answers on Cause and Effect 167:1",
+      "html": "1. The clash of surrounding light and inner light. 2. The refinement of the screen. 3. The incorporation of the screen in the records of the ten Sefirot of the Guf. 4. The two upper records: male and female. 5. Two kinds of coupling in the screen of the Rosh. 6. The renewal of the coarseness in the screen and the records. 7. The recognition of the coarseness of the Guf in them. 8. The concealment of the record of the last phase from them. 9. Their departure from the Rosh. 10. Their arrival at the externality of the Guf of the previous Partzuf at the place of the Chazeh. 11. The coupling by striking made in the screen at the place of the Chazeh, extending the ten Sefirot of the Rosh. 12. The expansion of Malchut of the Rosh from the Chazeh downward. 13. Its clothing of the previous Partzuf. 14. Its beginning from the Peh of the upper one. (Inner Observation, Item 11)",
+      "anchors": []
+    },
+    {
+      "n": 31,
+      "sefariaRef": "Talmud Eser HaSefirot, Section VI, List of Answers on Cause and Effect 168:1",
+      "html": "The clash of surrounding light and inner light causes three actions: the refinement of the screen, the incorporation of the screen in the records, and the concealment of the last phase. The concealment of the last phase causes two actions: two records ZON, and two new couplings in the Rosh. The incorporation in the coupling of the Rosh causes the manifestation of the coarseness of the Guf. The manifestation of the coarseness of the Guf causes three actions: the exit from the Rosh, the arrival at its corresponding phase in the externality of the Guf, and the new coupling at the place of the Chazeh. Three actions stem from the coupling in the Chazeh: Rosh-Toch-Sof. Two actions stem from the refinement of the screen and the departure of the lights of the Guf: the clothing of the lower one on the upper one, and the beginning of the level of the lower one from the Peh of the upper one.",
+      "anchors": []
+    },
+    {
+      "n": 32,
+      "sefariaRef": "Talmud Eser HaSefirot, Section VI, List of Answers on Cause and Effect 169:1",
+      "html": "The descent of the dots of SAG below Tabur of the inner AK, and the division of the Partzuf into tastes and dots.",
+      "anchors": []
+    },
+    {
+      "n": 33,
+      "sefariaRef": "Talmud Eser HaSefirot, Section VI, List of Answers on Cause and Effect 170:1",
+      "html": "See Inner Observation, Item 31",
+      "anchors": []
+    },
+    {
+      "n": 34,
+      "sefariaRef": "Talmud Eser HaSefirot, Section VI, List of Answers on Cause and Effect 171:1",
+      "html": "See Inner Observation, Items 32 through 35.",
+      "anchors": []
+    }
+  ]
+}

--- a/content/parts/part-06/chapters/questions-cause-effect-01/source.en-bb.json
+++ b/content/parts/part-06/chapters/questions-cause-effect-01/source.en-bb.json
@@ -1,0 +1,212 @@
+{
+  "chapterId": "part-06/questions-cause-effect-01",
+  "layer": "source",
+  "versionId": "en-bb",
+  "sefariaRef": "Talmud Eser HaSefirot, Section VI, List of Questions on Cause and Effect",
+  "items": [
+    {
+      "n": 1,
+      "sefariaRef": "Talmud Eser HaSefirot, Section VI, List of Questions on Cause and Effect 138",
+      "html": "What eventuates from the yearning of Malchut of Ein Sof for greater adhesion with the upper light?",
+      "anchors": []
+    },
+    {
+      "n": 2,
+      "sefariaRef": "Talmud Eser HaSefirot, Section VI, List of Questions on Cause and Effect 139",
+      "html": "What eventuates from the departure of the light from all four phases?",
+      "anchors": []
+    },
+    {
+      "n": 3,
+      "sefariaRef": "Talmud Eser HaSefirot, Section VI, List of Questions on Cause and Effect 140",
+      "html": "What eventuates from the screen?",
+      "anchors": []
+    },
+    {
+      "n": 4,
+      "sefariaRef": "Talmud Eser HaSefirot, Section VI, List of Questions on Cause and Effect 141",
+      "html": "What eventuates from the reflected light?",
+      "anchors": []
+    },
+    {
+      "n": 5,
+      "sefariaRef": "Talmud Eser HaSefirot, Section VI, List of Questions on Cause and Effect 142",
+      "html": "What eventuates from the screen of Tabur of Galgalta?",
+      "anchors": []
+    },
+    {
+      "n": 6,
+      "sefariaRef": "Talmud Eser HaSefirot, Section VI, List of Questions on Cause and Effect 143",
+      "html": "What eventuates from the clash of surrounding light with inner light in Partzuf Galgalta?",
+      "anchors": []
+    },
+    {
+      "n": 7,
+      "sefariaRef": "Talmud Eser HaSefirot, Section VI, List of Questions on Cause and Effect 144",
+      "html": "What eventuates from the disappearance of the last phase?",
+      "anchors": []
+    },
+    {
+      "n": 8,
+      "sefariaRef": "Talmud Eser HaSefirot, Section VI, List of Questions on Cause and Effect 145",
+      "html": "What eventuates from of the two records male and female that rose from the Guf of Galgalta?",
+      "anchors": []
+    },
+    {
+      "n": 9,
+      "sefariaRef": "Talmud Eser HaSefirot, Section VI, List of Questions on Cause and Effect 146",
+      "html": "What eventuates from the two couplings of ZON that the screen makes in its incorporation in Hotem in the Rosh of Galgalta?",
+      "anchors": []
+    },
+    {
+      "n": 10,
+      "sefariaRef": "Talmud Eser HaSefirot, Section VI, List of Questions on Cause and Effect 147",
+      "html": "What eventuates from the manifestation of the coarseness of Guf in the screen and the records?",
+      "anchors": []
+    },
+    {
+      "n": 11,
+      "sefariaRef": "Talmud Eser HaSefirot, Section VI, List of Questions on Cause and Effect 148",
+      "html": "What eventuates from the two couplings that the screen makes in the place of Chazeh of Galgalta?",
+      "anchors": []
+    },
+    {
+      "n": 12,
+      "sefariaRef": "Talmud Eser HaSefirot, Section VI, List of Questions on Cause and Effect 149",
+      "html": "What eventuates from the screen of Tabur of AB?",
+      "anchors": []
+    },
+    {
+      "n": 13,
+      "sefariaRef": "Talmud Eser HaSefirot, Section VI, List of Questions on Cause and Effect 150",
+      "html": "What eventuates from the clash of surrounding light with the inner light of AB?",
+      "anchors": []
+    },
+    {
+      "n": 14,
+      "sefariaRef": "Talmud Eser HaSefirot, Section VI, List of Questions on Cause and Effect 151",
+      "html": "What eventuates from the disappearance of the last phase of AB?",
+      "anchors": []
+    },
+    {
+      "n": 15,
+      "sefariaRef": "Talmud Eser HaSefirot, Section VI, List of Questions on Cause and Effect 152",
+      "html": "What eventuates from the two records male and female that rose from the departure of AB?",
+      "anchors": []
+    },
+    {
+      "n": 16,
+      "sefariaRef": "Talmud Eser HaSefirot, Section VI, List of Questions on Cause and Effect 153",
+      "html": "What eventuates from the two couplings of ZON that the screen made in its incorporation in the Ozen of the Rosh of AB?",
+      "anchors": []
+    },
+    {
+      "n": 17,
+      "sefariaRef": "Talmud Eser HaSefirot, Section VI, List of Questions on Cause and Effect 154",
+      "html": "What eventuates from the manifestation of the coarseness of the Guf in the screen?",
+      "anchors": []
+    },
+    {
+      "n": 18,
+      "sefariaRef": "Talmud Eser HaSefirot, Section VI, List of Questions on Cause and Effect 155",
+      "html": "What eventuates from the two couplings that the screen makes at the place of the Chazeh of AB?",
+      "anchors": []
+    },
+    {
+      "n": 19,
+      "sefariaRef": "Talmud Eser HaSefirot, Section VI, List of Questions on Cause and Effect 156",
+      "html": "What eventuates from the screen of Tabur of SAG?",
+      "anchors": []
+    },
+    {
+      "n": 20,
+      "sefariaRef": "Talmud Eser HaSefirot, Section VI, List of Questions on Cause and Effect 157",
+      "html": "What eventuates from the clash of surrounding light with the inner light of SAG?",
+      "anchors": []
+    },
+    {
+      "n": 21,
+      "sefariaRef": "Talmud Eser HaSefirot, Section VI, List of Questions on Cause and Effect 158",
+      "html": "What eventuates from the concealing of the last phase of SAG?",
+      "anchors": []
+    },
+    {
+      "n": 22,
+      "sefariaRef": "Talmud Eser HaSefirot, Section VI, List of Questions on Cause and Effect 159",
+      "html": "What eventuates from the two records of ZON that rose in the Nikvey Einayim of the Rosh of SAG?",
+      "anchors": []
+    },
+    {
+      "n": 23,
+      "sefariaRef": "Talmud Eser HaSefirot, Section VI, List of Questions on Cause and Effect 160",
+      "html": "What eventuates from the incorporation of the records in the couplings in the Nikvey Einayim of the Rosh of SAG?",
+      "anchors": []
+    },
+    {
+      "n": 24,
+      "sefariaRef": "Talmud Eser HaSefirot, Section VI, List of Questions on Cause and Effect 161",
+      "html": "What eventuates from the manifestation of coarseness of the Guf in the screen and the records?",
+      "anchors": []
+    },
+    {
+      "n": 25,
+      "sefariaRef": "Talmud Eser HaSefirot, Section VI, List of Questions on Cause and Effect 162",
+      "html": "What eventuates from the descent of the screen to its corresponding phases in the externality of the Guf of SAG?",
+      "anchors": []
+    },
+    {
+      "n": 26,
+      "sefariaRef": "Talmud Eser HaSefirot, Section VI, List of Questions on Cause and Effect 163",
+      "html": "What eventuates from the elicitation of the AHP from all the degrees?",
+      "anchors": []
+    },
+    {
+      "n": 27,
+      "sefariaRef": "Talmud Eser HaSefirot, Section VI, List of Questions on Cause and Effect 164",
+      "html": "How are the actions connected to one another through cause and consequence from the first restriction to the end of the world of Nekudim in Katnut?",
+      "anchors": []
+    },
+    {
+      "n": 28,
+      "sefariaRef": "Talmud Eser HaSefirot, Section VI, List of Questions on Cause and Effect 165",
+      "html": "What ten actions were taken up to the completion of Partzuf Galgalta of AK?",
+      "anchors": []
+    },
+    {
+      "n": 29,
+      "sefariaRef": "Talmud Eser HaSefirot, Section VI, List of Questions on Cause and Effect 166",
+      "html": "How are the ten actions connected to each other by cause and consequence?",
+      "anchors": []
+    },
+    {
+      "n": 30,
+      "sefariaRef": "Talmud Eser HaSefirot, Section VI, List of Questions on Cause and Effect 167",
+      "html": "What are the fourteen actions applied in the emanation of a Partzuf in general?",
+      "anchors": []
+    },
+    {
+      "n": 31,
+      "sefariaRef": "Talmud Eser HaSefirot, Section VI, List of Questions on Cause and Effect 168",
+      "html": "How are the fourteen actions in the emanation of the Partzuf connected to each other?",
+      "anchors": []
+    },
+    {
+      "n": 32,
+      "sefariaRef": "Talmud Eser HaSefirot, Section VI, List of Questions on Cause and Effect 169",
+      "html": "What are the two actions added in Partzuf SAG?",
+      "anchors": []
+    },
+    {
+      "n": 33,
+      "sefariaRef": "Talmud Eser HaSefirot, Section VI, List of Questions on Cause and Effect 170",
+      "html": "What are the thirteen actions added in Partzuf Nekudim?",
+      "anchors": []
+    },
+    {
+      "n": 34,
+      "sefariaRef": "Talmud Eser HaSefirot, Section VI, List of Questions on Cause and Effect 171",
+      "html": "How are the thirteen actions connected to each other by the above order of cause and consequence?",
+      "anchors": []
+    }
+  ]
+}

--- a/content/toc.json
+++ b/content/toc.json
@@ -4597,6 +4597,7 @@
               "availableVersions": {
                 "summary": [],
                 "source": [
+                  "en-bb",
                   "he-jerusalem-1956"
                 ],
                 "commentary": []
@@ -4656,6 +4657,7 @@
               "availableVersions": {
                 "summary": [],
                 "source": [
+                  "en-bb",
                   "he-jerusalem-1956"
                 ],
                 "commentary": []

--- a/content/toc.parts/part-06.json
+++ b/content/toc.parts/part-06.json
@@ -1304,6 +1304,7 @@
       "availableVersions": {
         "summary": [],
         "source": [
+          "en-bb",
           "he-jerusalem-1956"
         ],
         "commentary": []
@@ -1365,6 +1366,7 @@
       "availableVersions": {
         "summary": [],
         "source": [
+          "en-bb",
           "he-jerusalem-1956"
         ],
         "commentary": []

--- a/content/toc.volumes.json
+++ b/content/toc.volumes.json
@@ -208,7 +208,7 @@
           },
           "availableSummary": {
             "he": "full",
-            "en": "partial"
+            "en": "full"
           }
         },
         {

--- a/scripts/import-kabbalahmedia.ts
+++ b/scripts/import-kabbalahmedia.ts
@@ -130,10 +130,12 @@ import {
   indexKmTreePartsByNumber,
   KM_TES_COLLECTION_UID,
   parseKmChapterLeafNumber,
+  type KmLeafRole,
   type KmSqData,
   type KmTreeArticle,
   type KmTreePart,
 } from "./lib/km-tree.ts";
+import { firstSegmentPerAnswer } from "./lib/qa-consolidation.ts";
 import { writeTocSplitFiles } from "./lib/toc-splits.ts";
 import { validateContent } from "./validate-content.ts";
 
@@ -833,9 +835,23 @@ const processQaDialect = async (
   languages: Map<string, LanguageAccumulator>,
   client: HttpClient,
 ): Promise<void> => {
+  // Post-#91 there is exactly one answers chapter per kind. More than one
+  // means the tree predates the consolidation this importer now writes, and
+  // aligning against it would produce a shape nothing else in the corpus
+  // has — report rather than guess.
+  if (answersChapters.length > 1) {
+    for (const acc of languages.values()) {
+      acc.warnings.push(
+        `${partId} Q&A: ${answersChapters.length} answers chapters of one kind — expected the single consolidated chapter (#91); skipped`,
+      );
+    }
+    return;
+  }
+  const answersChapter = answersChapters[0];
+
   const targetChapterIds = [
     ...(questionsChapter ? [questionsChapter.id] : []),
-    ...answersChapters.map((c) => c.id),
+    ...(answersChapter ? [answersChapter.id] : []),
   ];
   if (targetChapterIds.length === 0 || candidateUids.length === 0) return;
 
@@ -851,22 +867,15 @@ const processQaDialect = async (
       )
     : undefined;
 
-  const answersGroundEntries = answersChapters
-    .map((chapter) => {
-      const dir = chapterDirFor(partId, chapter.id.split("/")[1] as string);
-      const heSegments = readHeSourceSegmentsOptional(dir);
-      return heSegments?.[0]
-        ? { number: chapter.number, sefariaRef: heSegments[0].sefariaRef }
-        : undefined;
-    })
-    .filter((entry): entry is { number: number; sefariaRef: string } =>
-      Boolean(entry),
-    );
-  const answersGroundSegments =
-    buildOrderAlignedGroundSegments(answersGroundEntries);
-  const answersChapterByNumber = new Map(
-    answersChapters.map((c) => [c.number, c]),
-  );
+  const answersDir = answersChapter
+    ? chapterDirFor(partId, answersChapter.id.split("/")[1] as string)
+    : undefined;
+  const answersGroundSegments = answersDir
+    ? firstSegmentPerAnswer(readHeSourceSegmentsOptional(answersDir) ?? [])
+    : [];
+  const answersSefariaRef = answersDir
+    ? heSefariaRef(answersDir, "source.he-jerusalem-1956.json")
+    : undefined;
   const emptyGroundTruth = buildKmChapterGroundTruth([]);
 
   const docFilesByLanguage = await collectKmDocFilesByLanguage(
@@ -906,7 +915,7 @@ const processQaDialect = async (
         const alignmentError = validateKmQaPairs(
           pairs,
           questionsHeItems?.length ?? 0,
-          answersGroundEntries.length,
+          answersGroundSegments.length,
         );
         return alignmentError
           ? { ok: false, kind: "unmatched", reason: alignmentError }
@@ -975,37 +984,35 @@ const processQaDialect = async (
       }
     }
 
-    // Answers half: N single-item chapters, split positionally.
-    const { segments: answerSegments, warnings: answerWarnings } =
-      buildKmSourceSegments(
+    // Answers half: one consolidated chapter (#91), one item per answer —
+    // the same shape, and the same call, as the questions half above.
+    if (answersChapter) {
+      const { segments, warnings } = buildKmSourceSegments(
         pairs.map((p) => ({ n: p.position, html: p.answerHtml })),
         answersGroundSegments,
         emptyGroundTruth,
       );
-    acc.warnings.push(
-      ...answerWarnings.map((w) => `${partId} answers: ${w.message}`),
-    );
-    const answersBySplit = splitOrderAlignedSegments(answerSegments);
-    for (const chapter of answersChapterByNumber.values()) {
-      const segment = answersBySplit.get(chapter.number);
-      if (!segment) {
+      acc.warnings.push(
+        ...warnings.map((w) => `${answersChapter.id} answers: ${w.message}`),
+      );
+      if (segments.length > 0) {
         acc.chapters.push({
-          chapterId: chapter.id,
+          chapterId: answersChapter.id,
+          status: "imported",
+          ...zeroCounts,
+          sourceSegments: segments.length,
+        });
+        acc.sourceByChapter.set(answersChapter.id, {
+          sefariaRef: answersSefariaRef,
+          segments,
+        });
+      } else {
+        acc.chapters.push({
+          chapterId: answersChapter.id,
           status: "unmatched",
           ...zeroCounts,
         });
-        continue;
       }
-      acc.chapters.push({
-        chapterId: chapter.id,
-        status: "imported",
-        ...zeroCounts,
-        sourceSegments: 1,
-      });
-      acc.sourceByChapter.set(chapter.id, {
-        sefariaRef: segment.sefariaRef,
-        segments: [segment],
-      });
     }
   }
 };
@@ -1061,6 +1068,13 @@ const processPart = async (
     tocPartChapters,
     "inner-observation",
   );
+  for (const article of articlesByRole.get("cause-and-consequence-essay") ??
+    []) {
+    chapterLevelWarnings.push(
+      `${partId}: KabbalahMedia leaf "${article.name}" (${article.id}) is the Cause and Consequence essay — already in the corpus as inner-observation-02 from Sefaria; not imported here`,
+    );
+  }
+
   for (const article of articlesByRole.get("inner-observation") ?? []) {
     await recordUnsupportedDialect(
       article.id,
@@ -1131,8 +1145,8 @@ const processPart = async (
 
   // Dialect 3: combined Q&A tables (terminology, topics).
   const qaFamilies: {
-    questionsRole: "questions-terminology" | "questions-topics";
-    answersRole: "answers-terminology" | "answers-topics";
+    questionsRole: KmLeafRole;
+    answersRole: KmLeafRole;
     questionsKind: ChapterKind;
     answersKind: ChapterKind;
   }[] = [
@@ -1147,6 +1161,15 @@ const processPart = async (
       answersRole: "answers-topics",
       questionsKind: "questions-topics",
       answersKind: "answers-topics",
+    },
+    // Section VI only — the one part with a Cause-and-Effect table
+    // (issue #86). Every other part simply has no article under these
+    // roles, so the family costs nothing there.
+    {
+      questionsRole: "questions-cause-effect",
+      answersRole: "answers-cause-effect",
+      questionsKind: "questions-cause-effect",
+      answersKind: "answers-cause-effect",
     },
   ];
 
@@ -1243,6 +1266,33 @@ export const main = async (argv: string[]): Promise<void> => {
     .filter((version) => version.source === "kabbalahmedia")
     .map((version) => version.id);
   let staleOutputs = 0;
+  let keptDespiteRefusal = 0;
+
+  /**
+   * Chapters this run looked at and declined to write, per version.
+   *
+   * "This run produced no file" has two very different causes: upstream no
+   * longer offers the chapter, or the importer refused it — an alignment it
+   * could not verify, a document dialect it does not parse, a language whose
+   * file was missing this time. Only the first is stale. Treating both the
+   * same deleted committed English whenever a refusal happened, so a run
+   * meant to *add* a translation silently subtracted four of them (#111).
+   *
+   * The importer records an outcome for every chapter it considered, so a
+   * non-`imported` outcome is exactly the evidence that its absence is a
+   * refusal rather than an absence upstream.
+   */
+  const refusedByVersion = new Map<string, Set<string>>();
+  for (const acc of languages.values()) {
+    refusedByVersion.set(
+      acc.versionId,
+      new Set(
+        acc.chapters
+          .filter((outcome) => outcome.status !== "imported")
+          .map((outcome) => outcome.chapterId),
+      ),
+    );
+  }
 
   for (const chapter of tocChapterIndex.values()) {
     const [partId, slug] = chapter.id.split("/") as [string, string];
@@ -1265,6 +1315,15 @@ export const main = async (argv: string[]): Promise<void> => {
       for (const { layer, desired } of layers) {
         const path = join(dir, `${layer}.${versionId}.json`);
         if (desired || !existsSync(path)) continue;
+
+        if (refusedByVersion.get(versionId)?.has(chapter.id)) {
+          keptDespiteRefusal += 1;
+          console.warn(
+            `Kept ${path}: this run declined to write it, which is not evidence it is gone upstream.`,
+          );
+          continue;
+        }
+
         staleOutputs += 1;
         if (args.dryRun) {
           console.log(`Would remove stale KabbalahMedia output: ${path}`);
@@ -1274,6 +1333,11 @@ export const main = async (argv: string[]): Promise<void> => {
         removeKmVersionAvailability(chapter, layer, versionId);
       }
     }
+  }
+  if (keptDespiteRefusal > 0) {
+    console.warn(
+      `\nKept ${keptDespiteRefusal} committed KabbalahMedia file(s) this run could not reproduce.`,
+    );
   }
   if (staleOutputs > 0) {
     console.log(

--- a/scripts/lib/km-tree.ts
+++ b/scripts/lib/km-tree.ts
@@ -131,10 +131,13 @@ export type KmLeafRole =
   | "chapter"
   | "whole-part"
   | "inner-observation"
+  | "cause-and-consequence-essay"
   | "questions-terminology"
   | "questions-topics"
+  | "questions-cause-effect"
   | "answers-terminology"
   | "answers-topics"
+  | "answers-cause-effect"
   | "unmapped";
 
 const ROLE_BY_ARTICLE_NAME: Record<string, KmLeafRole> = {
@@ -143,6 +146,19 @@ const ROLE_BY_ARTICLE_NAME: Record<string, KmLeafRole> = {
   "Table of Questions for Topics": "questions-topics",
   "Table of Answers for the Meaning of the Words": "answers-terminology",
   "Table of Answers for Topics": "answers-topics",
+  // Bnei Baruch call this family "Cause and Consequence" where Sefaria
+  // calls it "Cause and Effect" (issue #86). The essay under that name is
+  // Sefaria's `Histaklut Penimit 2` and is already in the corpus as
+  // `inner-observation-02`, imported from there and confirmed word for word
+  // against this very document. It gets a role of its own rather than
+  // `inner-observation`: that role means "the part's Inner Observation
+  // document", and two leaves claiming it made the importer record two
+  // outcomes for one chapter — which its own coverage guard rejects, quite
+  // rightly. Known, accounted for, and imported by nobody here.
+  "Cause and Consequence": "cause-and-consequence-essay",
+  "Questions Regarding Cause and Consequence": "questions-cause-effect",
+  "Answers of Questions Regarding Cause and Consequence":
+    "answers-cause-effect",
 };
 
 /**
@@ -154,10 +170,7 @@ const ROLE_BY_ARTICLE_NAME: Record<string, KmLeafRole> = {
  * this importer — its KabbalahMedia doc structure has been seen to vary
  * per part (verified: Part 1 uses bare `"N)"` markers with no real
  * headings, Part 2 uses `"N."` markers under real heading levels), so it is
- * reported rather than force-parsed against an unverified shape. The Cause/
- * Consequence family has no `ChapterKind` at all yet (see
- * `sefaria-index.ts`'s `mapNodeTitleToKind` for the same situation on the
- * Sefaria side) and falls through to `"unmapped"`.
+ * reported rather than force-parsed against an unverified shape.
  */
 export const classifyKmArticle = (
   articleName: string,

--- a/scripts/lib/qa-consolidation.ts
+++ b/scripts/lib/qa-consolidation.ts
@@ -29,6 +29,30 @@ export const isConsolidatedQaKind = (kind: ChapterKind): boolean =>
   CONSOLIDATED_QA_KINDS.includes(kind);
 
 /**
+ * The first stored segment of each answer, in answer order.
+ *
+ * Consolidation gave every item the answer number as its `n`, and the rare
+ * answer that upstream splits across several segments keeps one `n` across
+ * several items (told apart by `sefariaRef`). Anything aligning *answers*
+ * against this chapter — a KabbalahMedia document has one block per answer,
+ * not per segment — needs one entry per answer, and the entry that carries
+ * the citation an answer's text belongs to is its first.
+ *
+ * `checkSourceConsolidatedQaSubset` in `validate-content.ts` is the other
+ * half of this contract: a translation may cover an answer once, provided it
+ * carries the `sefariaRef` and anchors of the segment it matched.
+ */
+export const firstSegmentPerAnswer = (
+  segments: readonly SourceSegment[],
+): SourceSegment[] => {
+  const byAnswer = new Map<number, SourceSegment>();
+  for (const segment of segments) {
+    if (!byAnswer.has(segment.n)) byAnswer.set(segment.n, segment);
+  }
+  return [...byAnswer.values()].sort((a, b) => a.n - b.n);
+};
+
+/**
  * One per-answer chapter's own ordinal (its printed "answer number", e.g.
  * `answers-terminology-06` -> `6`) and its own segments — each segment still
  * carrying the *local* `n` it had inside its own one-answer file (almost

--- a/tests/e2e/reader.spec.ts
+++ b/tests/e2e/reader.spec.ts
@@ -51,8 +51,30 @@ test("serves the aligned English reader and synchronizes Ari anchors", async ({
   await expect(innerLight.locator("#op-1")).toContainText("spiritual time");
   await expect(innerObservation.locator("li").first()).not.toBeEmpty();
 
+  // The highlight is a flash: ~900ms under reduced motion, two frames
+  // without it. Polling for the class is a race with its own removal — it
+  // failed once under four-worker contention where it passes 5/5 solo. Watch
+  // for the transition instead of sampling for it, which is deterministic
+  // and asserts the same thing.
+  await innerLight.locator("#op-1").evaluate((el) => {
+    (window as unknown as { __flashed?: boolean }).__flashed = false;
+    new MutationObserver(() => {
+      if (/is-highlighted/.test(el.className)) {
+        (window as unknown as { __flashed?: boolean }).__flashed = true;
+      }
+    }).observe(el, { attributes: true, attributeFilter: ["class"] });
+  });
+
   await source.locator('[data-anchor="op-1"]').click();
-  await expect(innerLight.locator("#op-1")).toHaveClass(/is-highlighted/);
+
+  await expect
+    .poll(() =>
+      page.evaluate(
+        () => (window as unknown as { __flashed?: boolean }).__flashed,
+      ),
+    )
+    .toBe(true);
+  await expect(innerLight.locator("#op-1")).toBeInViewport();
 });
 
 test("switches languages, identifies AI text, and supports themes", async ({

--- a/tests/unit/import-kabbalahmedia.spec.ts
+++ b/tests/unit/import-kabbalahmedia.spec.ts
@@ -1138,12 +1138,28 @@ describe("classifyKmArticle", () => {
     ["Table of Questions for Topics", "questions-topics"],
     ["Table of Answers for the Meaning of the Words", "answers-terminology"],
     ["Table of Answers for Topics", "answers-topics"],
+    // Bnei Baruch's name for Sefaria's "Cause and Effect" (issue #86).
+    ["Questions Regarding Cause and Consequence", "questions-cause-effect"],
+    [
+      "Answers of Questions Regarding Cause and Consequence",
+      "answers-cause-effect",
+    ],
   ] as const)("classifies %s as %s", (name, role) => {
     expect(classifyKmArticle(name, "Part 1")).toBe(role);
   });
 
-  it("classifies an unrecognized leaf name as unmapped, never guessed", () => {
+  it("gives the Cause and Consequence essay its own role, not Inner Observation", () => {
+    // It is Sefaria's `Histaklut Penimit 2`, already in the corpus as
+    // `inner-observation-02`. Filing it under the `inner-observation` role
+    // would put two leaves on one chapter, which the importer's own
+    // coverage guard rejects — see `km-tree.ts`.
     expect(classifyKmArticle("Cause and Consequence", "Part 6")).toBe(
+      "cause-and-consequence-essay",
+    );
+  });
+
+  it("classifies an unrecognized leaf name as unmapped, never guessed", () => {
+    expect(classifyKmArticle("Introduction to the Wisdom", "Part 6")).toBe(
       "unmapped",
     );
   });

--- a/tests/unit/qa-consolidation.spec.ts
+++ b/tests/unit/qa-consolidation.spec.ts
@@ -15,6 +15,7 @@ import { hebrewNumeral } from "../../scripts/lib/hebrew-numerals.ts";
 import {
   consolidateAnswerSegments,
   CONSOLIDATED_QA_KINDS,
+  firstSegmentPerAnswer,
   isConsolidatedQaKind,
 } from "../../scripts/lib/qa-consolidation.ts";
 import { buildSourceSegments } from "../../scripts/lib/transform.ts";
@@ -62,6 +63,58 @@ describe("qa-consolidation: CONSOLIDATED_QA_KINDS / isConsolidatedQaKind", () =>
     expect(isConsolidatedQaKind("questions-terminology")).toBe(false);
     expect(isConsolidatedQaKind("questions-cause-effect")).toBe(false);
     expect(isConsolidatedQaKind("chapter")).toBe(false);
+  });
+});
+
+describe("qa-consolidation: firstSegmentPerAnswer", () => {
+  const segment = (n: number, sefariaRef: string) => ({
+    n,
+    sefariaRef,
+    html: sefariaRef,
+    anchors: [],
+  });
+
+  it("returns one entry per answer, in answer order", () => {
+    expect(
+      firstSegmentPerAnswer([segment(2, "b:1"), segment(1, "a:1")]).map(
+        (s) => s.n,
+      ),
+    ).toEqual([1, 2]);
+  });
+
+  it("keeps the FIRST segment of a multi-segment answer, not the last", () => {
+    // `part-01/answers-topics-01` answer 51 is two segments. A
+    // KabbalahMedia document has one block per answer, so it aligns
+    // against the answer — and the citation its text belongs to is where
+    // the answer starts. Taking the last would attach the whole English
+    // answer to its continuation's ref, which
+    // `checkSourceConsolidatedQaSubset` compares against.
+    const kept = firstSegmentPerAnswer([
+      segment(51, "…List of Answers on Topics 51:1"),
+      segment(51, "…List of Answers on Topics 51:2"),
+    ]);
+
+    expect(kept).toHaveLength(1);
+    expect(kept[0]?.sefariaRef).toBe("…List of Answers on Topics 51:1");
+  });
+
+  it("counts answers, not stored items — the number an aligner checks against", () => {
+    // The bug in issue #111 was counting the wrong thing entirely (answer
+    // *chapters*, always 1 post-#91). Items are the other wrong count: a
+    // part with any split answer has more items than answers.
+    const segments = [
+      segment(1, "a:1"),
+      segment(2, "b:1"),
+      segment(2, "b:2"),
+      segment(3, "c:1"),
+    ];
+
+    expect(segments).toHaveLength(4);
+    expect(firstSegmentPerAnswer(segments)).toHaveLength(3);
+  });
+
+  it("is empty for a chapter with no committed Hebrew", () => {
+    expect(firstSegmentPerAnswer([])).toEqual([]);
   });
 });
 


### PR DESCRIPTION
Closes #111. Also unblocks #86's English half, which was waiting on exactly this.

## Measured, against the same tree

| | before | after |
|---|---|---|
| committed files the sweep deletes | **16** | **0** |
| en-bb chapters imported | 66 / 2090 | **84 / 2090** |
| en-bb source segments | 80 | **1,474** |

`import:kabbalahmedia --part 6` now reproduces the committed English Q&A **byte-for-byte** — `git diff` empty — where before it refused it and removed the files.

## 1. The answers half still wrote the pre-#91 shape

It aligned a document's blocks against the number of answer *chapters*. Consolidation folded those to one per kind, so the check compared 30 parsed pairs against 1 and could never pass:

```
en-bb: part-06 Q&A candidate: pair count 30 does not match Hebrew questions (30) and answer chapters (1)
```

Read that line: the pairs matched the questions exactly. Only the third term was wrong.

It now aligns against `firstSegmentPerAnswer` — one entry per answer, keeping the segment the answer *starts* at. That matters because a handful of answers are split across several stored items sharing one `n`, and `checkSourceConsolidatedQaSubset` compares the translation's `sefariaRef` against the segment it matched. The answers half is now the same `buildKmSourceSegments` call as the questions half, instead of a positional split into single-item chapters.

The helper lives in `qa-consolidation.ts` — the module that created the multi-segment shape owns the rule for reading it back — with tests for the cases that bite: order, which segment of a split answer survives, and that it counts answers rather than items.

## 2. A refusal deleted committed content

The stale-output sweep removes committed KabbalahMedia files a run did not produce. But "did not produce" also covers every refusal — an alignment it could not verify, a dialect it does not parse, a language whose file was missing today. So a `--part N` run intended to *add* a translation silently subtracted four.

The importer already records an outcome for every chapter it considered, so a non-`imported` outcome is precisely the evidence that an absence is a refusal rather than an absence upstream. The sweep now skips those and names them.

## 3. Cause and Consequence (#86)

With alignment fixed, Bnei Baruch's leaves map to the kinds #86 added: **34 questions and 34 answers** of part 6's Cause and Effect table, in English, refs already carrying the index offset (`…Cause and Effect 138`). Spot-checked against the Hebrew: *"What eventuates from the yearning of Malchut of Ein Sof for greater adhesion with the upper light?"* against `מה מסובב מהחשק דמלכות דא״ס, אל יתר דבקות באור העליון`.

The **essay** of that name gets a role of its own rather than `inner-observation`. It is Sefaria's `Histaklut Penimit 2`, already in the corpus as `inner-observation-02` — and filing it under the Inner Observation role put two leaves on one chapter, which the importer's own coverage guard rejected. It was right to; the guard caught my first attempt.

## Found on the way, not fixed here

`import:kabbalahmedia --all` still cannot complete: it fails its own validation on content it just wrote, because the KM importer invents `label.en` (`"11"`) where the tree holds the printed marker (`"20"`). That is **#110**, which I've updated with the new evidence — it is three faults, not one, and the Sefaria importer disagrees in the opposite direction. This PR therefore keeps the refreshed `COVERAGE.md` and restores the four files that run mangled.

## Verification

- `task check` green: 921 unit tests (4 new), content validation, full generate, 9/9 e2e.
- Full-corpus `--all --dry-run` on both branches for the table above.
- Also made the anchor-highlight e2e deterministic. It sampled for a class the product removes after ~900ms and failed once under four-worker contention while passing 5/5 solo; it now observes the transition instead of racing it. 3x9 green at `--workers=4`.