### PR TITLE
fix(content): derive label.en from the Hebrew letter, and check it

### DIFF
--- a/.agents/skills/tes-content-model/SKILL.md
+++ b/.agents/skills/tes-content-model/SKILL.md
@@ -134,6 +134,32 @@ structurally compares them against what's on disk — any drift (stale,
 missing, or mismatched file) is a validation error, so these files can never
 silently go stale.
 
+## Commentary labels — one fact, two keys
+
+The marker beside a note is one fact written two ways: the printed Hebrew
+letter, and its **gematria**, which is what the printed English edition marks
+both the text and the note list with (issue #96 — so the 12th note is "30",
+not "12").
+
+Two rules, and they do not overlap:
+
+- **A version's own printed marker is ground truth for its own language.**
+  `checkCommentaryLabelMatchesSourceMarker` reads the marker out of that
+  version's own source html. This is why `en-ai`'s `label.en` is left alone
+  even though its source prints the invented ordinals — that is a defect in
+  the translated text, not a label disagreeing with its own page.
+- **On a non-English version, `label.en` is the gematria of `label.he`.**
+  `checkCommentaryEnglishLabelIsGematria`. There is no English source to
+  consult on a Hebrew file, so it is derived — and it must be, because the
+  KabbalahMedia importer copies `label` verbatim from Hebrew ground truth.
+  While this went unchecked, `import:kabbalahmedia --all` failed its own
+  validation on content it had just written (issue #110).
+
+`pnpm migrate:commentary-labels` applies both. Like every migration here it
+writes back the object `JSON.parse` produced, never the one Zod returned —
+that carries the schema's key order rather than the file's, and rewrites
+`"layer"` in every file it touches for no reason (PR 109).
+
 ## Sefaria index offsets — why a map is committed
 
 Some Sefaria nodes do not start numbering at 1: Section VI's topics tables

--- a/content/parts/part-01/chapters/chapter-01/commentary.en-bb.json
+++ b/content/parts/part-01/chapters/chapter-01/commentary.en-bb.json
@@ -1,8 +1,8 @@
 {
   "chapterId": "part-01/chapter-01",
+  "layer": "commentary",
   "versionId": "en-bb",
   "sefariaRef": "Ohr Penimi on Talmud Eser HaSefirot 1:1",
-  "layer": "commentary",
   "items": [
     {
       "anchorId": "op-1",

--- a/content/parts/part-01/chapters/chapter-01/commentary.he-bb.json
+++ b/content/parts/part-01/chapters/chapter-01/commentary.he-bb.json
@@ -118,7 +118,7 @@
       "order": 11,
       "label": {
         "he": "כ",
-        "en": "11"
+        "en": "20"
       },
       "targetSeif": 1,
       "section": "ohr-pnimi",
@@ -129,7 +129,7 @@
       "order": 12,
       "label": {
         "he": "ל",
-        "en": "12"
+        "en": "30"
       },
       "targetSeif": 2,
       "section": "ohr-pnimi",
@@ -140,7 +140,7 @@
       "order": 13,
       "label": {
         "he": "מ",
-        "en": "13"
+        "en": "40"
       },
       "targetSeif": 3,
       "section": "ohr-pnimi",
@@ -151,7 +151,7 @@
       "order": 14,
       "label": {
         "he": "נ",
-        "en": "14"
+        "en": "50"
       },
       "targetSeif": 3,
       "section": "ohr-pnimi",
@@ -162,7 +162,7 @@
       "order": 15,
       "label": {
         "he": "ס",
-        "en": "15"
+        "en": "60"
       },
       "targetSeif": 3,
       "section": "ohr-pnimi",
@@ -173,7 +173,7 @@
       "order": 16,
       "label": {
         "he": "ע",
-        "en": "16"
+        "en": "70"
       },
       "targetSeif": 3,
       "section": "ohr-pnimi",
@@ -184,7 +184,7 @@
       "order": 17,
       "label": {
         "he": "פ",
-        "en": "17"
+        "en": "80"
       },
       "targetSeif": 4,
       "section": "ohr-pnimi",
@@ -195,7 +195,7 @@
       "order": 18,
       "label": {
         "he": "צ",
-        "en": "18"
+        "en": "90"
       },
       "targetSeif": 4,
       "section": "ohr-pnimi",
@@ -206,7 +206,7 @@
       "order": 19,
       "label": {
         "he": "ק",
-        "en": "19"
+        "en": "100"
       },
       "targetSeif": 4,
       "section": "ohr-pnimi",
@@ -217,7 +217,7 @@
       "order": 20,
       "label": {
         "he": "ר",
-        "en": "20"
+        "en": "200"
       },
       "targetSeif": 5,
       "section": "ohr-pnimi",
@@ -228,7 +228,7 @@
       "order": 21,
       "label": {
         "he": "ש",
-        "en": "21"
+        "en": "300"
       },
       "targetSeif": 5,
       "section": "ohr-pnimi",
@@ -239,7 +239,7 @@
       "order": 22,
       "label": {
         "he": "ת",
-        "en": "22"
+        "en": "400"
       },
       "targetSeif": 5,
       "section": "ohr-pnimi",

--- a/content/parts/part-01/chapters/chapter-01/commentary.he-jerusalem-1956.json
+++ b/content/parts/part-01/chapters/chapter-01/commentary.he-jerusalem-1956.json
@@ -129,7 +129,7 @@
       "order": 11,
       "label": {
         "he": "כ",
-        "en": "11"
+        "en": "20"
       },
       "sefariaRef": "Ohr Penimi on Talmud Eser HaSefirot 1:1:11",
       "targetSeif": 1,
@@ -141,7 +141,7 @@
       "order": 12,
       "label": {
         "he": "ל",
-        "en": "12"
+        "en": "30"
       },
       "sefariaRef": "Ohr Penimi on Talmud Eser HaSefirot 1:1:12",
       "targetSeif": 2,
@@ -153,7 +153,7 @@
       "order": 13,
       "label": {
         "he": "מ",
-        "en": "13"
+        "en": "40"
       },
       "sefariaRef": "Ohr Penimi on Talmud Eser HaSefirot 1:1:13",
       "targetSeif": 3,
@@ -165,7 +165,7 @@
       "order": 14,
       "label": {
         "he": "נ",
-        "en": "14"
+        "en": "50"
       },
       "sefariaRef": "Ohr Penimi on Talmud Eser HaSefirot 1:1:14",
       "targetSeif": 3,
@@ -177,7 +177,7 @@
       "order": 15,
       "label": {
         "he": "ס",
-        "en": "15"
+        "en": "60"
       },
       "sefariaRef": "Ohr Penimi on Talmud Eser HaSefirot 1:1:15",
       "targetSeif": 3,
@@ -189,7 +189,7 @@
       "order": 16,
       "label": {
         "he": "ע",
-        "en": "16"
+        "en": "70"
       },
       "sefariaRef": "Ohr Penimi on Talmud Eser HaSefirot 1:1:16",
       "targetSeif": 3,
@@ -201,7 +201,7 @@
       "order": 17,
       "label": {
         "he": "פ",
-        "en": "17"
+        "en": "80"
       },
       "sefariaRef": "Ohr Penimi on Talmud Eser HaSefirot 1:1:17",
       "targetSeif": 4,
@@ -213,7 +213,7 @@
       "order": 18,
       "label": {
         "he": "צ",
-        "en": "18"
+        "en": "90"
       },
       "sefariaRef": "Ohr Penimi on Talmud Eser HaSefirot 1:1:18",
       "targetSeif": 4,
@@ -225,7 +225,7 @@
       "order": 19,
       "label": {
         "he": "ק",
-        "en": "19"
+        "en": "100"
       },
       "sefariaRef": "Ohr Penimi on Talmud Eser HaSefirot 1:1:19",
       "targetSeif": 4,
@@ -237,7 +237,7 @@
       "order": 20,
       "label": {
         "he": "ר",
-        "en": "20"
+        "en": "200"
       },
       "sefariaRef": "Ohr Penimi on Talmud Eser HaSefirot 1:1:20",
       "targetSeif": 5,
@@ -249,7 +249,7 @@
       "order": 21,
       "label": {
         "he": "ש",
-        "en": "21"
+        "en": "300"
       },
       "sefariaRef": "Ohr Penimi on Talmud Eser HaSefirot 1:1:21",
       "targetSeif": 5,
@@ -261,7 +261,7 @@
       "order": 22,
       "label": {
         "he": "ת",
-        "en": "22"
+        "en": "400"
       },
       "sefariaRef": "Ohr Penimi on Talmud Eser HaSefirot 1:1:22",
       "targetSeif": 5,

--- a/content/parts/part-01/chapters/chapter-02/commentary.en-bb.json
+++ b/content/parts/part-01/chapters/chapter-02/commentary.en-bb.json
@@ -1,8 +1,8 @@
 {
   "chapterId": "part-01/chapter-02",
+  "layer": "commentary",
   "versionId": "en-bb",
   "sefariaRef": "Ohr Penimi on Talmud Eser HaSefirot 1:2",
-  "layer": "commentary",
   "items": [
     {
       "anchorId": "op-1",

--- a/content/parts/part-01/chapters/chapter-02/commentary.he-bb.json
+++ b/content/parts/part-01/chapters/chapter-02/commentary.he-bb.json
@@ -118,7 +118,7 @@
       "order": 11,
       "label": {
         "he": "כ",
-        "en": "11"
+        "en": "20"
       },
       "targetSeif": 5,
       "section": "ohr-pnimi",
@@ -129,7 +129,7 @@
       "order": 12,
       "label": {
         "he": "ל",
-        "en": "12"
+        "en": "30"
       },
       "targetSeif": 5,
       "section": "ohr-pnimi",

--- a/content/parts/part-01/chapters/chapter-02/commentary.he-jerusalem-1956.json
+++ b/content/parts/part-01/chapters/chapter-02/commentary.he-jerusalem-1956.json
@@ -129,7 +129,7 @@
       "order": 11,
       "label": {
         "he": "כ",
-        "en": "11"
+        "en": "20"
       },
       "sefariaRef": "Ohr Penimi on Talmud Eser HaSefirot 1:2:11",
       "targetSeif": 5,
@@ -141,7 +141,7 @@
       "order": 12,
       "label": {
         "he": "ל",
-        "en": "12"
+        "en": "30"
       },
       "sefariaRef": "Ohr Penimi on Talmud Eser HaSefirot 1:2:12",
       "targetSeif": 5,

--- a/content/parts/part-02/chapters/chapter-01/commentary.he-jerusalem-1956.json
+++ b/content/parts/part-02/chapters/chapter-01/commentary.he-jerusalem-1956.json
@@ -129,7 +129,7 @@
       "order": 11,
       "label": {
         "he": "כ",
-        "en": "11"
+        "en": "20"
       },
       "sefariaRef": "Ohr Penimi on Talmud Eser HaSefirot 2:1:11",
       "targetSeif": 3,
@@ -141,7 +141,7 @@
       "order": 12,
       "label": {
         "he": "ל",
-        "en": "12"
+        "en": "30"
       },
       "sefariaRef": "Ohr Penimi on Talmud Eser HaSefirot 2:1:12",
       "targetSeif": 3,
@@ -153,7 +153,7 @@
       "order": 13,
       "label": {
         "he": "מ",
-        "en": "13"
+        "en": "40"
       },
       "sefariaRef": "Ohr Penimi on Talmud Eser HaSefirot 2:1:13",
       "targetSeif": 4,
@@ -165,7 +165,7 @@
       "order": 14,
       "label": {
         "he": "נ",
-        "en": "14"
+        "en": "50"
       },
       "sefariaRef": "Ohr Penimi on Talmud Eser HaSefirot 2:1:14",
       "targetSeif": 4,
@@ -177,7 +177,7 @@
       "order": 15,
       "label": {
         "he": "ס",
-        "en": "15"
+        "en": "60"
       },
       "sefariaRef": "Ohr Penimi on Talmud Eser HaSefirot 2:1:15",
       "targetSeif": 4,
@@ -189,7 +189,7 @@
       "order": 16,
       "label": {
         "he": "ע",
-        "en": "16"
+        "en": "70"
       },
       "sefariaRef": "Ohr Penimi on Talmud Eser HaSefirot 2:1:16",
       "targetSeif": 4,
@@ -201,7 +201,7 @@
       "order": 17,
       "label": {
         "he": "פ",
-        "en": "17"
+        "en": "80"
       },
       "sefariaRef": "Ohr Penimi on Talmud Eser HaSefirot 2:1:17",
       "targetSeif": 5,
@@ -213,7 +213,7 @@
       "order": 18,
       "label": {
         "he": "צ",
-        "en": "18"
+        "en": "90"
       },
       "sefariaRef": "Ohr Penimi on Talmud Eser HaSefirot 2:1:18",
       "targetSeif": 5,
@@ -225,7 +225,7 @@
       "order": 19,
       "label": {
         "he": "ק",
-        "en": "19"
+        "en": "100"
       },
       "sefariaRef": "Ohr Penimi on Talmud Eser HaSefirot 2:1:19",
       "targetSeif": 5,
@@ -237,7 +237,7 @@
       "order": 20,
       "label": {
         "he": "ר וש",
-        "en": "20"
+        "en": "200"
       },
       "sefariaRef": "Ohr Penimi on Talmud Eser HaSefirot 2:1:20",
       "targetSeif": 5,
@@ -249,7 +249,7 @@
       "order": 21,
       "label": {
         "he": "ת",
-        "en": "21"
+        "en": "400"
       },
       "sefariaRef": "Ohr Penimi on Talmud Eser HaSefirot 2:1:21",
       "targetSeif": 5,
@@ -261,7 +261,7 @@
       "order": 22,
       "label": {
         "he": "א",
-        "en": "22"
+        "en": "1"
       },
       "sefariaRef": "Ohr Penimi on Talmud Eser HaSefirot 2:1:22",
       "targetSeif": 5,
@@ -273,7 +273,7 @@
       "order": 23,
       "label": {
         "he": "ב",
-        "en": "23"
+        "en": "2"
       },
       "sefariaRef": "Ohr Penimi on Talmud Eser HaSefirot 2:1:23",
       "targetSeif": 5,
@@ -285,7 +285,7 @@
       "order": 24,
       "label": {
         "he": "ג",
-        "en": "24"
+        "en": "3"
       },
       "sefariaRef": "Ohr Penimi on Talmud Eser HaSefirot 2:1:24",
       "targetSeif": 6,
@@ -297,7 +297,7 @@
       "order": 25,
       "label": {
         "he": "ד",
-        "en": "25"
+        "en": "4"
       },
       "sefariaRef": "Ohr Penimi on Talmud Eser HaSefirot 2:1:25",
       "targetSeif": 6,
@@ -309,7 +309,7 @@
       "order": 26,
       "label": {
         "he": "ה",
-        "en": "26"
+        "en": "5"
       },
       "sefariaRef": "Ohr Penimi on Talmud Eser HaSefirot 2:1:26",
       "targetSeif": 6,
@@ -321,7 +321,7 @@
       "order": 27,
       "label": {
         "he": "ו",
-        "en": "27"
+        "en": "6"
       },
       "sefariaRef": "Ohr Penimi on Talmud Eser HaSefirot 2:1:27",
       "targetSeif": 6,
@@ -333,7 +333,7 @@
       "order": 28,
       "label": {
         "he": "ז",
-        "en": "28"
+        "en": "7"
       },
       "sefariaRef": "Ohr Penimi on Talmud Eser HaSefirot 2:1:28",
       "targetSeif": 6,
@@ -345,7 +345,7 @@
       "order": 29,
       "label": {
         "he": "ח",
-        "en": "29"
+        "en": "8"
       },
       "sefariaRef": "Ohr Penimi on Talmud Eser HaSefirot 2:1:29",
       "targetSeif": 7,
@@ -357,7 +357,7 @@
       "order": 30,
       "label": {
         "he": "ט",
-        "en": "30"
+        "en": "9"
       },
       "sefariaRef": "Ohr Penimi on Talmud Eser HaSefirot 2:1:30",
       "targetSeif": 7,
@@ -369,7 +369,7 @@
       "order": 31,
       "label": {
         "he": "י",
-        "en": "31"
+        "en": "10"
       },
       "sefariaRef": "Ohr Penimi on Talmud Eser HaSefirot 2:1:31",
       "targetSeif": 8,

--- a/content/parts/part-02/chapters/chapter-02/commentary.he-jerusalem-1956.json
+++ b/content/parts/part-02/chapters/chapter-02/commentary.he-jerusalem-1956.json
@@ -129,7 +129,7 @@
       "order": 11,
       "label": {
         "he": "כ",
-        "en": "11"
+        "en": "20"
       },
       "sefariaRef": "Ohr Penimi on Talmud Eser HaSefirot 2:2:11",
       "targetSeif": 4,
@@ -141,7 +141,7 @@
       "order": 12,
       "label": {
         "he": "ל",
-        "en": "12"
+        "en": "30"
       },
       "sefariaRef": "Ohr Penimi on Talmud Eser HaSefirot 2:2:12",
       "targetSeif": 4,
@@ -153,7 +153,7 @@
       "order": 13,
       "label": {
         "he": "מ",
-        "en": "13"
+        "en": "40"
       },
       "sefariaRef": "Ohr Penimi on Talmud Eser HaSefirot 2:2:13",
       "targetSeif": 5,
@@ -165,7 +165,7 @@
       "order": 14,
       "label": {
         "he": "נ",
-        "en": "14"
+        "en": "50"
       },
       "sefariaRef": "Ohr Penimi on Talmud Eser HaSefirot 2:2:14",
       "targetSeif": 5,
@@ -177,7 +177,7 @@
       "order": 15,
       "label": {
         "he": "ס",
-        "en": "15"
+        "en": "60"
       },
       "sefariaRef": "Ohr Penimi on Talmud Eser HaSefirot 2:2:15",
       "targetSeif": 5,
@@ -189,7 +189,7 @@
       "order": 16,
       "label": {
         "he": "ע",
-        "en": "16"
+        "en": "70"
       },
       "sefariaRef": "Ohr Penimi on Talmud Eser HaSefirot 2:2:16",
       "targetSeif": 5,
@@ -201,7 +201,7 @@
       "order": 17,
       "label": {
         "he": "פ",
-        "en": "17"
+        "en": "80"
       },
       "sefariaRef": "Ohr Penimi on Talmud Eser HaSefirot 2:2:17",
       "targetSeif": 5,
@@ -213,7 +213,7 @@
       "order": 18,
       "label": {
         "he": "צ",
-        "en": "18"
+        "en": "90"
       },
       "sefariaRef": "Ohr Penimi on Talmud Eser HaSefirot 2:2:18",
       "targetSeif": 5,
@@ -225,7 +225,7 @@
       "order": 19,
       "label": {
         "he": "ק",
-        "en": "19"
+        "en": "100"
       },
       "sefariaRef": "Ohr Penimi on Talmud Eser HaSefirot 2:2:19",
       "targetSeif": 5,
@@ -237,7 +237,7 @@
       "order": 20,
       "label": {
         "he": "ר",
-        "en": "20"
+        "en": "200"
       },
       "sefariaRef": "Ohr Penimi on Talmud Eser HaSefirot 2:2:20",
       "targetSeif": 5,
@@ -249,7 +249,7 @@
       "order": 21,
       "label": {
         "he": "ש",
-        "en": "21"
+        "en": "300"
       },
       "sefariaRef": "Ohr Penimi on Talmud Eser HaSefirot 2:2:21",
       "targetSeif": 5,
@@ -261,7 +261,7 @@
       "order": 22,
       "label": {
         "he": "ת",
-        "en": "22"
+        "en": "400"
       },
       "sefariaRef": "Ohr Penimi on Talmud Eser HaSefirot 2:2:22",
       "targetSeif": 6,
@@ -273,7 +273,7 @@
       "order": 23,
       "label": {
         "he": "א",
-        "en": "23"
+        "en": "1"
       },
       "sefariaRef": "Ohr Penimi on Talmud Eser HaSefirot 2:2:23",
       "targetSeif": 6,
@@ -285,7 +285,7 @@
       "order": 24,
       "label": {
         "he": "ב",
-        "en": "24"
+        "en": "2"
       },
       "sefariaRef": "Ohr Penimi on Talmud Eser HaSefirot 2:2:24",
       "targetSeif": 6,
@@ -297,7 +297,7 @@
       "order": 25,
       "label": {
         "he": "ג",
-        "en": "25"
+        "en": "3"
       },
       "sefariaRef": "Ohr Penimi on Talmud Eser HaSefirot 2:2:25",
       "targetSeif": 7,
@@ -309,7 +309,7 @@
       "order": 26,
       "label": {
         "he": "ד",
-        "en": "26"
+        "en": "4"
       },
       "sefariaRef": "Ohr Penimi on Talmud Eser HaSefirot 2:2:26",
       "targetSeif": 7,
@@ -321,7 +321,7 @@
       "order": 27,
       "label": {
         "he": "ה",
-        "en": "27"
+        "en": "5"
       },
       "sefariaRef": "Ohr Penimi on Talmud Eser HaSefirot 2:2:27",
       "targetSeif": 7,

--- a/content/parts/part-03/chapters/chapter-01/commentary.he-jerusalem-1956.json
+++ b/content/parts/part-03/chapters/chapter-01/commentary.he-jerusalem-1956.json
@@ -129,7 +129,7 @@
       "order": 11,
       "label": {
         "he": "כ",
-        "en": "11"
+        "en": "20"
       },
       "sefariaRef": "Ohr Penimi on Talmud Eser HaSefirot 3:1:11",
       "targetSeif": 2,
@@ -141,7 +141,7 @@
       "order": 12,
       "label": {
         "he": "ל",
-        "en": "12"
+        "en": "30"
       },
       "sefariaRef": "Ohr Penimi on Talmud Eser HaSefirot 3:1:12",
       "targetSeif": 2,
@@ -153,7 +153,7 @@
       "order": 13,
       "label": {
         "he": "מ",
-        "en": "13"
+        "en": "40"
       },
       "sefariaRef": "Ohr Penimi on Talmud Eser HaSefirot 3:1:13",
       "targetSeif": 2,
@@ -165,7 +165,7 @@
       "order": 14,
       "label": {
         "he": "נ",
-        "en": "14"
+        "en": "50"
       },
       "sefariaRef": "Ohr Penimi on Talmud Eser HaSefirot 3:1:14",
       "targetSeif": 2,
@@ -177,7 +177,7 @@
       "order": 15,
       "label": {
         "he": "ס",
-        "en": "15"
+        "en": "60"
       },
       "sefariaRef": "Ohr Penimi on Talmud Eser HaSefirot 3:1:15",
       "targetSeif": 2,
@@ -189,7 +189,7 @@
       "order": 16,
       "label": {
         "he": "ע",
-        "en": "16"
+        "en": "70"
       },
       "sefariaRef": "Ohr Penimi on Talmud Eser HaSefirot 3:1:16",
       "targetSeif": 3,
@@ -201,7 +201,7 @@
       "order": 17,
       "label": {
         "he": "פ",
-        "en": "17"
+        "en": "80"
       },
       "sefariaRef": "Ohr Penimi on Talmud Eser HaSefirot 3:1:17",
       "targetSeif": 3,
@@ -213,7 +213,7 @@
       "order": 18,
       "label": {
         "he": "צ",
-        "en": "18"
+        "en": "90"
       },
       "sefariaRef": "Ohr Penimi on Talmud Eser HaSefirot 3:1:18",
       "targetSeif": 3,
@@ -225,7 +225,7 @@
       "order": 19,
       "label": {
         "he": "ק",
-        "en": "19"
+        "en": "100"
       },
       "sefariaRef": "Ohr Penimi on Talmud Eser HaSefirot 3:1:19",
       "targetSeif": 3,
@@ -237,7 +237,7 @@
       "order": 20,
       "label": {
         "he": "ר",
-        "en": "20"
+        "en": "200"
       },
       "sefariaRef": "Ohr Penimi on Talmud Eser HaSefirot 3:1:20",
       "targetSeif": 3,
@@ -249,7 +249,7 @@
       "order": 21,
       "label": {
         "he": "ש",
-        "en": "21"
+        "en": "300"
       },
       "sefariaRef": "Ohr Penimi on Talmud Eser HaSefirot 3:1:21",
       "targetSeif": 3,
@@ -261,7 +261,7 @@
       "order": 22,
       "label": {
         "he": "ת",
-        "en": "22"
+        "en": "400"
       },
       "sefariaRef": "Ohr Penimi on Talmud Eser HaSefirot 3:1:22",
       "targetSeif": 3,
@@ -273,7 +273,7 @@
       "order": 23,
       "label": {
         "he": "א",
-        "en": "23"
+        "en": "1"
       },
       "sefariaRef": "Ohr Penimi on Talmud Eser HaSefirot 3:1:23",
       "targetSeif": 4,
@@ -285,7 +285,7 @@
       "order": 24,
       "label": {
         "he": "ב",
-        "en": "24"
+        "en": "2"
       },
       "sefariaRef": "Ohr Penimi on Talmud Eser HaSefirot 3:1:24",
       "targetSeif": 4,
@@ -297,7 +297,7 @@
       "order": 25,
       "label": {
         "he": "ג",
-        "en": "25"
+        "en": "3"
       },
       "sefariaRef": "Ohr Penimi on Talmud Eser HaSefirot 3:1:25",
       "targetSeif": 4,
@@ -309,7 +309,7 @@
       "order": 26,
       "label": {
         "he": "ד",
-        "en": "26"
+        "en": "4"
       },
       "sefariaRef": "Ohr Penimi on Talmud Eser HaSefirot 3:1:26",
       "targetSeif": 4,
@@ -321,7 +321,7 @@
       "order": 27,
       "label": {
         "he": "ה",
-        "en": "27"
+        "en": "5"
       },
       "sefariaRef": "Ohr Penimi on Talmud Eser HaSefirot 3:1:27",
       "targetSeif": 4,
@@ -333,7 +333,7 @@
       "order": 28,
       "label": {
         "he": "ו",
-        "en": "28"
+        "en": "6"
       },
       "sefariaRef": "Ohr Penimi on Talmud Eser HaSefirot 3:1:28",
       "targetSeif": 4,
@@ -345,7 +345,7 @@
       "order": 29,
       "label": {
         "he": "ז",
-        "en": "29"
+        "en": "7"
       },
       "sefariaRef": "Ohr Penimi on Talmud Eser HaSefirot 3:1:29",
       "targetSeif": 4,
@@ -357,7 +357,7 @@
       "order": 30,
       "label": {
         "he": "ח",
-        "en": "30"
+        "en": "8"
       },
       "sefariaRef": "Ohr Penimi on Talmud Eser HaSefirot 3:1:30",
       "targetSeif": 4,
@@ -369,7 +369,7 @@
       "order": 31,
       "label": {
         "he": "ט",
-        "en": "31"
+        "en": "9"
       },
       "sefariaRef": "Ohr Penimi on Talmud Eser HaSefirot 3:1:31",
       "targetSeif": 4,

--- a/content/parts/part-03/chapters/chapter-04/commentary.he-jerusalem-1956.json
+++ b/content/parts/part-03/chapters/chapter-04/commentary.he-jerusalem-1956.json
@@ -129,7 +129,7 @@
       "order": 11,
       "label": {
         "he": "כ",
-        "en": "11"
+        "en": "20"
       },
       "sefariaRef": "Ohr Penimi on Talmud Eser HaSefirot 3:4:11",
       "targetSeif": 4,
@@ -141,7 +141,7 @@
       "order": 12,
       "label": {
         "he": "ל",
-        "en": "12"
+        "en": "30"
       },
       "sefariaRef": "Ohr Penimi on Talmud Eser HaSefirot 3:4:12",
       "targetSeif": 4,
@@ -153,7 +153,7 @@
       "order": 13,
       "label": {
         "he": "מ",
-        "en": "13"
+        "en": "40"
       },
       "sefariaRef": "Ohr Penimi on Talmud Eser HaSefirot 3:4:13",
       "targetSeif": 4,
@@ -165,7 +165,7 @@
       "order": 14,
       "label": {
         "he": "נ",
-        "en": "14"
+        "en": "50"
       },
       "sefariaRef": "Ohr Penimi on Talmud Eser HaSefirot 3:4:14",
       "targetSeif": 6,
@@ -177,7 +177,7 @@
       "order": 15,
       "label": {
         "he": "ס",
-        "en": "15"
+        "en": "60"
       },
       "sefariaRef": "Ohr Penimi on Talmud Eser HaSefirot 3:4:15",
       "targetSeif": 6,
@@ -189,7 +189,7 @@
       "order": 16,
       "label": {
         "he": "ע",
-        "en": "16"
+        "en": "70"
       },
       "sefariaRef": "Ohr Penimi on Talmud Eser HaSefirot 3:4:16",
       "targetSeif": 7,
@@ -201,7 +201,7 @@
       "order": 17,
       "label": {
         "he": "פ",
-        "en": "17"
+        "en": "80"
       },
       "sefariaRef": "Ohr Penimi on Talmud Eser HaSefirot 3:4:17",
       "targetSeif": 7,
@@ -213,7 +213,7 @@
       "order": 18,
       "label": {
         "he": "צ",
-        "en": "18"
+        "en": "90"
       },
       "sefariaRef": "Ohr Penimi on Talmud Eser HaSefirot 3:4:18",
       "targetSeif": 7,
@@ -225,7 +225,7 @@
       "order": 19,
       "label": {
         "he": "ק",
-        "en": "19"
+        "en": "100"
       },
       "sefariaRef": "Ohr Penimi on Talmud Eser HaSefirot 3:4:19",
       "targetSeif": 8,
@@ -237,7 +237,7 @@
       "order": 20,
       "label": {
         "he": "ר",
-        "en": "20"
+        "en": "200"
       },
       "sefariaRef": "Ohr Penimi on Talmud Eser HaSefirot 3:4:20",
       "targetSeif": 8,
@@ -249,7 +249,7 @@
       "order": 21,
       "label": {
         "he": "ש",
-        "en": "21"
+        "en": "300"
       },
       "sefariaRef": "Ohr Penimi on Talmud Eser HaSefirot 3:4:21",
       "targetSeif": 9,

--- a/content/parts/part-03/chapters/chapter-05/commentary.he-jerusalem-1956.json
+++ b/content/parts/part-03/chapters/chapter-05/commentary.he-jerusalem-1956.json
@@ -129,7 +129,7 @@
       "order": 11,
       "label": {
         "he": "כ",
-        "en": "11"
+        "en": "20"
       },
       "sefariaRef": "Ohr Penimi on Talmud Eser HaSefirot 3:5:11",
       "targetSeif": 5,
@@ -141,7 +141,7 @@
       "order": 12,
       "label": {
         "he": "ל",
-        "en": "12"
+        "en": "30"
       },
       "sefariaRef": "Ohr Penimi on Talmud Eser HaSefirot 3:5:12",
       "targetSeif": 5,
@@ -153,7 +153,7 @@
       "order": 13,
       "label": {
         "he": "מ",
-        "en": "13"
+        "en": "40"
       },
       "sefariaRef": "Ohr Penimi on Talmud Eser HaSefirot 3:5:13",
       "targetSeif": 5,
@@ -165,7 +165,7 @@
       "order": 14,
       "label": {
         "he": "נ",
-        "en": "14"
+        "en": "50"
       },
       "sefariaRef": "Ohr Penimi on Talmud Eser HaSefirot 3:5:14",
       "targetSeif": 6,

--- a/content/parts/part-03/chapters/chapter-07/commentary.he-jerusalem-1956.json
+++ b/content/parts/part-03/chapters/chapter-07/commentary.he-jerusalem-1956.json
@@ -129,7 +129,7 @@
       "order": 11,
       "label": {
         "he": "כ",
-        "en": "11"
+        "en": "20"
       },
       "sefariaRef": "Ohr Penimi on Talmud Eser HaSefirot 3:7:11",
       "targetSeif": 5,
@@ -141,7 +141,7 @@
       "order": 12,
       "label": {
         "he": "ל",
-        "en": "12"
+        "en": "30"
       },
       "sefariaRef": "Ohr Penimi on Talmud Eser HaSefirot 3:7:12",
       "targetSeif": 5,
@@ -153,7 +153,7 @@
       "order": 13,
       "label": {
         "he": "מ",
-        "en": "13"
+        "en": "40"
       },
       "sefariaRef": "Ohr Penimi on Talmud Eser HaSefirot 3:7:13",
       "targetSeif": 5,
@@ -165,7 +165,7 @@
       "order": 14,
       "label": {
         "he": "נ",
-        "en": "14"
+        "en": "50"
       },
       "sefariaRef": "Ohr Penimi on Talmud Eser HaSefirot 3:7:14",
       "targetSeif": 7,
@@ -177,7 +177,7 @@
       "order": 15,
       "label": {
         "he": "ס",
-        "en": "15"
+        "en": "60"
       },
       "sefariaRef": "Ohr Penimi on Talmud Eser HaSefirot 3:7:15",
       "targetSeif": 8,
@@ -189,7 +189,7 @@
       "order": 16,
       "label": {
         "he": "ע",
-        "en": "16"
+        "en": "70"
       },
       "sefariaRef": "Ohr Penimi on Talmud Eser HaSefirot 3:7:16",
       "targetSeif": 9,
@@ -201,7 +201,7 @@
       "order": 17,
       "label": {
         "he": "פ",
-        "en": "17"
+        "en": "80"
       },
       "sefariaRef": "Ohr Penimi on Talmud Eser HaSefirot 3:7:17",
       "targetSeif": 10,
@@ -213,7 +213,7 @@
       "order": 18,
       "label": {
         "he": "צ",
-        "en": "18"
+        "en": "90"
       },
       "sefariaRef": "Ohr Penimi on Talmud Eser HaSefirot 3:7:18",
       "targetSeif": 10,

--- a/content/parts/part-03/chapters/chapter-11/commentary.he-jerusalem-1956.json
+++ b/content/parts/part-03/chapters/chapter-11/commentary.he-jerusalem-1956.json
@@ -129,7 +129,7 @@
       "order": 11,
       "label": {
         "he": "כ",
-        "en": "11"
+        "en": "20"
       },
       "sefariaRef": "Ohr Penimi on Talmud Eser HaSefirot 3:11:11",
       "targetSeif": 8,

--- a/content/parts/part-03/chapters/chapter-12/commentary.he-jerusalem-1956.json
+++ b/content/parts/part-03/chapters/chapter-12/commentary.he-jerusalem-1956.json
@@ -129,7 +129,7 @@
       "order": 11,
       "label": {
         "he": "כ",
-        "en": "11"
+        "en": "20"
       },
       "sefariaRef": "Ohr Penimi on Talmud Eser HaSefirot 3:12:11",
       "targetSeif": 7,
@@ -141,7 +141,7 @@
       "order": 12,
       "label": {
         "he": "ל",
-        "en": "12"
+        "en": "30"
       },
       "sefariaRef": "Ohr Penimi on Talmud Eser HaSefirot 3:12:12",
       "targetSeif": 7,
@@ -153,7 +153,7 @@
       "order": 13,
       "label": {
         "he": "מ",
-        "en": "13"
+        "en": "40"
       },
       "sefariaRef": "Ohr Penimi on Talmud Eser HaSefirot 3:12:13",
       "targetSeif": 7,
@@ -165,7 +165,7 @@
       "order": 14,
       "label": {
         "he": "נ",
-        "en": "14"
+        "en": "50"
       },
       "sefariaRef": "Ohr Penimi on Talmud Eser HaSefirot 3:12:14",
       "targetSeif": 7,
@@ -177,7 +177,7 @@
       "order": 15,
       "label": {
         "he": "ס",
-        "en": "15"
+        "en": "60"
       },
       "sefariaRef": "Ohr Penimi on Talmud Eser HaSefirot 3:12:15",
       "targetSeif": 7,
@@ -189,7 +189,7 @@
       "order": 16,
       "label": {
         "he": "ע",
-        "en": "16"
+        "en": "70"
       },
       "sefariaRef": "Ohr Penimi on Talmud Eser HaSefirot 3:12:16",
       "targetSeif": 7,

--- a/content/parts/part-04/chapters/chapter-01/commentary.he-jerusalem-1956.json
+++ b/content/parts/part-04/chapters/chapter-01/commentary.he-jerusalem-1956.json
@@ -129,7 +129,7 @@
       "order": 11,
       "label": {
         "he": "כ",
-        "en": "11"
+        "en": "20"
       },
       "sefariaRef": "Ohr Penimi on Talmud Eser HaSefirot 4:1:11",
       "targetSeif": 5,
@@ -141,7 +141,7 @@
       "order": 12,
       "label": {
         "he": "ל",
-        "en": "12"
+        "en": "30"
       },
       "sefariaRef": "Ohr Penimi on Talmud Eser HaSefirot 4:1:12",
       "targetSeif": 5,
@@ -153,7 +153,7 @@
       "order": 13,
       "label": {
         "he": "מ",
-        "en": "13"
+        "en": "40"
       },
       "sefariaRef": "Ohr Penimi on Talmud Eser HaSefirot 4:1:13",
       "targetSeif": 7,
@@ -165,7 +165,7 @@
       "order": 14,
       "label": {
         "he": "נ",
-        "en": "14"
+        "en": "50"
       },
       "sefariaRef": "Ohr Penimi on Talmud Eser HaSefirot 4:1:14",
       "targetSeif": 7,
@@ -177,7 +177,7 @@
       "order": 15,
       "label": {
         "he": "ס",
-        "en": "15"
+        "en": "60"
       },
       "sefariaRef": "Ohr Penimi on Talmud Eser HaSefirot 4:1:15",
       "targetSeif": 7,
@@ -189,7 +189,7 @@
       "order": 16,
       "label": {
         "he": "ע",
-        "en": "16"
+        "en": "70"
       },
       "sefariaRef": "Ohr Penimi on Talmud Eser HaSefirot 4:1:16",
       "targetSeif": 7,
@@ -201,7 +201,7 @@
       "order": 17,
       "label": {
         "he": "פ",
-        "en": "17"
+        "en": "80"
       },
       "sefariaRef": "Ohr Penimi on Talmud Eser HaSefirot 4:1:17",
       "targetSeif": 8,
@@ -213,7 +213,7 @@
       "order": 18,
       "label": {
         "he": "צ",
-        "en": "18"
+        "en": "90"
       },
       "sefariaRef": "Ohr Penimi on Talmud Eser HaSefirot 4:1:18",
       "targetSeif": 8,
@@ -225,7 +225,7 @@
       "order": 19,
       "label": {
         "he": "ק",
-        "en": "19"
+        "en": "100"
       },
       "sefariaRef": "Ohr Penimi on Talmud Eser HaSefirot 4:1:19",
       "targetSeif": 8,
@@ -237,7 +237,7 @@
       "order": 20,
       "label": {
         "he": "ר",
-        "en": "20"
+        "en": "200"
       },
       "sefariaRef": "Ohr Penimi on Talmud Eser HaSefirot 4:1:20",
       "targetSeif": 9,
@@ -249,7 +249,7 @@
       "order": 21,
       "label": {
         "he": "ש",
-        "en": "21"
+        "en": "300"
       },
       "sefariaRef": "Ohr Penimi on Talmud Eser HaSefirot 4:1:21",
       "targetSeif": 10,
@@ -261,7 +261,7 @@
       "order": 22,
       "label": {
         "he": "ת",
-        "en": "22"
+        "en": "400"
       },
       "sefariaRef": "Ohr Penimi on Talmud Eser HaSefirot 4:1:22",
       "targetSeif": 11,

--- a/content/parts/part-04/chapters/chapter-02/commentary.he-jerusalem-1956.json
+++ b/content/parts/part-04/chapters/chapter-02/commentary.he-jerusalem-1956.json
@@ -129,7 +129,7 @@
       "order": 11,
       "label": {
         "he": "כ",
-        "en": "11"
+        "en": "20"
       },
       "sefariaRef": "Ohr Penimi on Talmud Eser HaSefirot 4:2:11",
       "targetSeif": 10,

--- a/content/parts/part-04/chapters/chapter-03/commentary.he-jerusalem-1956.json
+++ b/content/parts/part-04/chapters/chapter-03/commentary.he-jerusalem-1956.json
@@ -129,7 +129,7 @@
       "order": 11,
       "label": {
         "he": "כ",
-        "en": "11"
+        "en": "20"
       },
       "sefariaRef": "Ohr Penimi on Talmud Eser HaSefirot 4:3:11",
       "targetSeif": 9,
@@ -141,7 +141,7 @@
       "order": 12,
       "label": {
         "he": "ל",
-        "en": "12"
+        "en": "30"
       },
       "sefariaRef": "Ohr Penimi on Talmud Eser HaSefirot 4:3:12",
       "targetSeif": 9,
@@ -153,7 +153,7 @@
       "order": 13,
       "label": {
         "he": "מ",
-        "en": "13"
+        "en": "40"
       },
       "sefariaRef": "Ohr Penimi on Talmud Eser HaSefirot 4:3:13",
       "targetSeif": 9,
@@ -165,7 +165,7 @@
       "order": 14,
       "label": {
         "he": "נ",
-        "en": "14"
+        "en": "50"
       },
       "sefariaRef": "Ohr Penimi on Talmud Eser HaSefirot 4:3:14",
       "targetSeif": 10,
@@ -177,7 +177,7 @@
       "order": 15,
       "label": {
         "he": "ס",
-        "en": "15"
+        "en": "60"
       },
       "sefariaRef": "Ohr Penimi on Talmud Eser HaSefirot 4:3:15",
       "targetSeif": 10,
@@ -189,7 +189,7 @@
       "order": 16,
       "label": {
         "he": "ע",
-        "en": "16"
+        "en": "70"
       },
       "sefariaRef": "Ohr Penimi on Talmud Eser HaSefirot 4:3:16",
       "targetSeif": 10,
@@ -201,7 +201,7 @@
       "order": 17,
       "label": {
         "he": "פ",
-        "en": "17"
+        "en": "80"
       },
       "sefariaRef": "Ohr Penimi on Talmud Eser HaSefirot 4:3:17",
       "targetSeif": 10,
@@ -213,7 +213,7 @@
       "order": 18,
       "label": {
         "he": "צ",
-        "en": "18"
+        "en": "90"
       },
       "sefariaRef": "Ohr Penimi on Talmud Eser HaSefirot 4:3:18",
       "targetSeif": 12,
@@ -225,7 +225,7 @@
       "order": 19,
       "label": {
         "he": "ק",
-        "en": "19"
+        "en": "100"
       },
       "sefariaRef": "Ohr Penimi on Talmud Eser HaSefirot 4:3:19",
       "targetSeif": 13,
@@ -237,7 +237,7 @@
       "order": 20,
       "label": {
         "he": "ר",
-        "en": "20"
+        "en": "200"
       },
       "sefariaRef": "Ohr Penimi on Talmud Eser HaSefirot 4:3:20",
       "targetSeif": 13,

--- a/content/parts/part-04/chapters/chapter-04/commentary.he-jerusalem-1956.json
+++ b/content/parts/part-04/chapters/chapter-04/commentary.he-jerusalem-1956.json
@@ -129,7 +129,7 @@
       "order": 11,
       "label": {
         "he": "כ",
-        "en": "11"
+        "en": "20"
       },
       "sefariaRef": "Ohr Penimi on Talmud Eser HaSefirot 4:4:11",
       "targetSeif": 5,
@@ -141,7 +141,7 @@
       "order": 12,
       "label": {
         "he": "ל",
-        "en": "12"
+        "en": "30"
       },
       "sefariaRef": "Ohr Penimi on Talmud Eser HaSefirot 4:4:12",
       "targetSeif": 5,
@@ -153,7 +153,7 @@
       "order": 13,
       "label": {
         "he": "מ",
-        "en": "13"
+        "en": "40"
       },
       "sefariaRef": "Ohr Penimi on Talmud Eser HaSefirot 4:4:13",
       "targetSeif": 5,
@@ -165,7 +165,7 @@
       "order": 14,
       "label": {
         "he": "נ",
-        "en": "14"
+        "en": "50"
       },
       "sefariaRef": "Ohr Penimi on Talmud Eser HaSefirot 4:4:14",
       "targetSeif": 6,
@@ -177,7 +177,7 @@
       "order": 15,
       "label": {
         "he": "ס",
-        "en": "15"
+        "en": "60"
       },
       "sefariaRef": "Ohr Penimi on Talmud Eser HaSefirot 4:4:15",
       "targetSeif": 6,
@@ -189,7 +189,7 @@
       "order": 16,
       "label": {
         "he": "ע",
-        "en": "16"
+        "en": "70"
       },
       "sefariaRef": "Ohr Penimi on Talmud Eser HaSefirot 4:4:16",
       "targetSeif": 6,
@@ -201,7 +201,7 @@
       "order": 17,
       "label": {
         "he": "פ",
-        "en": "17"
+        "en": "80"
       },
       "sefariaRef": "Ohr Penimi on Talmud Eser HaSefirot 4:4:17",
       "targetSeif": 6,
@@ -213,7 +213,7 @@
       "order": 18,
       "label": {
         "he": "צ",
-        "en": "18"
+        "en": "90"
       },
       "sefariaRef": "Ohr Penimi on Talmud Eser HaSefirot 4:4:18",
       "targetSeif": 6,
@@ -225,7 +225,7 @@
       "order": 19,
       "label": {
         "he": "ק",
-        "en": "19"
+        "en": "100"
       },
       "sefariaRef": "Ohr Penimi on Talmud Eser HaSefirot 4:4:19",
       "targetSeif": 6,
@@ -237,7 +237,7 @@
       "order": 20,
       "label": {
         "he": "ר",
-        "en": "20"
+        "en": "200"
       },
       "sefariaRef": "Ohr Penimi on Talmud Eser HaSefirot 4:4:20",
       "targetSeif": 6,
@@ -249,7 +249,7 @@
       "order": 21,
       "label": {
         "he": "ש",
-        "en": "21"
+        "en": "300"
       },
       "sefariaRef": "Ohr Penimi on Talmud Eser HaSefirot 4:4:21",
       "targetSeif": 7,
@@ -261,7 +261,7 @@
       "order": 22,
       "label": {
         "he": "ת",
-        "en": "22"
+        "en": "400"
       },
       "sefariaRef": "Ohr Penimi on Talmud Eser HaSefirot 4:4:22",
       "targetSeif": 8,

--- a/content/parts/part-04/chapters/chapter-05/commentary.he-jerusalem-1956.json
+++ b/content/parts/part-04/chapters/chapter-05/commentary.he-jerusalem-1956.json
@@ -129,7 +129,7 @@
       "order": 11,
       "label": {
         "he": "כ",
-        "en": "11"
+        "en": "20"
       },
       "sefariaRef": "Ohr Penimi on Talmud Eser HaSefirot 4:5:11",
       "targetSeif": 4,
@@ -141,7 +141,7 @@
       "order": 12,
       "label": {
         "he": "ל",
-        "en": "12"
+        "en": "30"
       },
       "sefariaRef": "Ohr Penimi on Talmud Eser HaSefirot 4:5:12",
       "targetSeif": 5,
@@ -153,7 +153,7 @@
       "order": 13,
       "label": {
         "he": "מ",
-        "en": "13"
+        "en": "40"
       },
       "sefariaRef": "Ohr Penimi on Talmud Eser HaSefirot 4:5:13",
       "targetSeif": 5,
@@ -165,7 +165,7 @@
       "order": 14,
       "label": {
         "he": "נ",
-        "en": "14"
+        "en": "50"
       },
       "sefariaRef": "Ohr Penimi on Talmud Eser HaSefirot 4:5:14",
       "targetSeif": 6,
@@ -177,7 +177,7 @@
       "order": 15,
       "label": {
         "he": "ס",
-        "en": "15"
+        "en": "60"
       },
       "sefariaRef": "Ohr Penimi on Talmud Eser HaSefirot 4:5:15",
       "targetSeif": 6,
@@ -189,7 +189,7 @@
       "order": 16,
       "label": {
         "he": "ע",
-        "en": "16"
+        "en": "70"
       },
       "sefariaRef": "Ohr Penimi on Talmud Eser HaSefirot 4:5:16",
       "targetSeif": 6,
@@ -201,7 +201,7 @@
       "order": 17,
       "label": {
         "he": "פ",
-        "en": "17"
+        "en": "80"
       },
       "sefariaRef": "Ohr Penimi on Talmud Eser HaSefirot 4:5:17",
       "targetSeif": 7,
@@ -213,7 +213,7 @@
       "order": 18,
       "label": {
         "he": "צ",
-        "en": "18"
+        "en": "90"
       },
       "sefariaRef": "Ohr Penimi on Talmud Eser HaSefirot 4:5:18",
       "targetSeif": 7,
@@ -225,7 +225,7 @@
       "order": 19,
       "label": {
         "he": "ק",
-        "en": "19"
+        "en": "100"
       },
       "sefariaRef": "Ohr Penimi on Talmud Eser HaSefirot 4:5:19",
       "targetSeif": 8,
@@ -237,7 +237,7 @@
       "order": 20,
       "label": {
         "he": "ר",
-        "en": "20"
+        "en": "200"
       },
       "sefariaRef": "Ohr Penimi on Talmud Eser HaSefirot 4:5:20",
       "targetSeif": 8,

--- a/content/parts/part-04/chapters/chapter-06/commentary.he-jerusalem-1956.json
+++ b/content/parts/part-04/chapters/chapter-06/commentary.he-jerusalem-1956.json
@@ -129,7 +129,7 @@
       "order": 11,
       "label": {
         "he": "כ",
-        "en": "11"
+        "en": "20"
       },
       "sefariaRef": "Ohr Penimi on Talmud Eser HaSefirot 4:6:11",
       "targetSeif": 3,
@@ -141,7 +141,7 @@
       "order": 12,
       "label": {
         "he": "ל",
-        "en": "12"
+        "en": "30"
       },
       "sefariaRef": "Ohr Penimi on Talmud Eser HaSefirot 4:6:12",
       "targetSeif": 4,
@@ -153,7 +153,7 @@
       "order": 13,
       "label": {
         "he": "מ",
-        "en": "13"
+        "en": "40"
       },
       "sefariaRef": "Ohr Penimi on Talmud Eser HaSefirot 4:6:13",
       "targetSeif": 6,
@@ -165,7 +165,7 @@
       "order": 14,
       "label": {
         "he": "נ",
-        "en": "14"
+        "en": "50"
       },
       "sefariaRef": "Ohr Penimi on Talmud Eser HaSefirot 4:6:14",
       "targetSeif": 6,
@@ -177,7 +177,7 @@
       "order": 15,
       "label": {
         "he": "ס",
-        "en": "15"
+        "en": "60"
       },
       "sefariaRef": "Ohr Penimi on Talmud Eser HaSefirot 4:6:15",
       "targetSeif": 6,
@@ -189,7 +189,7 @@
       "order": 16,
       "label": {
         "he": "ע",
-        "en": "16"
+        "en": "70"
       },
       "sefariaRef": "Ohr Penimi on Talmud Eser HaSefirot 4:6:16",
       "targetSeif": 7,
@@ -201,7 +201,7 @@
       "order": 17,
       "label": {
         "he": "פ",
-        "en": "17"
+        "en": "80"
       },
       "sefariaRef": "Ohr Penimi on Talmud Eser HaSefirot 4:6:17",
       "targetSeif": 8,
@@ -213,7 +213,7 @@
       "order": 18,
       "label": {
         "he": "צ",
-        "en": "18"
+        "en": "90"
       },
       "sefariaRef": "Ohr Penimi on Talmud Eser HaSefirot 4:6:18",
       "targetSeif": 8,
@@ -225,7 +225,7 @@
       "order": 19,
       "label": {
         "he": "ק",
-        "en": "19"
+        "en": "100"
       },
       "sefariaRef": "Ohr Penimi on Talmud Eser HaSefirot 4:6:19",
       "targetSeif": 10,
@@ -237,7 +237,7 @@
       "order": 20,
       "label": {
         "he": "ר",
-        "en": "20"
+        "en": "200"
       },
       "sefariaRef": "Ohr Penimi on Talmud Eser HaSefirot 4:6:20",
       "targetSeif": 11,
@@ -249,7 +249,7 @@
       "order": 21,
       "label": {
         "he": "ש",
-        "en": "21"
+        "en": "300"
       },
       "sefariaRef": "Ohr Penimi on Talmud Eser HaSefirot 4:6:21",
       "targetSeif": 12,
@@ -261,7 +261,7 @@
       "order": 22,
       "label": {
         "he": "ת",
-        "en": "22"
+        "en": "400"
       },
       "sefariaRef": "Ohr Penimi on Talmud Eser HaSefirot 4:6:22",
       "targetSeif": 14,
@@ -273,7 +273,7 @@
       "order": 23,
       "label": {
         "he": "א",
-        "en": "23"
+        "en": "1"
       },
       "sefariaRef": "Ohr Penimi on Talmud Eser HaSefirot 4:6:23",
       "targetSeif": 14,
@@ -285,7 +285,7 @@
       "order": 24,
       "label": {
         "he": "ב",
-        "en": "24"
+        "en": "2"
       },
       "sefariaRef": "Ohr Penimi on Talmud Eser HaSefirot 4:6:24",
       "targetSeif": 15,
@@ -297,7 +297,7 @@
       "order": 25,
       "label": {
         "he": "ג",
-        "en": "25"
+        "en": "3"
       },
       "sefariaRef": "Ohr Penimi on Talmud Eser HaSefirot 4:6:25",
       "targetSeif": 15,
@@ -309,7 +309,7 @@
       "order": 26,
       "label": {
         "he": "ד",
-        "en": "26"
+        "en": "4"
       },
       "sefariaRef": "Ohr Penimi on Talmud Eser HaSefirot 4:6:26",
       "targetSeif": 15,
@@ -321,7 +321,7 @@
       "order": 27,
       "label": {
         "he": "ה",
-        "en": "27"
+        "en": "5"
       },
       "sefariaRef": "Ohr Penimi on Talmud Eser HaSefirot 4:6:27",
       "targetSeif": 15,
@@ -333,7 +333,7 @@
       "order": 28,
       "label": {
         "he": "ו",
-        "en": "28"
+        "en": "6"
       },
       "sefariaRef": "Ohr Penimi on Talmud Eser HaSefirot 4:6:28",
       "targetSeif": 15,
@@ -345,7 +345,7 @@
       "order": 29,
       "label": {
         "he": "ז",
-        "en": "29"
+        "en": "7"
       },
       "sefariaRef": "Ohr Penimi on Talmud Eser HaSefirot 4:6:29",
       "targetSeif": 16,
@@ -357,7 +357,7 @@
       "order": 30,
       "label": {
         "he": "ח",
-        "en": "30"
+        "en": "8"
       },
       "sefariaRef": "Ohr Penimi on Talmud Eser HaSefirot 4:6:30",
       "targetSeif": 16,
@@ -369,7 +369,7 @@
       "order": 31,
       "label": {
         "he": "ט",
-        "en": "31"
+        "en": "9"
       },
       "sefariaRef": "Ohr Penimi on Talmud Eser HaSefirot 4:6:31",
       "targetSeif": 16,
@@ -381,7 +381,7 @@
       "order": 32,
       "label": {
         "he": "י",
-        "en": "32"
+        "en": "10"
       },
       "sefariaRef": "Ohr Penimi on Talmud Eser HaSefirot 4:6:32",
       "targetSeif": 17,
@@ -393,7 +393,7 @@
       "order": 33,
       "label": {
         "he": "כ",
-        "en": "33"
+        "en": "20"
       },
       "sefariaRef": "Ohr Penimi on Talmud Eser HaSefirot 4:6:33",
       "targetSeif": 17,
@@ -405,7 +405,7 @@
       "order": 34,
       "label": {
         "he": "ל",
-        "en": "34"
+        "en": "30"
       },
       "sefariaRef": "Ohr Penimi on Talmud Eser HaSefirot 4:6:34",
       "targetSeif": 17,
@@ -417,7 +417,7 @@
       "order": 35,
       "label": {
         "he": "מ",
-        "en": "35"
+        "en": "40"
       },
       "sefariaRef": "Ohr Penimi on Talmud Eser HaSefirot 4:6:35",
       "targetSeif": 18,
@@ -429,7 +429,7 @@
       "order": 36,
       "label": {
         "he": "נ",
-        "en": "36"
+        "en": "50"
       },
       "sefariaRef": "Ohr Penimi on Talmud Eser HaSefirot 4:6:36",
       "targetSeif": 19,
@@ -441,7 +441,7 @@
       "order": 37,
       "label": {
         "he": "ס",
-        "en": "37"
+        "en": "60"
       },
       "sefariaRef": "Ohr Penimi on Talmud Eser HaSefirot 4:6:37",
       "targetSeif": 19,
@@ -453,7 +453,7 @@
       "order": 38,
       "label": {
         "he": "ע",
-        "en": "38"
+        "en": "70"
       },
       "sefariaRef": "Ohr Penimi on Talmud Eser HaSefirot 4:6:38",
       "targetSeif": 20,
@@ -465,7 +465,7 @@
       "order": 39,
       "label": {
         "he": "פ",
-        "en": "39"
+        "en": "80"
       },
       "sefariaRef": "Ohr Penimi on Talmud Eser HaSefirot 4:6:39",
       "targetSeif": 20,
@@ -477,7 +477,7 @@
       "order": 40,
       "label": {
         "he": "צ",
-        "en": "40"
+        "en": "90"
       },
       "sefariaRef": "Ohr Penimi on Talmud Eser HaSefirot 4:6:40",
       "targetSeif": 21,
@@ -489,7 +489,7 @@
       "order": 41,
       "label": {
         "he": "ק",
-        "en": "41"
+        "en": "100"
       },
       "sefariaRef": "Ohr Penimi on Talmud Eser HaSefirot 4:6:41",
       "targetSeif": 21,
@@ -501,7 +501,7 @@
       "order": 42,
       "label": {
         "he": "ר",
-        "en": "42"
+        "en": "200"
       },
       "sefariaRef": "Ohr Penimi on Talmud Eser HaSefirot 4:6:42",
       "targetSeif": 21,
@@ -513,7 +513,7 @@
       "order": 43,
       "label": {
         "he": "ש",
-        "en": "43"
+        "en": "300"
       },
       "sefariaRef": "Ohr Penimi on Talmud Eser HaSefirot 4:6:43",
       "targetSeif": 22,

--- a/scripts/migrate-commentary-labels.ts
+++ b/scripts/migrate-commentary-labels.ts
@@ -23,9 +23,19 @@
  * no marker in it, and every unanchored item (no marker exists to derive
  * from — see `commentaryItemSchema`) are all left untouched.
  *
- * Only the key for the version's own language is rewritten: `en-bb`'s
- * `label.en`, `he-jerusalem-1956`'s `label.he`. The other key is left as
- * imported.
+ * Both keys are rewritten, not just the version's own language.
+ *
+ * The first pass only corrected the language whose source it had read, which
+ * left `label.en` on every Hebrew-version file holding the invented running
+ * ordinal — and the KabbalahMedia importer copies `label` verbatim from that
+ * Hebrew ground truth, so the wrong value propagated into `en-bb` too and
+ * made `import:kabbalahmedia --all` fail its own validation (issue #110).
+ *
+ * The other key is derived rather than read, because the two are one fact:
+ * the printed English marker IS the gematria of the printed Hebrew letter
+ * (issue #96). `printedMarkerForHebrewLabel` returns `null` for a label with
+ * no Hebrew letter in it — an unanchored item's plain digits — and nothing
+ * is derived in that case.
  *
  * `pnpm migrate:commentary-labels [--dry-run]`. Deterministic and
  * idempotent: a second run against unchanged input writes nothing and
@@ -46,6 +56,7 @@ import {
   anchorMarkersFromHtml,
   labelNamesMarker,
 } from "../shared/utils/anchorMarkers.ts";
+import { printedMarkerForHebrewLabel } from "./lib/hebrew-numerals.ts";
 
 const CONTENT_ROOT = fileURLToPath(new URL("../content", import.meta.url));
 const PARTS_ROOT = join(CONTENT_ROOT, "parts");
@@ -115,13 +126,26 @@ for (const dir of chapterDirs()) {
     if (markers.size === 0) continue;
 
     const commentaryPath = join(dir, fileName);
-    const commentaryFile = chapterLayerFileSchema.parse(
-      JSON.parse(readFileSync(commentaryPath, "utf8")),
-    );
+    // Validated through Zod, written back from what `JSON.parse` produced:
+    // `.parse()` returns a new object carrying the schema's key order rather
+    // than the file's, which rewrites `"layer"` to a different position in
+    // every file it touches — a diff that says nothing, and one the
+    // importers flip straight back (the same fault as PR 109).
+    const commentaryRaw = JSON.parse(readFileSync(commentaryPath, "utf8")) as {
+      items: { label: Record<string, string> }[];
+    };
+    const commentaryFile = chapterLayerFileSchema.parse(commentaryRaw);
     if (commentaryFile.layer !== "commentary") continue;
 
     let changedHere = 0;
-    for (const item of commentaryFile.items as CommentaryItem[]) {
+    // `commentaryFile` is the validated read model; `commentaryRaw.items[i]`
+    // is what gets serialised, so every write below goes there by index.
+    const labelAt = (index: number): Record<string, string> =>
+      commentaryRaw.items[index]!.label;
+
+    for (const [index, item] of (
+      commentaryFile.items as CommentaryItem[]
+    ).entries()) {
       if (item.targetSeif === undefined) continue;
 
       const marker = markers.get(item.anchorId);
@@ -134,7 +158,34 @@ for (const dir of chapterDirs()) {
       // the marker at all (the invented running ordinals) are replaced.
       if (labelNamesMarker(item.label[language], marker)) continue;
 
+      labelAt(index)[language] = marker;
       item.label[language] = marker;
+      changedHere++;
+    }
+
+    // Second pass: fill in the OTHER language key, which has no source of
+    // its own to read.
+    //
+    // Only on non-English versions. A version's own printed marker is ground
+    // truth for its own language — that is the rule the loop above applies
+    // and `checkCommentaryLabelMatchesSourceMarker` enforces — so deriving
+    // `label.en` on an English version overrides the very text the reader
+    // sees. (Tried it: 29 validation errors, because `en-ai`'s source prints
+    // "11" where the Hebrew letter is כ. That the AI translation carries the
+    // invented numbering at all is a real defect, but it is a defect in that
+    // text, not something a label may silently disagree with.)
+    //
+    // On a Hebrew version there is no English source to consult, and the
+    // printed English marker is simply the gematria of the printed Hebrew
+    // letter (issue #96) — which is where the invented ordinals survived,
+    // and what the KabbalahMedia importer then copied verbatim into `en-bb`.
+    for (const [index, item] of language === "en"
+      ? []
+      : (commentaryFile.items as CommentaryItem[]).entries()) {
+      const derived = printedMarkerForHebrewLabel(item.label.he ?? "");
+      if (derived === null || item.label.en === derived) continue;
+
+      labelAt(index).en = derived;
       changedHere++;
     }
 
@@ -151,7 +202,7 @@ for (const dir of chapterDirs()) {
     if (!isDryRun) {
       writeFileSync(
         commentaryPath,
-        `${JSON.stringify(commentaryFile, null, 2)}\n`,
+        `${JSON.stringify(commentaryRaw, null, 2)}\n`,
         "utf8",
       );
     }

--- a/scripts/validate-content.ts
+++ b/scripts/validate-content.ts
@@ -35,6 +35,7 @@ import {
   GLOSSARY_FILE_NAME,
   GLOSSARY_INDEX_FILE_NAME,
 } from "./lib/glossary-splits.ts";
+import { printedMarkerForHebrewLabel } from "./lib/hebrew-numerals.ts";
 import { CONSOLIDATED_QA_KINDS } from "./lib/qa-consolidation.ts";
 import {
   offsetViolations,
@@ -616,6 +617,47 @@ const checkSefariaRefsApplyIndexOffsets = (
   }
 };
 
+/**
+ * On a version that prints Hebrew markers, `label.en` must be the gematria
+ * of `label.he` (issue #96: that is what the printed English edition marks
+ * both the text and its note list with).
+ *
+ * `checkCommentaryLabelMatchesSourceMarker` above only ever checks a
+ * version's *own* language, so `label.en` on a Hebrew file was unchecked —
+ * and it held the invented running ordinal for the whole corpus. That would
+ * be a quiet inconsistency on its own; what made it a blocker is that the
+ * KabbalahMedia importer copies `label` verbatim from Hebrew ground truth,
+ * so the wrong value propagated into `en-bb` and `import:kabbalahmedia --all`
+ * failed its own validation on content it had just written (issue #110).
+ *
+ * Deliberately not applied to English versions. There the source text prints
+ * its own marker and that text is what the reader sees, so it — not a
+ * derivation — is ground truth. `en-ai` currently prints the invented
+ * ordinals, which is a defect in that translation rather than a label
+ * disagreeing with its own page.
+ */
+const checkCommentaryEnglishLabelIsGematria = (
+  loaded: LoadedChapterFile[],
+  versions: ContentVersion[],
+  errors: string[],
+): void => {
+  const languageOf = new Map(versions.map((v) => [v.id, v.language]));
+
+  for (const entry of loaded) {
+    if (entry.file.layer !== "commentary") continue;
+    if (languageOf.get(entry.file.versionId) === "en") continue;
+
+    for (const item of entry.file.items) {
+      const expected = printedMarkerForHebrewLabel(item.label.he ?? "");
+      if (expected === null || item.label.en === expected) continue;
+
+      errors.push(
+        `${entry.relativePath}: anchor "${item.anchorId}" is labelled "${item.label.en}" (en) but "${item.label.he}" reads ${expected} — run \`pnpm migrate:commentary-labels\``,
+      );
+    }
+  }
+};
+
 const checkTocFileCrossReferences = (
   toc: Toc,
   loaded: LoadedChapterFile[],
@@ -952,6 +994,7 @@ export const validateContent = (contentDir: string): ValidationResult => {
       versionsParsed.data,
       errors,
     );
+    checkCommentaryEnglishLabelIsGematria(loaded, versionsParsed.data, errors);
     checkTranslatedVersionIntegrity(
       versionsParsed.data,
       loaded,

--- a/tests/fixtures/content-integrity/en-label-not-gematria/parts/part-01/chapters/chapter-01/commentary.v1.json
+++ b/tests/fixtures/content-integrity/en-label-not-gematria/parts/part-01/chapters/chapter-01/commentary.v1.json
@@ -1,0 +1,28 @@
+{
+  "chapterId": "part-01/chapter-01",
+  "layer": "commentary",
+  "versionId": "v1",
+  "items": [
+    {
+      "anchorId": "op-1",
+      "order": 1,
+      "label": {
+        "en": "11",
+        "he": "כ"
+      },
+      "targetSeif": 1,
+      "section": "ohr-pnimi",
+      "html": "<p>Anchored commentary for op-1.</p>"
+    },
+    {
+      "anchorId": "op-2",
+      "order": 2,
+      "label": {
+        "en": "2",
+        "he": "2"
+      },
+      "section": "ohr-pnimi",
+      "html": "<p>Unanchored commentary, known chapter, unknown seif.</p>"
+    }
+  ]
+}

--- a/tests/fixtures/content-integrity/en-label-not-gematria/parts/part-01/chapters/chapter-01/source.v1.json
+++ b/tests/fixtures/content-integrity/en-label-not-gematria/parts/part-01/chapters/chapter-01/source.v1.json
@@ -1,0 +1,19 @@
+{
+  "chapterId": "part-01/chapter-01",
+  "layer": "source",
+  "versionId": "v1",
+  "items": [
+    {
+      "n": 1,
+      "sefariaRef": "Fixture 1:1",
+      "html": "<p>Text <a class=\"tes-anchor\" href=\"#op-1\" data-anchor=\"op-1\">כ</a></p>",
+      "anchors": ["op-1"]
+    },
+    {
+      "n": 2,
+      "sefariaRef": "Fixture 1:2",
+      "html": "<p>No inline markers here.</p>",
+      "anchors": []
+    }
+  ]
+}

--- a/tests/fixtures/content-integrity/en-label-not-gematria/toc.json
+++ b/tests/fixtures/content-integrity/en-label-not-gematria/toc.json
@@ -1,0 +1,31 @@
+{
+  "volumes": [
+    {
+      "id": "volume-01",
+      "number": 1,
+      "title": { "en": "Volume 1" },
+      "parts": [
+        {
+          "id": "part-01",
+          "number": 1,
+          "sefariaNode": "Fixture Node",
+          "title": { "en": "Part 1" },
+          "chapters": [
+            {
+              "id": "part-01/chapter-01",
+              "kind": "chapter",
+              "number": 1,
+              "title": { "en": "Chapter 1" },
+              "availableLayers": ["source", "commentary"],
+              "availableVersions": {
+                "summary": [],
+                "source": ["v1"],
+                "commentary": ["v1"]
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tests/fixtures/content-integrity/en-label-not-gematria/versions.json
+++ b/tests/fixtures/content-integrity/en-label-not-gematria/versions.json
@@ -1,0 +1,10 @@
+[
+  {
+    "id": "v1",
+    "language": "he",
+    "direction": "rtl",
+    "title": "Fixture Version",
+    "license": "Public Domain",
+    "source": "curated"
+  }
+]

--- a/tests/unit/content-integrity.spec.ts
+++ b/tests/unit/content-integrity.spec.ts
@@ -111,6 +111,22 @@ describe("content integrity — unanchored commentary items", () => {
     ]);
   });
 
+  it("fires when a Hebrew version's English label is not its letter's gematria (issue #110)", () => {
+    // `label.he` here names the printed marker, so the own-language rule is
+    // satisfied and only this one can fire. Unchecked, `label.en` on Hebrew
+    // files held the invented running ordinal for the whole corpus — and the
+    // KabbalahMedia importer copies `label` verbatim from that ground truth,
+    // which is how the wrong value reached `en-bb` and made
+    // `import:kabbalahmedia --all` fail on its own output.
+    const { errors } = validateContent(
+      join(fixturesDir, "en-label-not-gematria"),
+    );
+
+    expect(nonBoilerplateErrors(errors)).toEqual([
+      'parts/part-01/chapters/chapter-01/commentary.v1.json: anchor "op-1" is labelled "11" (en) but "כ" reads 20 — run `pnpm migrate:commentary-labels`',
+    ]);
+  });
+
   it("accepts a label that names its marker among several (a note covering two printed letters)", () => {
     // `part-02/chapter-01` op-20 is labelled "ר וש" against a source that
     // prints only "ר" — richer data, not drift, so it must not fire.


### PR DESCRIPTION
Closes #110, which turned out to be three faults rather than one.

## The acceptance test, run against a clean tree

| | before | after |
|---|---|---|
| `import:sefaria --part 1` changes | 24 files | **0** |
| `import:kabbalahmedia --all` | fails its own validation, 14 errors | **completes, validates, 0 changes** |
| `migrate:commentary-labels` run twice | 58 labels on the second run | **0** |

That last one is the property the repo asks of every migration and this one never had.

## What was wrong

**1. `label.en` on Hebrew files was never checked.** `checkCommentaryLabelMatchesSourceMarker` only ever looks at a version's *own* language, so `label.en` on `he-jerusalem-1956` kept the invented running ordinal — "11" where the printed English edition marks "20", the gematria of כ (#96).

**2. That value propagates.** The KabbalahMedia importer copies `label` verbatim from Hebrew ground truth, so `en-bb` inherited it and `import:kabbalahmedia --all` failed validation *on content it had just written*. This is what forced the corpus-wide coverage refresh in #123 to be done by hand.

**3. `migrate-commentary-labels` reordered keys**, the same fault as PR 109 — it serialised Zod's object, which carries the schema's key order rather than the file's. Every commentary file it had ever touched disagreed with both importers on where `"layer"` goes.

## The rule, and where it stops

`label.en` is the gematria of `label.he` — **on non-English versions only**.

I tried the global version first and it produced 29 validation errors, which taught me the boundary: `en-ai`'s own source text prints "11" where the Hebrew letter is כ. On a version that prints its own markers, that text is what the reader sees and it is ground truth; deriving over it would make the label disagree with its own page. That the AI translation carries the invented numbering at all is a real defect — filed separately, not papered over here.

So: own-language from the printed marker, other-language by derivation. The two rules don't overlap, and `checkCommentaryEnglishLabelIsGematria` now enforces the second with a negative fixture (a Hebrew-version chapter whose `label.he` correctly names its marker, so only the new rule can fire).

## Content change

195 labels across 18 files, all `label.en`, no key-order churn. Plus a one-time key-order normalisation of two `en-bb` commentary files left over from the old migration.

## Verification

`task check` green: 922 unit tests (1 new), content validation, full generate, 9/9 e2e. Red-green checked the new validator by reverting one label: it fires with `anchor "op-11" is labelled "11" (en) but "כ" reads 20`.