### PR TITLE
ci: cache the font downloads, and refuse to deploy a build that lost them

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -56,8 +56,33 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
+      # `@nuxt/fonts` downloads every subset from Google at build time, and a
+      # single 404 from `fonts.gstatic.com` fails the whole deploy — it did,
+      # for a commit with nothing wrong with it, and a re-run of the same SHA
+      # then succeeded (issue #121). A failed deploy is also invisible from
+      # the outside: `main` has merged and the site simply keeps serving the
+      # previous build.
+      #
+      # The cache is the module's own download cache, so a warm run needs no
+      # font network at all. Keyed on the font configuration: change a family
+      # or a subset and the key changes, so a stale cache can never mask a
+      # config that no longer fetches what it should.
+      - name: Restore font download cache
+        uses: actions/cache@v4
+        with:
+          path: node_modules/.cache/nuxt/fonts
+          key: nuxt-fonts-${{ hashFiles('nuxt.config.ts') }}
+          restore-keys: |
+            nuxt-fonts-
+
       - name: Generate static site
         run: pnpm generate
+
+      # The Hebrew families ship zero glyphs if their subsets are ever
+      # dropped, and nothing errors when that happens (see the `tes-seo-ssg`
+      # skill). A build that silently lost its fonts should not deploy.
+      - name: Verify font output
+        run: node scripts/verify-font-output.mjs
 
       # The Actions-based Pages deploy serves the artifact verbatim (no
       # Jekyll pass), but the marker costs nothing and guards the

--- a/scripts/verify-font-output.mjs
+++ b/scripts/verify-font-output.mjs
@@ -1,0 +1,104 @@
+/**
+ * Fails a build whose font output is missing or implausibly small.
+ *
+ * Two failure modes this catches, both of which ship a broken site without
+ * erroring on their own:
+ *
+ * - **Hebrew subsets dropped.** `@nuxt/fonts` defaults to latin-only, and a
+ *   Hebrew family configured without `subsets: ["latin", "hebrew"]` emits
+ *   @font-face rules with no Hebrew glyph coverage at all. The site renders,
+ *   in a fallback serif, and nothing anywhere says so (see `tes-seo-ssg`).
+ * - **A partial font fetch.** The download step reaches Google per subset;
+ *   anything that leaves some of them unfetched produces a thinner `_fonts`
+ *   directory rather than an error (issue #121).
+ *
+ * Deliberately a floor rather than an exact count: the exact number of subset
+ * files is Google's business and changes when they re-cut a family. What is
+ * ours is "the Hebrew reading faces are present, and the payload is the size
+ * a full fetch produces".
+ */
+import { readdirSync, readFileSync, statSync } from "node:fs";
+import { join } from "node:path";
+
+const FONT_DIR = ".output/public/_fonts";
+/**
+ * The generated `@font-face` rules end up in the built entry stylesheet, not
+ * in `.nuxt/nuxt-fonts-global.css` (which is the module's build-time input
+ * and is empty by the time the output exists). Checking the shipped CSS is
+ * also the more honest test: it is what the browser reads.
+ */
+const CSS_DIR = ".output/public/_nuxt";
+
+/** Families the reader cannot do without — the two Hebrew reading faces. */
+const REQUIRED_FAMILIES = ["David Libre", "Frank Ruhl Libre"];
+
+/**
+ * The Hebrew block. A shipped stylesheet with no `@font-face` covering it
+ * has no Hebrew glyphs, whatever else it has — which is the failure that
+ * produces a rendered, wrong-looking site and no error anywhere.
+ */
+const HEBREW_UNICODE_RANGE = "U+590-5FF";
+
+/** A full fetch is ~716KB across ~28 files; well under either means a partial one. */
+const MIN_FILES = 20;
+const MIN_BYTES = 500_000;
+
+const fail = (message) => {
+  console.error(`✖ ${message}`);
+  process.exitCode = 1;
+};
+
+let files = [];
+try {
+  files = readdirSync(FONT_DIR);
+} catch {
+  fail(`${FONT_DIR} does not exist — the build shipped no fonts at all.`);
+  process.exit(1);
+}
+
+const bytes = files.reduce(
+  (total, name) => total + statSync(join(FONT_DIR, name)).size,
+  0,
+);
+
+if (files.length < MIN_FILES) {
+  fail(
+    `${FONT_DIR} has ${files.length} files, expected at least ${MIN_FILES}.`,
+  );
+}
+if (bytes < MIN_BYTES) {
+  fail(`${FONT_DIR} is ${bytes} bytes, expected at least ${MIN_BYTES}.`);
+}
+
+const css = readdirSync(CSS_DIR)
+  .filter((name) => name.endsWith(".css"))
+  .map((name) => readFileSync(join(CSS_DIR, name), "utf8"))
+  .join("");
+
+const flat = css.replaceAll("\n", "");
+
+for (const family of REQUIRED_FAMILIES) {
+  // The real assertion is a `src:` pointing at a downloaded file — a
+  // `font-family` mention alone is also produced by the local-fallback
+  // metrics rule, which is present even when nothing was fetched.
+  const declared = new RegExp(
+    `font-family:${family}[;,}][^}]*?src:[^}]*?_fonts`,
+  ).test(flat);
+  if (!declared) {
+    fail(`No @font-face for "${family}" — Hebrew would render in a fallback.`);
+  }
+}
+
+if (!flat.includes(HEBREW_UNICODE_RANGE)) {
+  fail(
+    `No @font-face covers ${HEBREW_UNICODE_RANGE} — the site would render Hebrew in a fallback serif, silently.`,
+  );
+}
+
+if (process.exitCode === 1) {
+  console.error("\nFont output verification failed.");
+} else {
+  console.log(
+    `✓ Fonts: ${files.length} files, ${Math.round(bytes / 1024)}KB, Hebrew families present.`,
+  );
+}


### PR DESCRIPTION
Refs #121. Does not fully close it — see the last section.

## What happened

The deploy for #120 failed on:

```
FetchError: [GET] "https://fonts.gstatic.com/s/inter/v20/…woff2": 404 Not Found
  at @nuxt/fonts/dist/module.mjs:192
```

Nothing was wrong with the commit; re-running the same SHA succeeded. And the failure is invisible from outside — `main` had merged and the site kept serving the previous build, which looks identical to "not deployed yet". I only noticed because the owner said a fix wasn't there.

Local builds never see it, because the font cache is already warm. That is the shape of the problem: `task check` green, CI red.

## Two changes

**Cache the module's own download cache**, keyed on `nuxt.config.ts`. A warm run needs no font network at all; changing a family or a subset changes the key, so a stale cache can never mask a config that stopped fetching what it should.

**Verify the font output before deploying.** This is the half I care about more. The Hebrew families ship zero glyphs if their subsets are dropped and *nothing errors* — the site renders, in a fallback serif (the repo has shipped exactly that once). `scripts/verify-font-output.mjs` fails on:

- a missing or implausibly small `_fonts` directory (a partial fetch produces a thinner one, not an error);
- a Hebrew reading face with no `@font-face` whose `src:` points at a downloaded file — a bare `font-family` mention is also emitted by the local-fallback metrics rule, so that alone proves nothing;
- **shipped CSS with no `@font-face` covering `U+590-5FF`** at all.

## On that last check, and being straight about it

My first version asserted the Hebrew families were "present". I tried to prove it by dropping `subsets: ["latin", "hebrew"]` from David Libre — and **it passed anyway**, because the family is still declared and the other Hebrew families still cover the range. The check was weaker than the commit message I had written for it.

So the assertion is now the unicode range, and it only trips when *every* Hebrew family loses its subsets — which is precisely the historical failure, since the default is latin-only for all of them at once. Verified by removing all three and rebuilding:

```
✖ No @font-face covers U+590-5FF — the site would render Hebrew in a fallback serif, silently.
```

and passing again on the restored config.

## What this does not do

Issue #121's acceptance criterion is "a deploy succeeds with no network access to `fonts.gstatic.com`". A **cold** cache still reaches Google, so this makes the failure rare rather than impossible. Truly removing it means committing the woff2 files and hand-writing the `@font-face` rules with their unicode-ranges — which trades a rare upstream flake for a permanently hand-maintained stylesheet in the exact area that fails silently. I'd rather leave #121 open with that trade written down than take it on unasked. `verify-font-output.mjs` is what makes either choice safe.

`task check` green: 922 unit tests, full generate, 9/9 e2e.