### PR TITLE
fix(reader): dock the pane bar in normal flow, not against the viewport

### DIFF
--- a/app/assets/css/main.css
+++ b/app/assets/css/main.css
@@ -693,11 +693,7 @@ a[href],
 }
 
 .tes-pane-body {
-  @apply min-h-0 flex-1 overflow-y-auto px-4 lg:pb-4;
-  /* Clears the docked pane-switcher bar (`MobilePanePill`, fixed to the
-     bottom edge below `lg`) plus the device's own safe area, so the last
-     line of a chapter is never sitting underneath it. */
-  padding-block-end: calc(3.5rem + env(safe-area-inset-bottom));
+  @apply min-h-0 flex-1 overflow-y-auto px-4 pb-4;
   /* Named rather than a bare `pt-4` because the sticky headings inside have
      to cancel exactly this value — see `.tes-commentary-seif-heading`. */
   --pane-pad-block-start: 1rem;

--- a/app/components/reader/MobilePanePill.vue
+++ b/app/components/reader/MobilePanePill.vue
@@ -1,12 +1,29 @@
 <script setup lang="ts">
-// Mobile panes swipe mode's pane switcher (T9): a floating pill fixed near
-// the bottom of the viewport (the thumb zone) — not a top tab bar — so it
+// Mobile panes swipe mode's pane switcher (T9): a bar docked to the bottom
+// of the reader (the thumb zone) — not a top tab bar — so it
 // stays reachable one-handed and never competes with the toolbar for space.
 // Always visible while this mode is active: it does not participate in
 // study mode's auto-hiding chrome (that mechanism doesn't run in panes
-// mode at all — see `useAutoHidingChrome`), and hides only while
-// `CommentarySheet` (`useCommentarySheet`) or the Contents panel
-// (`useContentsPanel`) is open, so no two floating surfaces ever overlap.
+// mode at all — see `useAutoHidingChrome`).
+//
+// In normal flow, not `position: fixed`. It is the last child of
+// `.tes-pane-shell`, which is a flex column, so it simply occupies the
+// bottom row and the swipe track shrinks above it. `fixed` looked
+// equivalent and was not: on Firefox for Android the dynamic address bar
+// moves the viewport a fixed element anchors to, and `bottom: 0` came to
+// rest a strip above the actual bottom edge with the page background
+// showing beneath it (issue #122). Everything else on the page is placed
+// by layout — sized off the reader root's `h-dvh` — and rendered correctly
+// throughout; only the one element positioned against the viewport did
+// not. Being in flow also means the pane body needs no compensating
+// bottom padding to avoid it.
+//
+// It stays rendered while `CommentarySheet` (`useCommentarySheet`) or the
+// Contents panel (`useContentsPanel`) is open, and goes `inert` instead.
+// Removing it from the DOM would reflow the pane underneath every time one
+// opens or closes; `inert` takes it out of the tab order and the
+// accessibility tree without moving anything, which is what a modal above
+// it wants anyway.
 //
 // `panes`: the panes that actually exist for this chapter (from
 // `resolveReaderPanes` via `MobileSwipePanes`) — `segments` renders a tab
@@ -110,8 +127,9 @@ const onKeydown = (event: KeyboardEvent, index: number) => {
 
 <template>
   <div
-    v-if="!isSheetOpen && !isContentsOpen && segments.length > 1"
-    class="fixed inset-x-0 bottom-0 z-30 border-t border-(--border) bg-(--surface-raised) pb-[env(safe-area-inset-bottom)] lg:hidden"
+    v-if="segments.length > 1"
+    :inert="isSheetOpen || isContentsOpen"
+    class="shrink-0 border-t border-(--border) bg-(--surface-raised) pb-[env(safe-area-inset-bottom)] lg:hidden"
   >
     <div
       role="tablist"

--- a/tests/e2e/reader.spec.ts
+++ b/tests/e2e/reader.spec.ts
@@ -346,7 +346,7 @@ test.describe("mobile reader", () => {
 
     const bar = page
       .getByRole("tablist", { name: "Reader pane" })
-      .locator("xpath=ancestor::div[contains(@class,'fixed')][1]");
+      .locator("xpath=..");
     const box = (await bar.boundingBox())!;
     const viewport = page.viewportSize()!;
 
@@ -356,5 +356,47 @@ test.describe("mobile reader", () => {
 
     // One row, not two — "Inner Observation" wrapping made the bar ragged.
     expect(box.height).toBeLessThan(72);
+
+    // In normal flow, not `position: fixed`. On Firefox for Android the
+    // dynamic address bar moves the viewport a fixed element anchors to, and
+    // `bottom: 0` came to rest a strip above the real bottom edge with the
+    // page showing beneath it (issue #122). Everything placed by layout was
+    // correct throughout, so the fix is to be placed by layout.
+    await expect(bar).toHaveCSS("position", "static");
+
+    // The pane ends exactly where the bar begins — no overlap to compensate
+    // for with padding, and nothing hidden underneath it.
+    const paneBody = page.locator("#reader-source-pane .tes-pane-body");
+    expect(
+      Math.round(
+        (await paneBody.boundingBox())!.y +
+          (await paneBody.boundingBox())!.height,
+      ),
+    ).toBe(Math.round(box.y));
+  });
+
+  test("keeps the pane still when the contents panel opens over the bar", async ({
+    page,
+  }) => {
+    // The bar used to be removed from the DOM while a panel was open, which
+    // in flow would reflow the pane underneath on every open and close. It
+    // goes `inert` instead: out of the tab order and the accessibility tree,
+    // still occupying its row.
+    await page.goto(CHAPTER_PATH);
+    await waitForHydration(page);
+    await page
+      .getByRole("group", { name: "Reading mode" })
+      .getByRole("button", { name: "Panes" })
+      .click();
+
+    const paneBody = page.locator("#reader-source-pane .tes-pane-body");
+    const heightOf = async () =>
+      Math.round((await paneBody.boundingBox())!.height);
+    const closed = await heightOf();
+
+    await page.getByRole("button", { name: "Contents", exact: true }).click();
+    await expect(page.getByRole("dialog")).toBeVisible();
+
+    expect(await heightOf()).toBe(closed);
   });
 });

--- a/tests/unit/mobile-pane-pill.spec.ts
+++ b/tests/unit/mobile-pane-pill.spec.ts
@@ -159,17 +159,25 @@ describe("MobilePanePill", () => {
     expect(wrapper.vm.state.activePane.value).toBe("source");
   });
 
-  it("hides itself while the commentary sheet is open", async () => {
+  it("goes inert — not away — while the commentary sheet is open", async () => {
+    // It used to be removed from the DOM. Now that the bar sits in normal
+    // flow rather than `position: fixed` (issue #122), removing it would
+    // reflow the pane above it on every open and close. `inert` takes it
+    // out of the tab order and the accessibility tree without moving
+    // anything, which is what a modal above it wants regardless.
     stubNarrowViewport();
     const wrapper = await mountSuspended(Host);
-    expect(wrapper.find('[role="tablist"]').exists()).toBe(true);
+    const bar = () => wrapper.find('[role="tablist"]').element.parentElement;
+
+    expect(bar()?.hasAttribute("inert")).toBe(false);
 
     wrapper.vm.sheet.open(1);
     await nextTick();
-    expect(wrapper.find('[role="tablist"]').exists()).toBe(false);
+    expect(wrapper.find('[role="tablist"]').exists()).toBe(true);
+    expect(bar()?.hasAttribute("inert")).toBe(true);
 
     wrapper.vm.sheet.close();
     await nextTick();
-    expect(wrapper.find('[role="tablist"]').exists()).toBe(true);
+    expect(bar()?.hasAttribute("inert")).toBe(false);
   });
 });


### PR DESCRIPTION
Closes #122.

## What you were seeing

A strip of page background below the bar — it wasn't reaching the bottom edge.

Desktop Gecko measures perfectly clean at the same viewport (`top 870, bottom 915` against a 915px screen), so it isn't a Gecko CSS difference. It's Firefox for Android's **dynamic address bar** moving the viewport that a `position: fixed` element anchors to.

The diagnosis that matters: everything else on the page is placed by *layout* — sized off the reader root's `h-dvh` — and rendered correctly throughout. Only the one element positioned against the *viewport* didn't. So the fix is to stop positioning it against the viewport.

## The fix is a deletion

The bar is already the last child of `.tes-pane-shell`, which is `flex h-full min-h-0 flex-col`. So it just becomes the bottom row, and the swipe track shrinks above it. Gone with `fixed`:

- `inset-x-0 bottom-0 z-30`
- `.tes-pane-body`'s `padding-block-end: calc(3.5rem + env(safe-area-inset-bottom))` — an in-flow bar cannot cover the text it sits beneath, so there is nothing to compensate for. Back to a plain `pb-4`.

## The one thing that needed thought

The bar used to unmount while the commentary sheet or contents panel was open. Harmless when it floated; in flow it would reflow the pane on every open and close. It now goes `inert` instead — out of the tab order and the accessibility tree, still occupying its row, which is what a modal above it wants anyway.

Measured with the panel open and closed: pane body identical in both states (`bottom 870, height 589`), in both engines.

## Verification

Driven at 412x915 in **both** Chromium and Firefox:

```
CHROMIUM  position: static  gapBelowBar: 0  bodyBottom: 870  barTop: 870
FIREFOX   position: static  gapBelowBar: 0  bodyBottom: 870  barTop: 870
```

The pane ends exactly where the bar begins — no overlap, nothing hidden underneath.

`task check` green: 922 unit tests, content validation, full generate, **10/10 e2e** (one new). The e2e now asserts `position: static` and the pane/bar edges meeting, and there's a new case for the panel-open reflow. The unit spec that pinned the old "removed from the DOM" contract is updated to the `inert` one rather than deleted.

I can't test Firefox Android directly, so this is reasoned from the mechanism plus both desktop engines — please give it a look once it deploys.