### PR TITLE
feat(content): translate the first Ohr Pnimi batch into English

### DIFF
--- a/content/parts/part-02/chapters/chapter-01/commentary.en-ai.json
+++ b/content/parts/part-02/chapters/chapter-01/commentary.en-ai.json
@@ -1,8 +1,8 @@
 {
   "chapterId": "part-02/chapter-01",
+  "layer": "commentary",
   "versionId": "en-ai",
   "sefariaRef": "Ohr Penimi on Talmud Eser HaSefirot 2:1",
-  "layer": "commentary",
   "items": [
     {
       "anchorId": "op-1",
@@ -375,6 +375,248 @@
       "targetSeif": 8,
       "section": "ohr-pnimi",
       "html": "You already know regarding the matter of “near” that there is no meaning here of place, heaven forbid, but rather the meaning is a nearness of form. You also know that from Ein Sof to the middle point there are four phases of a change of form, which are the ten Sefirot of the circles, where the middle point is phase four, the coarsest of all. And the first circle, called Keter, is the aspect of the resting of the root of these four phases, as above. And it is understood of itself that the circle of Keter, being the purest of all the circles, has a form that is closer to Ein Sof than all of them. And phase one, a little coarser than it, is farther from Ein Sof than Keter. And phase two, coarser still, is farther from Ein Sof than phase one, until the middle point, the coarsest of all, is regarded as being farther from Ein Sof than all of them.<br>And one should not object to this from what is written above (Part 1, Chapter 1, item 100), that there is no aspect of above and below in the circles. Because the intention here is that after the circles received into themselves the illumination of the line, then the aspect of above and below, and all the qualities prevailing in the line, were made in them."
+    },
+    {
+      "anchorId": "op-32",
+      "order": 32,
+      "label": {
+        "he": "32",
+        "en": "32"
+      },
+      "sefariaRef": "Ohr Penimi on Talmud Eser HaSefirot 2:1:32",
+      "section": "ohr-pnimi",
+      "html": "The Keter in a world or in a Sefira is regarded by the name “roof” of that world or that Sefira, and the Malchut in every world and Sefira is regarded by the name “ground” in that world or that Sefira. And behold, the upper circle is the Sefira of Keter, and the roof of this Keter is the Keter in the ten Sefirot of this Keter."
+    },
+    {
+      "anchorId": "op-33",
+      "order": 33,
+      "label": {
+        "he": "33",
+        "en": "33"
+      },
+      "sefariaRef": "Ohr Penimi on Talmud Eser HaSefirot 2:1:33",
+      "section": "ohr-pnimi",
+      "html": "The garments of the Mochin are called by the name Tzelem [image], from the word Tzel [shadow]. And the illumination of straightness that is included of the first three Sefirot is called by the name “Adam,” because it receives GAR in the garments of Tzelem. This is a lengthy matter, and this is not its place."
+    },
+    {
+      "anchorId": "op-34",
+      "order": 34,
+      "label": {
+        "he": "34",
+        "en": "34"
+      },
+      "sefariaRef": "Ohr Penimi on Talmud Eser HaSefirot 2:1:34",
+      "section": "ohr-pnimi",
+      "html": "The Rosh [head] of every Sefira and Partzuf is the first three Sefirot: Keter, Hochma, Bina. And the seven lower Sefirot — Hesed, Gevura, Tifferet, Netzah, Hod, Yesod, Malchut — that are in every Sefira and Partzuf are regarded as the aspect of the Guf [body] of that Sefira and Partzuf. And when they are in order, that is, the lights of GAR in the vessels of GAR and the lights of ZAT in the vessels of ZAT, then the Partzuf is regarded as “possessing an upright stature.” But if the lights of the Guf are found in the vessels of GAR, and not the lights that belong to them, then that Partzuf is regarded as having no upright stature, since the aspect of the Rosh is not more important than the aspect of the Guf, seeing that even in the Rosh only the aspects of the lights of the Guf serve. And this is called the bowing of the head, for the Rosh is with the Guf in one degree."
+    },
+    {
+      "anchorId": "op-35",
+      "order": 35,
+      "label": {
+        "he": "35",
+        "en": "35"
+      },
+      "sefariaRef": "Ohr Penimi on Talmud Eser HaSefirot 2:1:35",
+      "section": "ohr-pnimi",
+      "html": "This means that there are 248 discernments of Hesed in the upper Partzuf, from which the 248 organs in the lower ones are drawn, as detailed (in the Mishnah, Ohalot). This is not the place to elaborate, and it will be explained in its place."
+    },
+    {
+      "anchorId": "op-36",
+      "order": 36,
+      "label": {
+        "he": "36",
+        "en": "36"
+      },
+      "sefariaRef": "Ohr Penimi on Talmud Eser HaSefirot 2:1:36",
+      "section": "ohr-pnimi",
+      "html": "There is no essence in all the worlds, neither in the upper worlds nor in this world, in which the above ten Sefirot are not discerned, which are the four known phases and their root. And this is what he says, that in the lower man of this world, too, there are likewise five phases, etc."
+    },
+    {
+      "anchorId": "op-37",
+      "order": 37,
+      "label": {
+        "he": "37",
+        "en": "37"
+      },
+      "sefariaRef": "Ohr Penimi on Talmud Eser HaSefirot 2:1:37",
+      "section": "ohr-pnimi",
+      "html": "The vessels in the ten Sefirot are called Keter, Hochma, Bina, ZA, Malchut. And the lights in them are called Yechida, Haya, Neshama, Ruach, Nefesh (as written in Devarim Rabbah, Chapter 2, 26), for the light of Yechida clothes in the vessel of Keter, the light of Haya clothes in the vessel of Hochma, the light of Neshama in the vessel of Bina, the light of Ruach in the vessel of Zeir Anpin, and the light of Nefesh in the vessel of Malchut."
+    },
+    {
+      "anchorId": "op-38",
+      "order": 38,
+      "label": {
+        "he": "38",
+        "en": "38"
+      },
+      "sefariaRef": "Ohr Penimi on Talmud Eser HaSefirot 2:1:38",
+      "section": "ohr-pnimi",
+      "html": "You already know that the discernment of the degrees is according to the refinement and the coarseness in them, and that every “higher” means the measure that is more refined than its counterpart."
+    },
+    {
+      "anchorId": "op-39",
+      "order": 39,
+      "label": {
+        "he": "39",
+        "en": "39"
+      },
+      "sefariaRef": "Ohr Penimi on Talmud Eser HaSefirot 2:1:39",
+      "section": "ohr-pnimi",
+      "html": "The lights are Nefesh, Ruach, Neshama, Haya, Yechida, and the vessels are KHB ZON, as above."
+    },
+    {
+      "anchorId": "op-40",
+      "order": 40,
+      "label": {
+        "he": "40",
+        "en": "40"
+      },
+      "sefariaRef": "Ohr Penimi on Talmud Eser HaSefirot 2:1:40",
+      "section": "ohr-pnimi",
+      "html": "The matter of division in spirituality is by reason of the disparity of form that was renewed there (as above, Part 1, Chapter 1, item 30, the passage beginning “However”). And every one that is above its counterpart means that it is more refined than its counterpart, and every one that is below its counterpart means that it is more coarse than its counterpart. For through this disparity of form of coarseness it parted and emerged from its counterpart and became lower than it. And it is known that the lights are bestowed from every upper one to the one below it, and for this reason the lower one is compelled to receive the abundance in the highest and most refined phase in it, while the upper one gives it the abundance only from the lowest and most coarse phase that is in it. In this way the form of the light that comes from the upper one equalizes with the form of the vessel that is in the lower one, for the most coarse and gross phase in the upper one has equivalence with the finer and more refined phase in the lower one. It follows that the lower one cannot receive all the light that belongs to it to receive, but only a very small part, that is, only as much as the most refined vessel in it can receive; and the rest of the phases in it, which are not so refined, must remain without the light that belongs to them, because of their disparity of form toward the upper one that bestows upon them.<br>Therefore it is discerned here that the light belonging to the lower one divides into two phases. The first is the small measure of the light that it receives from the upper one inside the highest vessel in it, as above, and this light that it receives is called the “inner light” of the lower one. The second is the entire measure of light belonging to the phases that remained in the lower one and could not receive from the upper one because of their disparity of form, as above; and this whole measure is regarded as having remained in the upper one and not descended to the lower one, and it is called “surrounding light.” It is called so because it surrounds the lower one, that is to say, it shines upon it from afar, even though it is not clothed in it, but is a distant and scant illumination. And this matter of a distant illumination is capable of refining the aspects of coarseness in the lower one, until the forms of all the phases in the lower one equalize with the form of the upper one, and then it will be able to receive all the light that belongs to it. And this is called the entrance of the surrounding lights, that is, that the surrounding lights entered and clothed in the vessels of the lower one, which had been refined and all became the aspect of inner light."
+    },
+    {
+      "anchorId": "op-41",
+      "order": 41,
+      "label": {
+        "he": "41",
+        "en": "41"
+      },
+      "sefariaRef": "Ohr Penimi on Talmud Eser HaSefirot 2:1:41",
+      "section": "ohr-pnimi",
+      "html": "That is to say, since the lights divided into inner light and surrounding light, as above, there are consequently two kinds of reception in the vessel, which are reception inside the vessel and reception from the externality of the vessel (see the Table of Answers, Part 1, item 102). The inner light is received within the innermost part of the vessel, and the surrounding light, which refines it of its coarseness (as above in the adjacent passage), is regarded as being received through the externality of the vessel, that is, without any clothing in the vessel.<br>And the matter of the division into externality and internality that is said of the vessel is according to the discernment of the refinement and the coarseness in the vessel, for only the coarseness in it is fit for the reception of the inner light, since the principal vessel of reception of the emanated being is phase four. However, the first three phases are not fit for reception; rather, they are what cause phase four to be revealed. And therefore every vessel is regarded in itself as four phases in the vessel, in which the light is received principally in phase four in it, and it is therefore called the internality of the vessel and its innermost part, where the abundance dwells.<br>And the three phases, which only cause the revelation of phase four in the vessel and are themselves not capable of reception, are considered as surrounding phase four from its externality. This is similar to the thickness of the wall of a corporeal vessel, which holds four shells surrounding one another, where everything received in the vessel is in the internality in it, that is, in the inner shell, and the other three shells in the thickness of the wall only strengthen the inner shell, so that it will have the strength to bear what fills it. And in this same way one should understand here in spirituality, that the principal phase that holds the abundance within it is phase four in the vessel, and the first three phases are the causes that reveal phase four in all its strength, until it becomes fit to hold the abundance; but they themselves are not capable of receiving the inner light.<br>Therefore they are called the externality of the vessel, being outside the aspect of the reception of the inner light: phase three is externality to phase four, and phase two is externality to phase three, and phase one is externality to them all and surrounds them all. And above them all there is an external phase without any coarseness whatsoever, which is the aspect of the root of all four phases in the vessel. And know that this completely refined phase is the vessel of reception for the surrounding light, for by reason of the wondrous refinement in it, it can receive the illumination of the surrounding light, even though it is from afar.<br>And thus the matter of the division of the vessel has been explained, that the internality in it means the more coarse phase in the vessel, that is, phase four in the vessel, and it is what receives the inner light; and the externality in it means the more refined phase in the vessel, that is, the aspect of the root of the vessel, as above, and it is what receives the surrounding light from afar. And one should not object that phase four is not fit for reception by force of the restriction and the screen, for we are dealing here only with the aspect of the reflected light that rises from within phase four (and see the Inner Observation)."
+    },
+    {
+      "anchorId": "op-42",
+      "order": 42,
+      "label": {
+        "he": "42",
+        "en": "42"
+      },
+      "sefariaRef": "Ohr Penimi on Talmud Eser HaSefirot 2:1:42",
+      "section": "ohr-pnimi",
+      "html": "All the Sefirot that are able only to receive lights and have no ability to bestow upon others — the light in them is called by the name light of Nefesh. And it has already been explained that all the light in the circles must be received from the light of the line (as above, Part 2, Chapter 1, item 30). The reason is that it is impossible for the upper light to connect with the vessels except by means of a coupling with the screen that raises reflected light, for this reflected light connects the light with the vessels, as above (Part 2, Chapter 2, item 20). Therefore, in the vessels in which there is no such screen, the upper light does not connect with them, such that they might bestow upon others from above downward, and they are fit only to receive light from the preceding degree, from below upward, for the need of their own vitality alone; and this light is called the light of Nefesh, as above. And therefore, since there is no screen in the vessels of the circles, as above, the upper light does not connect with them themselves, but they must receive the light from the line, and this too only in the measure of their own vitality, and not in order to bestow, as explained. And therefore the light in the circles is called the light of Nefesh, as explained."
+    },
+    {
+      "anchorId": "op-43",
+      "order": 43,
+      "label": {
+        "he": "43",
+        "en": "43"
+      },
+      "sefariaRef": "Ohr Penimi on Talmud Eser HaSefirot 2:1:43",
+      "section": "ohr-pnimi",
+      "html": "The ten Sefirot of Ruach are aspects of bestowal, and therefore the light of Ruach is called by the name male light, that is to say, that it bestows. But the ten Sefirot of Nefesh are called by the name female light, that is to say, that it receives and cannot bestow. And therefore the ten Sefirot of the light of the line are called by the name ten Sefirot of Ruach, to indicate that they are the aspect of male and bestowing light. And the reason has already been explained above, in the adjacent passage; see there. And therefore Ruach is higher than the degree of Nefesh, since it is what bestows upon Nefesh."
+    },
+    {
+      "anchorId": "op-44",
+      "order": 44,
+      "label": {
+        "he": "44",
+        "en": "44"
+      },
+      "sefariaRef": "Ohr Penimi on Talmud Eser HaSefirot 2:1:44",
+      "section": "ohr-pnimi",
+      "html": "That is to say, that the five degrees KHB ZON are not drawn in straightness, the meaning of which is one below the other, that is, from the refined to the coarse (Part 2, Chapter 1, item 5), but rather the five degrees are equal to one another, and not one of them is below its counterpart, that is, coarser than its counterpart. Yet certainly there is between them, at the very least, the discernment of cause and consequence, for they emerge one from the other and are drawn one from the other: Hochma emerged from Keter, and Bina from Hochma, and ZA from Bina, and Malchut from Zeir Anpin (as above in the Inner Light, Part 1, Chapter 1, item 50, the passage beginning “Now”). However, this discernment of cause and consequence that is spoken of is defined by the aspect of their being found this inside that, in which every cause brings about its consequence, for Hochma is brought about by Keter, and Bina is brought about by Hochma, and so forth — in such a way that “this inside that” means that this is brought about by that, as explained. But there is no discernment of higher and lower between them at all (as above, Part 1, Chapter 1, item 100)."
+    },
+    {
+      "anchorId": "op-45",
+      "order": 45,
+      "label": {
+        "he": "45",
+        "en": "45"
+      },
+      "sefariaRef": "Ohr Penimi on Talmud Eser HaSefirot 2:1:45",
+      "section": "ohr-pnimi",
+      "html": "For the light is impressed by the vessel clothed in it, such that even when it leaves there for another vessel, it does not change the ways that it had in the previous vessel. And therefore, since while the light was in the line of straightness it was drawn and descended, this one below that one, that is, that it went on thickening in the order of the degrees by reason of the screen found there, as above (Part 2, Chapter 1, item 6) — therefore, even after it left there and came to the ten Sefirot of the circles, in which there is no screen, and necessarily becomes circular in them, even so it does not change its ways in its expansion from degree to degree. This means, for example, that when the light of the line comes to the Sefira of Keter, it becomes circular there, that is to say, it receives the form of that vessel, in which there is no discernment of higher and lower. However, when the light expands from the circle of Keter to the circle of Hochma, it does not become circular (see the Table of Answers, Part 1, item 3), but is drawn in straightness, that is, with a discernment of higher and lower. And it follows from this that the Sefira of the circle of Hochma is below the circle of Keter and coarser than Keter, for their form is not equal. And in this same way, when the light comes from Hochma to Bina, it is drawn to it in straightness, and Bina is discerned as below Hochma, that is, coarser than Hochma; and so with all the Sefirot. In such a way that although the ten Sefirot of the circles are equal in form, without a discernment of higher and lower on the part of the vessels, as above, nevertheless there is in them a discernment of higher and lower on the part of “their having in them all the aspects of the reception of the abundance that are in the ten Sefirot in the line of straightness.”"
+    },
+    {
+      "anchorId": "op-46",
+      "order": 46,
+      "label": {
+        "he": "46",
+        "en": "46"
+      },
+      "sefariaRef": "Ohr Penimi on Talmud Eser HaSefirot 2:1:46",
+      "section": "ohr-pnimi",
+      "html": "This means that after the four worlds ABYA were corrected, every Sefira became a complete Partzuf, with Rosh [head], Toch and Sof [end]. And because of this they received other names. The Partzuf that was made from Keter is called by the name Arich Anpin; the Partzuf that was made from Hochma is called by the name Abba; the Partzuf that was made from Bina is called by the name Ima; the Partzuf that was made from the six Sefirot HGT NHY is called by the name Zeir Anpin; and the Partzuf that was made from Malchut is called by the name Nukva. And the meaning of these names will be explained in their place."
+    },
+    {
+      "anchorId": "op-47",
+      "order": 47,
+      "label": {
+        "he": "47",
+        "en": "47"
+      },
+      "sefariaRef": "Ohr Penimi on Talmud Eser HaSefirot 2:1:47",
+      "section": "ohr-pnimi",
+      "html": "This means, for you already know that by reason of the light of the ten Sefirot of the line that is received in the circles, all the aspects of straightness are necessarily impressed in the circles as well (as above, item 50, the passage beginning “There is”). And behold, this aspect that is in the line, which is called a screen, whose reflected light is found to connect the upper light with the vessels (as above, Part 2, Chapter 1, item 20) — behold, this screen too is impressed in the circles, but without the coarseness in it. For coarseness cannot rise from a lower degree to one higher than it, not in the least; for it is called higher precisely because it does not have coarseness as the lower one does; and understand this. Rather, only the aspect of the opening that this screen reveals in the lower one, that is, in the ten Sefirot of straightness — that alone is what rises from the screen of the line of straightness and is impressed in the circles. And this opening from the screen is called by the name “window,” after the manner of the window fitted in a room in order to bring the light into that room; so this screen, by its property, reveals the reflected light so as to connect the light to the emanated being. In such a way that if the screen were to vanish from there, the light would depart from the emanated being and it would remain in darkness, after the manner of the blocking up of the window in a room. Therefore, when we come to name only the opening from the screen, and to exclude its coarseness, we define this by the name “window or aperture.”"
+    },
+    {
+      "anchorId": "op-48",
+      "order": 48,
+      "label": {
+        "he": "48",
+        "en": "48"
+      },
+      "sefariaRef": "Ohr Penimi on Talmud Eser HaSefirot 2:1:48",
+      "section": "ohr-pnimi",
+      "html": "That is, that it was impressed likewise in the values of right and left that served in the ten Sefirot of straightness (see the Table of Answers, Part 1, 23)."
+    },
+    {
+      "anchorId": "op-49",
+      "order": 49,
+      "label": {
+        "he": "49",
+        "en": "49"
+      },
+      "sefariaRef": "Ohr Penimi on Talmud Eser HaSefirot 2:1:49",
+      "section": "ohr-pnimi",
+      "html": "That is to say, that by reason of the aforementioned window there came to be there the discernment of the drawing and the descent of the light, that is, that it goes on thickening in the order of the degrees, in which the lower degree is coarser than the one preceding it. And this is what he says, “and from there Arich descends to the circle of Abba,” that is to say, that by reason of the window the light received an aspect of coarseness and an aspect of below at Abba of the circles, that is, Hochma, which was lowered in degree and is now not equal to the Keter of the circles as it was before they received the light of straightness through the window. And likewise Bina is below Hochma."
+    },
+    {
+      "anchorId": "op-50",
+      "order": 50,
+      "label": {
+        "he": "50",
+        "en": "50"
+      },
+      "sefariaRef": "Ohr Penimi on Talmud Eser HaSefirot 2:1:50",
+      "section": "ohr-pnimi",
+      "html": "He informs us that the matter of this window came about in the Sefirot together with the descent of the light to it from the upper circle. That is to say, that this light then impresses in it the matter of the screen that is included in it, as above, and it is therefore regarded as though the light pierces it and makes a window in it."
+    },
+    {
+      "anchorId": "op-51",
+      "order": 51,
+      "label": {
+        "he": "51",
+        "en": "51"
+      },
+      "sefariaRef": "Ohr Penimi on Talmud Eser HaSefirot 2:1:51",
+      "section": "ohr-pnimi",
+      "html": "This matter has already been explained well above (Part 2, Chapter 1, item 4, the passage beginning “This means”)."
+    },
+    {
+      "anchorId": "op-52",
+      "order": 52,
+      "label": {
+        "he": "52",
+        "en": "52"
+      },
+      "sefariaRef": "Ohr Penimi on Talmud Eser HaSefirot 2:1:52",
+      "section": "ohr-pnimi",
+      "html": "That is to say, that the light descends from circle to circle by way of drawing in straightness, in straight lines; but this is not considered an actual aspect of the correction of lines, which descend “from the screen” and in which there is male light, such that they could bestow upon others. Rather, these lines of the circles have no power of bestowal, because they descend in the aspect of “windows,” which suffice only for the reception of light for their own need alone, and not to bestow upon others. And this is the rule: whatever has no aspect of a screen in it has no male light in it, but female light, which is the light of Nefesh."
+    },
+    {
+      "anchorId": "op-53",
+      "order": 53,
+      "label": {
+        "he": "53",
+        "en": "53"
+      },
+      "sefariaRef": "Ohr Penimi on Talmud Eser HaSefirot 2:1:53",
+      "section": "ohr-pnimi",
+      "html": "One should not wonder at the name Adam that is used here, for it is as it is brought (in Midrash Rabbah, Bereshit 27): Rabbi Yudan said, Great is the power of the prophets, who liken the form to its Maker, as it is said, “And I heard a man's voice between the banks of Ulai,” etc., and “upon the likeness of the throne was a likeness as the appearance of a man upon it from above”; end of quote. And the reason for this will be explained in its place."
     }
   ]
 }

--- a/content/parts/part-03/chapters/chapter-08/commentary.en-ai.json
+++ b/content/parts/part-03/chapters/chapter-08/commentary.en-ai.json
@@ -111,6 +111,17 @@
       "targetSeif": 9,
       "section": "ohr-pnimi",
       "html": "<strong> The general rule:</strong> This is the general rule: wherever it is discerned that the reflected light ascends from below upward, the self of the upper light is found clothed there in this reflected light, which indicates the expansion of the light of Ein Sof, blessed be He, to make vessels, of which the ARI speaks above (Part 1, Chapter 1, Item 1); but in the place where it is discerned that the reflected light expands from above downward, in the manner mentioned, in the ten Sefirot of Beria, as written above in the passage nearby, then the upper light clothed here in this reflected light is no longer the self of the upper light, but is regarded rather as \"a light of offspring,\" drawn from the upper light, \"and not the very light of the upper light itself.\" And the reason is that it is drawn by force of the screen that raises reflected light because of the restraint within it, as above, and therefore the power of the lower one is already mixed into it, and it too is limited by the measure of the vessels and the stature that is in the screen, since the screen precedes the expansion of these ten Sefirot; that is, the screen is the cause that brings about the appearance of these ten Sefirot, and for this reason the light is limited by it, and it has already gone out from the category of the self of the upper light and is regarded as a light of offspring — unlike the reflected light ascending from the screen upward, which cannot raise anything at all of its coarseness there (as above, Part 3, Chapter 4, Ohr Pnimi, Item 50) — see there. Indeed this is said of the world of Beria and below; but in Atzilut there is no screen at all, as above, and therefore every light that is there, up to the conclusion of the legs, is regarded as the self of the light."
+    },
+    {
+      "anchorId": "op-10",
+      "order": 10,
+      "label": {
+        "he": "10",
+        "en": "10"
+      },
+      "sefariaRef": "Ohr Penimi on Talmud Eser HaSefirot 3:8:10",
+      "section": "ohr-pnimi",
+      "html": "For the Malchut of the upper one is for this reason called a spark of the Creator, as above, being what draws and emanates the degree below her — as written above, that all the degrees and the Partzufim [pl. of Partzuf] and the worlds, from the Rosh [head] of the line to the end of Assiya, emerge and are emanated one from the other by way of cause and effect. That is, that the Malchut of Malchut of every upper one descends below her degree, and she is what draws all four phases of the lower one, as is explained well and at length in Part 2, in the Inner Observation, Chapter 5, item 59. (For all these matters would have needed to be written here, had I not spared the printing costs.)"
     }
   ]
 }

--- a/content/parts/part-05/chapters/chapter-01/commentary.en-ai.json
+++ b/content/parts/part-05/chapters/chapter-01/commentary.en-ai.json
@@ -1,0 +1,19 @@
+{
+  "chapterId": "part-05/chapter-01",
+  "layer": "commentary",
+  "versionId": "en-ai",
+  "sefariaRef": "Ohr Penimi on Talmud Eser HaSefirot 5:1",
+  "items": [
+    {
+      "anchorId": "op-1",
+      "order": 1,
+      "label": {
+        "he": "1",
+        "en": "1"
+      },
+      "sefariaRef": "Ohr Penimi on Talmud Eser HaSefirot 5:1:1",
+      "section": "ohr-pnimi",
+      "html": "<b>Malchut, in which there are ten roots:</b> The matter of the expansion of every Partzuf has already been explained: that the upper light first expands to a coupling by striking on the screen in the vessel of Malchut, and reflected light rises from the screen upward and clothes the ten Sefirot that are in the upper light. And this clothing is called the ten Sefirot of the Rosh [head]. And afterward Malchut widens, by means of the reflected light that she raised, into ten Sefirot from herself and within herself, from above downward. And this clothing is called Guf [body], and in the Partzufim [pl. of Partzuf] of AK they are called Akudim. And you find that Malchut with the ten Sefirot of her reflected light are what draw and emanate the ten Sefirot of the Guf, and therefore her ten Sefirot are called by the name roots to the Sefirot of the Guf."
+    }
+  ]
+}

--- a/content/parts/part-05/chapters/chapter-02/commentary.en-ai.json
+++ b/content/parts/part-05/chapters/chapter-02/commentary.en-ai.json
@@ -1,0 +1,85 @@
+{
+  "chapterId": "part-05/chapter-02",
+  "layer": "commentary",
+  "versionId": "en-ai",
+  "sefariaRef": "Ohr Penimi on Talmud Eser HaSefirot 5:2",
+  "items": [
+    {
+      "anchorId": "op-1",
+      "order": 1,
+      "label": {
+        "he": "1",
+        "en": "1"
+      },
+      "sefariaRef": "Ohr Penimi on Talmud Eser HaSefirot 5:2:1",
+      "section": "ohr-pnimi",
+      "html": "<b>It stood there below the Sefira of Malchut</b>: It has already been explained that the first expansion of Akudim was at the level of Keter, since the coupling by striking was there, on the screen in the coarseness of phase four. And it is known that this level of Keter, after it departed from the first expansion of Akudim, did not again descend in the second expansion, but remained in its source in the Emanator, that is, the Malchut of the Rosh [head], which is its Emanator, as the ARI writes here. And this is what he says, that it stood there below the Sefira of Malchut that is in the ten Sefirot called the roots of Akudim. That is to say, that this level of Keter, which returned to the Emanator, that is, to the Malchut of the Rosh, being the branch of Malchut — therefore, when it returned to her, it is found to stand beneath her. And one must know the discernment between the Malchut of the Rosh, which possesses the screen, in which there is the coupling by striking and the reflected light, and the light of Keter that rose, which is the aspect of that same light that had already been clothed in a vessel, but returned and left there, and is now the aspect of light without a vessel. And remember this throughout all that follows."
+    },
+    {
+      "anchorId": "op-2",
+      "order": 2,
+      "label": {
+        "he": "2",
+        "en": "2"
+      },
+      "sefariaRef": "Ohr Penimi on Talmud Eser HaSefirot 5:2:2",
+      "section": "ohr-pnimi",
+      "html": "<br><b>3) Their faces are turned downward, to shine in the world of Akudim by means of that Keter:</b> This means that even after the departure of Akudim, the vessels of Akudim need to receive light from the ten Sefirot of the Rosh [head], and this is in order to give them vitality, which is a scant illumination, sufficient only for their existence. And behold, they must receive this illumination by means of the light of Keter, which stands beneath the Malchut of the Rosh. For this is the rule, that everything that comes and is bestowed upon the Partzuf is bestowed by means of the Sefira of Keter of that Partzuf, it being the upper root of those ten Sefirot. And therefore here too, although the light of Keter has already departed from the Partzuf, nevertheless the vessels cannot receive the aforementioned illumination that gives them vitality except by means of the light of Keter, which stands beneath the Malchut of the Rosh, as above."
+    },
+    {
+      "anchorId": "op-3",
+      "order": 3,
+      "label": {
+        "he": "3",
+        "en": "3"
+      },
+      "sefariaRef": "Ohr Penimi on Talmud Eser HaSefirot 5:2:3",
+      "section": "ohr-pnimi",
+      "html": "<br><b>The upper Keter of the roots also desires to bestow, etc., and they will beget offspring:</b> That is to say, that apart from the vitality that the branches receive from their light of Keter, which stands beneath the Malchut of the Rosh [head], as above in the adjacent passage, behold, they have a desire for the upper roots that are in the Rosh, that they should bestow upon their branches an abundant illumination sufficient for them, such that they will be able to couple and beget offspring. And this abundant illumination is not bestowed upon them except by means of the upper Keter of the roots, that is, by means of a coupling on the screen of the Malchut of the Rosh, which bestows upon the light of Keter that stands beneath that Malchut, and from there it is bestowed upon the branches, as is written further on."
+    },
+    {
+      "anchorId": "op-4",
+      "order": 4,
+      "label": {
+        "he": "4",
+        "en": "4"
+      },
+      "sefariaRef": "Ohr Penimi on Talmud Eser HaSefirot 5:2:4",
+      "section": "ohr-pnimi",
+      "html": "<br><b>4) The male and the female in the vessel of Keter of the upper branches:</b> They are the record of Keter with the record of phase three, which are included in the screen that rose and departed from the first expansion to the Malchut of the Rosh [head] (as explained in Part 4, Chapter 4, in the Inner Light, item 50; study it there well). And although phase four left no record, from where, then, is there here a record of the level of Keter? However, there are in every phase two kinds of records, for there is the aspect of the record of drawing, which belongs to the lower phase of the degree, and there is the aspect of the record of the clothing of the light, which belongs to the upper phase in the level of the degree. (And see concerning this in the Inner Observation, Part 4, item 41.) And the relation of these two records is as the aspects of male and Nukva, in which the record of clothing is the aspect of male in the record, and the record of drawing is the aspect of female in the record. And know that only the aspect of the female of the record of phase four vanished, that is, the one belonging to Malchut; but the aspect of the male of the record, which belongs to Keter, remained and is included in the screen that rose to the Malchut of the Rosh, as above."
+    },
+    {
+      "anchorId": "op-5",
+      "order": 5,
+      "label": {
+        "he": "5",
+        "en": "5"
+      },
+      "sefariaRef": "Ohr Penimi on Talmud Eser HaSefirot 5:2:5",
+      "section": "ohr-pnimi",
+      "html": "<br><b>Both of them rise, etc., and there they receive their illumination from it</b>: Behold, the ascent comes about through the refinement of the screen in the Tabur of the first expansion, until it becomes refined like the Emanator, that is, the Malchut of the Rosh [head], for equivalence of form unites spiritual things into one. And since the screen of the Guf [body] became refined like the screen of the Rosh, it is discerned that it rose and united with it in its place as one. And it is known that departure does not apply in the Rosh at all; rather, the screen that is there is always in an unceasing coupling with the upper light, and therefore the screen that rose there is likewise included with it in its coupling, and receives together with it from the upper light. And this is what he says, “that both of them rise, etc., beneath the Malchut, and there they receive their illumination from it,” that is, by being included in the upper coupling that is there, as explained."
+    },
+    {
+      "anchorId": "op-6",
+      "order": 6,
+      "label": {
+        "he": "6",
+        "en": "6"
+      },
+      "sefariaRef": "Ohr Penimi on Talmud Eser HaSefirot 5:2:6",
+      "section": "ohr-pnimi",
+      "html": "<br><b>And after they received all that they needed</b>, this means until they became fit to expand, with this illumination that they received, to their place in the Guf [body], as is written further on."
+    },
+    {
+      "anchorId": "op-7",
+      "order": 7,
+      "label": {
+        "he": "7",
+        "en": "7"
+      },
+      "sefariaRef": "Ohr Penimi on Talmud Eser HaSefirot 5:2:7",
+      "section": "ohr-pnimi",
+      "html": "<br><b>Now it turns its face upward</b>, that is to say, that the coupling belonging to the light of Keter ceased, at which point its illumination stops expanding to the ZON that are beneath it. And this is called that its posterior is toward the ZON, for the withholding of illumination is called by the name posterior. And the reason its illumination ceased will be explained further on, which is that the coupling reached the Nukva that is included in the record, which is the coarseness of phase three, and which draws only from the level of Hochma of the upper roots, and not from the Keter of the roots. And therefore the light of Keter that is beneath the Malchut no longer receives light for the ZON that are beneath it. And after the aforementioned coupling of phase three came about, behold, then the male and the female immediately expand to the Guf [body], to the vessel of Keter that is there, as is written further on. And the second expansion of Akudim comes about."
+    }
+  ]
+}

--- a/content/toc.json
+++ b/content/toc.json
@@ -1841,6 +1841,7 @@
                   "he-jerusalem-1956"
                 ],
                 "commentary": [
+                  "en-ai",
                   "he-jerusalem-1956"
                 ]
               }
@@ -1864,6 +1865,7 @@
                   "he-jerusalem-1956"
                 ],
                 "commentary": [
+                  "en-ai",
                   "he-jerusalem-1956"
                 ]
               }

--- a/content/toc.parts/part-05.json
+++ b/content/toc.parts/part-05.json
@@ -35,6 +35,7 @@
           "he-jerusalem-1956"
         ],
         "commentary": [
+          "en-ai",
           "he-jerusalem-1956"
         ]
       }
@@ -58,6 +59,7 @@
           "he-jerusalem-1956"
         ],
         "commentary": [
+          "en-ai",
           "he-jerusalem-1956"
         ]
       }

--- a/scripts/translate-apply.ts
+++ b/scripts/translate-apply.ts
@@ -1,7 +1,17 @@
 /**
  * Ingests a translated batch result and writes the corpus files.
  *
- * `pnpm translate:apply --file <result>.json [--dry-run]`
+ * `pnpm translate:apply --file <result>.json [--target <versionId>] [--dry-run]`
+ *
+ * `--target` names the version being written. It is a flag rather than a
+ * required field of the result file because the result file is what comes back
+ * from a MODEL, and the manifest's own instructions tell it to return
+ * `{ batch, translations }` and nothing else — deliberately, since the whole
+ * safety property below is that the model decides only `html`. Requiring it to
+ * echo `targetVersionId` made the documented output shape fail here with
+ * "`targetVersionId` undefined is not in content/versions.json", which is a
+ * confusing way to say "the runner forgot to tell me". A `targetVersionId` in
+ * the file is still honoured, so results that carry one keep working.
  *
  * The result file carries ONLY `{ chapterId, anchorId, html }` per item. Every
  * other field on a `CommentaryItem` — `order`, `label`, `sefariaRef`,
@@ -45,8 +55,12 @@ const arg = (flag: string): string | undefined => {
 const resultPath = arg("--file");
 const isDryRun = process.argv.includes("--dry-run");
 
+const targetFlag = arg("--target");
+
 if (!resultPath) {
-  console.error("usage: pnpm translate:apply --file <result>.json [--dry-run]");
+  console.error(
+    "usage: pnpm translate:apply --file <result>.json [--target <versionId>] [--dry-run]",
+  );
   process.exit(2);
 }
 
@@ -69,11 +83,15 @@ const versions = versionsFileSchema.parse(
   JSON.parse(readFileSync(join(CONTENT_ROOT, "versions.json"), "utf8")),
 );
 
-const targetVersionId = result.targetVersionId;
+// The flag wins over the file: the runner knows which version it is filling,
+// and a result file that names a different one is a mistake, not an override.
+const targetVersionId = targetFlag ?? result.targetVersionId;
 const targetVersion = versions.find((v) => v.id === targetVersionId);
 if (!targetVersion) {
   console.error(
-    `${resultPath}: \`targetVersionId\` ${JSON.stringify(targetVersionId)} is not in content/versions.json.`,
+    targetVersionId === undefined
+      ? `${resultPath}: no target version. Pass \`--target <versionId>\` (e.g. --target en-ai), which is what the batch manifest's \`targetVersionId\` names.`
+      : `${resultPath}: target version ${JSON.stringify(targetVersionId)} is not in content/versions.json.`,
   );
   process.exit(1);
 }

--- a/scripts/translate-export.ts
+++ b/scripts/translate-export.ts
@@ -276,6 +276,6 @@ console.log(
     `batches         ${batches.length} (budget ${budgetChars.toLocaleString()} chars)`,
     `written to      ${outDir}`,
     ``,
-    `Next: translate each manifest, then \`pnpm translate:apply --file <result>.json\`.`,
+    `Next: translate each manifest, then \`pnpm translate:apply --file <result>.json --target ${targetVersion.id}\`.`,
   ].join("\n"),
 );


### PR DESCRIPTION
Refs #87. **Batch 1 of 121** — a quality sample, not the whole job.

## Why one batch

The pipeline is offline and model-agnostic by design: `translate:export` writes manifests "ready to hand to any model or agent," and `translate:apply` copies every structural field from the Hebrew source so the model only ever decides `html`. That means the remaining 120 batches can be run by anything.

Which one, though, is a judgement call — and nobody had anything concrete to judge. So this batch is translated here, at full care, to set the bar. Read it, and the choice for the other 120 becomes an informed one instead of a guess.

Real numbers from the export, not remembered ones:

```
chapters      782
items        1254
source chars  2,106,243
batches       121  (budget 20,000 chars each)
```

## What changed for a reader

`part-02/chapter-01` in English had 31 anchored notes, then 22 more sitting under **"Not matched to a seif"** — in Hebrew, on an English page. Those 22 now read in English. Same for `part-03/chapter-08` (1), `part-05/chapter-01` (1) and `part-05/chapter-02` (7).

`part-05/chapter-01` and `part-05/chapter-02` had **no** English commentary file at all before this.

## How it was translated

Against the manifest's binding glossary and its 13 conventions:

- **Gematria markers** — the 11th note is 20, not 11.
- **Transliteration with a bracketed gloss on first use in an item** — `Rosh [head]`, `Guf [body]`, `Sof [end]`, `Tzelem [image]`, `Partzufim [pl. of Partzuf]`.
- **Glossary terms are binding** — `אור` is *light*, never "Ohr"; `כלי` is *vessel*, never "Kli"; `רשימו` is *record*; `זווג דהכאה` is *coupling by striking*; `בחינה` is *phase*, while `מדרגה` is *degree* and `קומה` is *level*.
- **Phase ordinals spelled as words** — "phase four", never "phase 4".
- **Malchut keeps feminine grammar** — "the reflected light that **she** raised", "descends below **her** degree".
- **Hebrew citation abbreviations expanded, never transliterated** — `ח"ב פ"א אות כ'` → *Part 2, Chapter 1, item 20*; `ד"ה אמנם` → *the passage beginning "However"*; `לה"ת` → *the Table of Answers*; `הסת"פ` → *the Inner Observation*.
- **`הרב` is "the ARI"**, never "the Rav".
- **Honorifics dropped** — `בע"ה`, `ב"ה`.
- **Curly typographic quotes** throughout.

A sample, `op-40`, the longest item in the batch:

> …It follows that the lower one cannot receive all the light that belongs to it to receive, but only a very small part, that is, only as much as the most refined vessel in it can receive; and the rest of the phases in it, which are not so refined, must remain without the light that belongs to them, because of their disparity of form toward the upper one that bestows upon them.

## A pipeline paper cut, fixed

`translate:apply` required the result file to carry `targetVersionId`. But the manifest's own instructions tell the model to return `{ batch, translations }` **and nothing else** — deliberately, since the entire safety property is that the model decides only `html`.

So following the documented instructions produced:

```
en-001.result.json: `targetVersionId` undefined is not in content/versions.json.
```

which is a confusing way to say "the runner forgot to tell me where it was writing". It is now `--target <versionId>`, which `translate:export` prints in its own next-step line. A `targetVersionId` in the file is still honoured, so anything that already carries one keeps working.

Verified both paths: without `--target` it now says what to pass; with it, applying twice hits `op-5 is already translated — refusing to overwrite`, which is the existing guard doing its job.

## Verification

```
pnpm translate:apply --file en-001.result.json --target en-ai   # 31 items, 4 files
pnpm validate:content                                           # ✓ passed
task check                                                      # green
```

937 unit tests / 78 files, generate (4,206 routes), verify:fonts, 10 e2e. Screenshotted the result in the generated build at 1280px — the "Not matched to a seif" group renders in English, with the dashed unanchored markers from #129.

## What a reviewer should double-check

- **`op-47`: I rendered `הריוח` as "the opening."** The screen minus its coarseness is what the text then names a "window or aperture," so "opening" reads naturally — but `רווח` can equally be "the benefit," and I could not settle it from the corpus, since `en-bb` has no coverage of this passage. This is the one word in the batch I am not confident about.
- **`op-53` quotes Daniel 8:16** — `בין אולי` is "between the banks of Ulai," a place name rather than the word "perhaps." Worth a second pair of eyes as a scriptural citation.
- **`part-03/chapter-08` op-10 renders `עילה ועלול` as "cause and effect"**, distinct from the glossary's `סבה ומסובב` → "cause and consequence". Two different Hebrew pairs; the glossary only binds the second.
- **The register.** This is the thing to judge. If it reads right, the same care applied to the other 120 batches is the highest-fidelity path; if a cheaper run would be good enough, this is the baseline to measure it against.
