### PR TITLE
feat(import): read the unnumbered whole-part dialect, and honour a declared item range

### DIFF
--- a/content/parts/part-16/chapters/chapter-42/source.en-bb.json
+++ b/content/parts/part-16/chapters/chapter-42/source.en-bb.json
@@ -1,0 +1,14 @@
+{
+  "chapterId": "part-16/chapter-42",
+  "layer": "source",
+  "versionId": "en-bb",
+  "sefariaRef": "Talmud Eser HaSefirot, Section XVI 42",
+  "items": [
+    {
+      "n": 1,
+      "sefariaRef": "Talmud Eser HaSefirot, Section XVI 42",
+      "html": "* It is written in the Zohar (Kedoshim) about the secretes of the Torah: “<em>Adam ha Rishon</em> did not have anything of <em> Olam ha Zeh</em>. One righteous made use of his <em> Nukva</em>, and one <em> Guf</em> was made of that usage, whose <em> Ohr</em> is more than all those angels above etc.” First, I will explain a certain matter that I had briefly heard from my teacher and then I will elaborate more as much as I heard later on.",
+      "anchors": []
+    }
+  ]
+}

--- a/content/parts/part-16/chapters/chapter-43/source.en-bb.json
+++ b/content/parts/part-16/chapters/chapter-43/source.en-bb.json
@@ -1,0 +1,14 @@
+{
+  "chapterId": "part-16/chapter-43",
+  "layer": "source",
+  "versionId": "en-bb",
+  "sefariaRef": "Talmud Eser HaSefirot, Section XVI 43",
+  "items": [
+    {
+      "n": 1,
+      "sefariaRef": "Talmud Eser HaSefirot, Section XVI 43",
+      "html": "<em> Adam ha Rishon</em> had no part of <em> Olam ha Zeh</em>, which is <em> Olam</em> <em> Assiya</em>. His <em> Guf</em> was from <em> Olam</em> <em> Yetzira</em>, his <em> Nefesh</em> from <em> Olam</em> <em> Beria</em>, his <em> Ruach</em> from <em> Nukva</em> <em> de</em> <em> ZA</em> <em> de</em> <em> Atzilut</em>, and his <em> Neshama</em> from <em> ZA</em> <em> de</em> <em> Atzilut</em>. Also, He had <em> Neshama</em> to <em> Neshama</em> from <em> Abba ve Ima de</em> <em> Atzilut</em>.",
+      "anchors": []
+    }
+  ]
+}

--- a/content/parts/part-16/chapters/chapter-44/source.en-bb.json
+++ b/content/parts/part-16/chapters/chapter-44/source.en-bb.json
@@ -1,0 +1,14 @@
+{
+  "chapterId": "part-16/chapter-44",
+  "layer": "source",
+  "versionId": "en-bb",
+  "sefariaRef": "Talmud Eser HaSefirot, Section XVI 44",
+  "items": [
+    {
+      "n": 1,
+      "sefariaRef": "Talmud Eser HaSefirot, Section XVI 44",
+      "html": "The reason why he had no part in <em> Olam</em> <em> Assiya</em> is what we will explain about the order of the world and its division. Its place of ruin is opposite the <em> Klipa</em>, and the settled world is divided into many divisions: <em> Hutz la Eretz</em> is opposite <em> Assiya</em> and the whole of <em> Eretz Israel</em> is opposite <em> Yetzira</em>. It is written in the Zohar, “The firmaments of <em> Assiya</em> exist on <em> Eretz Israel</em> to defend it etc.” The place of <em> Beit</em> <em> ha</em> <em> Mikdash</em> is opposite <em> Beria</em> and the <em> Kodesh</em> <em> Kodashim</em> is opposite the Upper <em> Heichal Kodesh</em> <em> Kodashim</em> of <em> Beria</em>.",
+      "anchors": []
+    }
+  ]
+}

--- a/content/parts/part-16/chapters/chapter-45/source.en-bb.json
+++ b/content/parts/part-16/chapters/chapter-45/source.en-bb.json
@@ -1,0 +1,14 @@
+{
+  "chapterId": "part-16/chapter-45",
+  "layer": "source",
+  "versionId": "en-bb",
+  "sefariaRef": "Talmud Eser HaSefirot, Section XVI 45",
+  "items": [
+    {
+      "n": 1,
+      "sefariaRef": "Talmud Eser HaSefirot, Section XVI 45",
+      "html": "It turns out that since <em> Adam ha Rishon</em> was created from the place of his repentance, the <em> Olam</em> was always in the form of <em> Beria</em>. After he had sinned, he was created in the weekdays. We have already explained in Parashat Pekudei that <em> Adam ha Rishon</em> was created by <em> Zivug</em> <em> ZA</em> and its <em> Nukva</em>, who rose up to the <em> Heichal</em> of <em> Abba ve Ima</em> where they mated <em> Panim</em> <em> be Panim</em> and procreated <em> Adam</em> and <em> Hava</em>.",
+      "anchors": []
+    }
+  ]
+}

--- a/content/parts/part-16/chapters/chapter-46/source.en-bb.json
+++ b/content/parts/part-16/chapters/chapter-46/source.en-bb.json
@@ -1,0 +1,14 @@
+{
+  "chapterId": "part-16/chapter-46",
+  "layer": "source",
+  "versionId": "en-bb",
+  "sefariaRef": "Talmud Eser HaSefirot, Section XVI 46",
+  "items": [
+    {
+      "n": 1,
+      "sefariaRef": "Talmud Eser HaSefirot, Section XVI 46",
+      "html": "For that reason <em> ZA</em> was then in the form of <em> Neshama</em>, which is <em> Bina</em>, and his <em> Nukva</em> was in the form of <em> Ruach</em>, which is <em> ZA</em>. It is said in that regard in the Zohar, “a man's soul is the candle of God” that <em> Neshama</em> is <em> Dechura</em> from the Upper Great Tree, and <em> Ruach</em> is from the Small Tree.",
+      "anchors": []
+    }
+  ]
+}

--- a/content/parts/part-16/chapters/chapter-47/source.en-bb.json
+++ b/content/parts/part-16/chapters/chapter-47/source.en-bb.json
@@ -1,0 +1,14 @@
+{
+  "chapterId": "part-16/chapter-47",
+  "layer": "source",
+  "versionId": "en-bb",
+  "sefariaRef": "Talmud Eser HaSefirot, Section XVI 47",
+  "items": [
+    {
+      "n": 1,
+      "sefariaRef": "Talmud Eser HaSefirot, Section XVI 47",
+      "html": "The thing is that <em> ZA</em>, which is <em> Dechura</em> Great Upper Tree, where the <em> Neshama</em> of <em> Adam ha Rishon</em> came from, called <em> Neshama</em> after <em> ZA</em> being up in the place of <em> Bina</em>. The <em> Ruach</em> of <em> Adam</em> is from <em> Nukva</em> <em> de</em> <em> ZA</em> Small Tree, <em> Nukva</em>, called <em> Ruach</em> after his <em> Nukva</em> having been at that time in the place of her husband <em> ZA</em>, as explained there in the Zohar.",
+      "anchors": []
+    }
+  ]
+}

--- a/content/parts/part-16/chapters/chapter-48/source.en-bb.json
+++ b/content/parts/part-16/chapters/chapter-48/source.en-bb.json
@@ -1,0 +1,14 @@
+{
+  "chapterId": "part-16/chapter-48",
+  "layer": "source",
+  "versionId": "en-bb",
+  "sefariaRef": "Talmud Eser HaSefirot, Section XVI 48",
+  "items": [
+    {
+      "n": 1,
+      "sefariaRef": "Talmud Eser HaSefirot, Section XVI 48",
+      "html": "After <em> Adam ha Rishon</em> sinned in <em> Etz</em> <em> ha</em> <em> Daat</em>, which is <em> Olam</em> <em> Assiya</em> that he was commanded not to eat from since he had no part in <em> Assiya</em> but only from <em> Yetzira</em> upward. Since he broke it and ate from <em> Etz</em> <em> ha</em> <em> Daat</em>, which is <em> Assiya</em>, he flawed all the <em> Olamot</em>. Hence, they all descended from their degree because <em> Yetzira</em> clothed in <em> Assiya</em>.",
+      "anchors": []
+    }
+  ]
+}

--- a/content/parts/part-16/chapters/chapter-49/source.en-bb.json
+++ b/content/parts/part-16/chapters/chapter-49/source.en-bb.json
@@ -1,0 +1,14 @@
+{
+  "chapterId": "part-16/chapter-49",
+  "layer": "source",
+  "versionId": "en-bb",
+  "sefariaRef": "Talmud Eser HaSefirot, Section XVI 49",
+  "items": [
+    {
+      "n": 1,
+      "sefariaRef": "Talmud Eser HaSefirot, Section XVI 49",
+      "html": "It follows, that <em> Eretz Israel</em> that was opposite <em> Yetzira</em> does not receive from it but through <em> Assiya</em> because <em> Yetzira</em> is clothed in it. Also, <em> Beria</em> is clothed in <em> Yetzira</em>, <em> Nukva</em> <em> de</em> <em> Atzilut</em> clothed in <em> Beria</em> and <em> ZA</em> clothed in its <em> Nukva</em>. Similarly, all the <em> Elyonim</em> of it descended from their degree.",
+      "anchors": []
+    }
+  ]
+}

--- a/content/parts/part-16/chapters/chapter-50/source.en-bb.json
+++ b/content/parts/part-16/chapters/chapter-50/source.en-bb.json
@@ -1,0 +1,14 @@
+{
+  "chapterId": "part-16/chapter-50",
+  "layer": "source",
+  "versionId": "en-bb",
+  "sefariaRef": "Talmud Eser HaSefirot, Section XVI 50",
+  "items": [
+    {
+      "n": 1,
+      "sefariaRef": "Talmud Eser HaSefirot, Section XVI 50",
+      "html": "Now the <em> Nefesh</em> of <em> Adam</em> was from <em> Nukva</em> <em> de</em> <em> ZA</em> that descended in the place of <em> Nefesh</em> in <em> Beria</em>, and his <em> Ruach</em> was from <em> ZA</em> that descended in the place of his <em> Nukva</em>. In that, the text that states that <em> Nefesh</em> and <em> Ruach</em> are <em> Malchut</em> and <em> Tifferet</em> is correct and does not dispute with the article of Sabba, which speaks of after the sin of <em> Adam</em>.",
+      "anchors": []
+    }
+  ]
+}

--- a/content/parts/part-16/chapters/chapter-51/source.en-bb.json
+++ b/content/parts/part-16/chapters/chapter-51/source.en-bb.json
@@ -1,0 +1,14 @@
+{
+  "chapterId": "part-16/chapter-51",
+  "layer": "source",
+  "versionId": "en-bb",
+  "sefariaRef": "Talmud Eser HaSefirot, Section XVI 51",
+  "items": [
+    {
+      "n": 1,
+      "sefariaRef": "Talmud Eser HaSefirot, Section XVI 51",
+      "html": "Now you see how many degrees <em> Adam ha Rishon</em> fell. In the beginning his <em> Guf</em> was from <em> Yetzira</em> and now his <em> Guf</em> is from <em> Olam ha Zeh</em>, his <em> Nefesh</em> from <em> Assiya</em> and his <em> Ruach</em> from <em> Yetzira</em>, the place where his <em> Guf</em> first was.",
+      "anchors": []
+    }
+  ]
+}

--- a/content/parts/part-16/chapters/chapter-52/source.en-bb.json
+++ b/content/parts/part-16/chapters/chapter-52/source.en-bb.json
@@ -1,0 +1,14 @@
+{
+  "chapterId": "part-16/chapter-52",
+  "layer": "source",
+  "versionId": "en-bb",
+  "sefariaRef": "Talmud Eser HaSefirot, Section XVI 52",
+  "items": [
+    {
+      "n": 1,
+      "sefariaRef": "Talmud Eser HaSefirot, Section XVI 52",
+      "html": "Do not be surprised if you will find several places in the Zohar where <em> Etz</em> <em> ha</em> <em> Daat</em> is good, <em> Matatron</em>, and bad, <em> Sam’el</em>. This is because <em> Etz</em> <em> ha</em> <em> Daat</em> is not only in <em> Assiya</em> where there are <em> Klipot</em> mixed with <em> Kedusha</em>. However, after <em> Yetzira</em> came down and clothed in <em> Assiya</em>, <em> Yetzira</em> is called “<em>Etz</em> <em> ha</em> <em> Daat</em> of good and bad”, the name of <em> Assiya</em>. Thus we have thoroughly explained what was <em> Etz</em> <em> ha</em> <em> Daat</em>.",
+      "anchors": []
+    }
+  ]
+}

--- a/content/parts/part-16/chapters/chapter-53/source.en-bb.json
+++ b/content/parts/part-16/chapters/chapter-53/source.en-bb.json
@@ -1,0 +1,14 @@
+{
+  "chapterId": "part-16/chapter-53",
+  "layer": "source",
+  "versionId": "en-bb",
+  "sefariaRef": "Talmud Eser HaSefirot, Section XVI 53",
+  "items": [
+    {
+      "n": 1,
+      "sefariaRef": "Talmud Eser HaSefirot, Section XVI 53",
+      "html": "In this explanation we settle both verses. One says “And God created man” and the other says, “Then the Lord God formed man.” The <em> Guf</em> of <em> Adam</em> was made of <em> Yetzira</em>, hence the word “created” and after <em> Beria</em> descended and clothed in <em> Yetzira</em> it is as though he was created from <em> Beria</em>, hence the word “formed.”",
+      "anchors": []
+    }
+  ]
+}

--- a/content/parts/part-16/chapters/chapter-54/source.en-bb.json
+++ b/content/parts/part-16/chapters/chapter-54/source.en-bb.json
@@ -1,0 +1,14 @@
+{
+  "chapterId": "part-16/chapter-54",
+  "layer": "source",
+  "versionId": "en-bb",
+  "sefariaRef": "Talmud Eser HaSefirot, Section XVI 54",
+  "items": [
+    {
+      "n": 1,
+      "sefariaRef": "Talmud Eser HaSefirot, Section XVI 54",
+      "html": "Now we will explain a matter which is discussed elaborately and then we will explain the superficiality of the above-mentioned text. First we will explain the matter of the order of the degrees of the <em> Olamot</em> and how they stood in the beginning, before <em> Adam</em> was created, and also how they descended from their degree after he had sinned. Know, that the number of the <em> Olamot</em> itself did not change and they are always four, <em> Atzilut</em>, <em> Beria</em>, <em> Yetzira Assiya</em>.",
+      "anchors": []
+    }
+  ]
+}

--- a/content/parts/part-16/chapters/chapter-55/source.en-bb.json
+++ b/content/parts/part-16/chapters/chapter-55/source.en-bb.json
@@ -1,0 +1,14 @@
+{
+  "chapterId": "part-16/chapter-55",
+  "layer": "source",
+  "versionId": "en-bb",
+  "sefariaRef": "Talmud Eser HaSefirot, Section XVI 55",
+  "items": [
+    {
+      "n": 1,
+      "sefariaRef": "Talmud Eser HaSefirot, Section XVI 55",
+      "html": "However, their order of degrees was thus since the entire place of <em> Eser</em> <em> Sefirot</em> of the current <em> Olam</em> <em> Assiya</em> as well as the place of the four bottom <em> Sefirot</em> of the current <em> Yetzira</em> were empty and vacant. There in that place was <em> Mador</em> <em> ha</em> <em> Klipot</em>.",
+      "anchors": []
+    }
+  ]
+}

--- a/content/parts/part-16/chapters/chapter-56/source.en-bb.json
+++ b/content/parts/part-16/chapters/chapter-56/source.en-bb.json
@@ -1,0 +1,14 @@
+{
+  "chapterId": "part-16/chapter-56",
+  "layer": "source",
+  "versionId": "en-bb",
+  "sefariaRef": "Talmud Eser HaSefirot, Section XVI 56",
+  "items": [
+    {
+      "n": 1,
+      "sefariaRef": "Talmud Eser HaSefirot, Section XVI 56",
+      "html": "The bottom six of <em> Assiya</em> were in the place where now the first six of <em> Yetzira</em> are and the first four of <em> Assiya</em> were in the place where the last four of <em> Beria</em> are now. The last six of <em> Yetzira</em> where in the place where the first six of <em> Beria</em> are now and the first four of <em> Yetzira</em> were in the place where <em> Nukva</em> <em> de</em> <em> ZA</em> <em> de</em> <em> Atzilut</em> now is. You already know that she only takes the place of the last four of <em> ZA</em>, namely <em> Netzah Hod</em> <em> Yesod</em> <em> Malchut</em> in him. She stands opposite them from behind, hence the name <em> Dalet</em>, since her place is only in the four mentioned <em> Sefirot</em>.",
+      "anchors": []
+    }
+  ]
+}

--- a/content/parts/part-16/chapters/chapter-57/source.en-bb.json
+++ b/content/parts/part-16/chapters/chapter-57/source.en-bb.json
@@ -1,0 +1,14 @@
+{
+  "chapterId": "part-16/chapter-57",
+  "layer": "source",
+  "versionId": "en-bb",
+  "sefariaRef": "Talmud Eser HaSefirot, Section XVI 57",
+  "items": [
+    {
+      "n": 1,
+      "sefariaRef": "Talmud Eser HaSefirot, Section XVI 57",
+      "html": "All <em> Eser</em> <em> Sefirot</em> of <em> Beria</em> were in the place which is now <em> ZA</em> <em> de</em> <em> Atzilut</em> in all its <em> Eser</em> <em> Sefirot</em> and his <em> Nukva</em> <em> de</em> <em> Atzilut</em> was then in the current place of <em> Abba ve Ima de</em> <em> Atzilut</em>. The <em> Olamot</em> continue similarly from <em> Abba ve Ima de</em> <em> Atzilut</em> upward to the highest degree, to <em> Ein Sof</em>, higher than their current degree and we need not elaborate here.",
+      "anchors": []
+    }
+  ]
+}

--- a/content/parts/part-16/chapters/chapter-58/source.en-bb.json
+++ b/content/parts/part-16/chapters/chapter-58/source.en-bb.json
@@ -1,0 +1,14 @@
+{
+  "chapterId": "part-16/chapter-58",
+  "layer": "source",
+  "versionId": "en-bb",
+  "sefariaRef": "Talmud Eser HaSefirot, Section XVI 58",
+  "items": [
+    {
+      "n": 1,
+      "sefariaRef": "Talmud Eser HaSefirot, Section XVI 58",
+      "html": "Indeed there is a question here. We have already learned that the lowest degree in the entire <em> Atzilut</em> is higher than every thing below it through the end of <em> Assiya</em> etc. similarly in all the degrees. This is so because even the bottom degree in <em> Beria</em> is greater than every thing below it, which are <em> Yetzira</em> and <em> Assiya</em>. Thus, how did we say above that <em> Olam</em> <em> Yetzira</em> had only its Upper four above where <em> Nukva</em> <em> de</em> <em> Atzilut</em> now stands and the rest of the bottom six <em> Sefirot de Yetzira</em> remained below in the place that it is now <em> Beria</em>? After all, all the <em> Olamot</em> could stand at the lowest degree <em> de</em> <em> Nukva</em> <em> de</em> <em> Atzilut</em>, which is beneath it.",
+      "anchors": []
+    }
+  ]
+}

--- a/content/parts/part-16/chapters/chapter-59/source.en-bb.json
+++ b/content/parts/part-16/chapters/chapter-59/source.en-bb.json
@@ -1,0 +1,14 @@
+{
+  "chapterId": "part-16/chapter-59",
+  "layer": "source",
+  "versionId": "en-bb",
+  "sefariaRef": "Talmud Eser HaSefirot, Section XVI 59",
+  "items": [
+    {
+      "n": 1,
+      "sefariaRef": "Talmud Eser HaSefirot, Section XVI 59",
+      "html": "The answer to that is that when it is written in a different place that the lowest degree in the higher <em> Olam</em> is greater than everything below it, it does not relate to quantity and a measurement of limited space. Rather, it is discerned in the quality of the <em> Ohr</em> itself being better than everything below it. In that aspect of quality and merit it contains everything that is below it. In comparison, we see that the last drop in a human being’s brain contains everything that exists below it in the entire human body. It is so although we see that it is not so with respect to the size of the place. Moreover, a single organ of the body such as the thigh of the leg is bigger than the size of the entire head.",
+      "anchors": []
+    }
+  ]
+}

--- a/content/parts/part-16/chapters/chapter-60/source.en-bb.json
+++ b/content/parts/part-16/chapters/chapter-60/source.en-bb.json
@@ -1,0 +1,14 @@
+{
+  "chapterId": "part-16/chapter-60",
+  "layer": "source",
+  "versionId": "en-bb",
+  "sefariaRef": "Talmud Eser HaSefirot, Section XVI 60",
+  "items": [
+    {
+      "n": 1,
+      "sefariaRef": "Talmud Eser HaSefirot, Section XVI 60",
+      "html": "I also believe I had heard from my teacher a different answer regarding this. It is that this is only meant to be when every single degree is in its proper place because then the measure of the lowest degree in the higher <em> Olam</em> is greater than everything below it. However, when <em> Olam</em> <em> Beria</em> rises to <em> Olam</em> <em> Atzilut</em> <em> Beria</em> returns to being in the degree of <em> Atzilut</em> itself and requires the same amount of space as if it is <em> Atzilut</em> in itself, etc. similarly. Hence, when <em> Yetzira</em> rises to <em> Nukva</em> <em> de</em> <em> Atzilut’s</em> place she returns to being in her merit. Then the first four <em> Sefirot</em> of <em> Yetzira</em> require the same measure of space as the <em> Nekeva</em> of <em> Atzilut</em>, whose measure is also four <em> Sefirot de</em> <em> Atzilut</em>.",
+      "anchors": []
+    }
+  ]
+}

--- a/content/parts/part-16/chapters/chapter-61/source.en-bb.json
+++ b/content/parts/part-16/chapters/chapter-61/source.en-bb.json
@@ -1,0 +1,14 @@
+{
+  "chapterId": "part-16/chapter-61",
+  "layer": "source",
+  "versionId": "en-bb",
+  "sefariaRef": "Talmud Eser HaSefirot, Section XVI 61",
+  "items": [
+    {
+      "n": 1,
+      "sefariaRef": "Talmud Eser HaSefirot, Section XVI 61",
+      "html": "Let us return to the first matter. Before <em> Adam</em> was created the <em> Sium</em> of <em> Assiya</em> was at the end of the sixth <em> Sefira</em> of the current <em> Olam</em> <em> Yetzira</em> and the bottom four <em> de</em> <em> Yetzira</em> were all vacant, and all the <em> Eser</em> <em> Sefirot</em> of the current <em> Assiya</em> too. Together they are fourteen <em> Sefirot</em> and there was the section of all the <em> Klipot</em>.",
+      "anchors": []
+    }
+  ]
+}

--- a/content/parts/part-16/chapters/chapter-62/source.en-bb.json
+++ b/content/parts/part-16/chapters/chapter-62/source.en-bb.json
@@ -1,0 +1,14 @@
+{
+  "chapterId": "part-16/chapter-62",
+  "layer": "source",
+  "versionId": "en-bb",
+  "sefariaRef": "Talmud Eser HaSefirot, Section XVI 62",
+  "items": [
+    {
+      "n": 1,
+      "sefariaRef": "Talmud Eser HaSefirot, Section XVI 62",
+      "html": "That place of the fourteen <em> Sefirot</em> was then the zone of the <em> Olamot</em>, such as we place in every town a Shabbat Zone around it. This is the meaning of the words of our sages why He is called <em> El</em> <em> Shadai</em>, since He said to His world <em> Dai</em> (Heb: enough). Interpretation: As these four <em> Olamot</em> <em> ABYA</em> expanded when they reached the place of <em> Sium</em> of the sixth <em> Sefira</em> of the current <em> Yetzira</em>, He said to them “<em>Dai</em>, do not expand and do not enter the zone of the above-mentioned fourteen.” Instead, they would remain a <em> Halal</em> for the <em> Klipot</em> as was mentioned.",
+      "anchors": []
+    }
+  ]
+}

--- a/content/parts/part-16/chapters/chapter-63/source.en-bb.json
+++ b/content/parts/part-16/chapters/chapter-63/source.en-bb.json
@@ -1,0 +1,14 @@
+{
+  "chapterId": "part-16/chapter-63",
+  "layer": "source",
+  "versionId": "en-bb",
+  "sefariaRef": "Talmud Eser HaSefirot, Section XVI 63",
+  "items": [
+    {
+      "n": 1,
+      "sefariaRef": "Talmud Eser HaSefirot, Section XVI 63",
+      "html": "Now we shall explain the matter of <em> Adam ha Rishon</em>, how he expanded in these <em> Olamot</em>. I have already notified you in the article Studied in the House of Eliyahu, section The World Exists Six Thousand Years, in Parashat Bereshit, regarding the sin of <em> Adam ha Rishon</em>, that <em> Adam ha Rishon</em> contained three <em> Olamot</em>, which are <em> Beria</em> <em> Yetzira</em> and <em> Assiya</em>.",
+      "anchors": []
+    }
+  ]
+}

--- a/content/parts/part-16/chapters/chapter-64/source.en-bb.json
+++ b/content/parts/part-16/chapters/chapter-64/source.en-bb.json
@@ -1,0 +1,14 @@
+{
+  "chapterId": "part-16/chapter-64",
+  "layer": "source",
+  "versionId": "en-bb",
+  "sefariaRef": "Talmud Eser HaSefirot, Section XVI 64",
+  "items": [
+    {
+      "n": 1,
+      "sefariaRef": "Talmud Eser HaSefirot, Section XVI 64",
+      "html": "This is the order of his <em> Hitpashtut</em> in them: The <em> Rosh</em> of <em> Adam ha Rishon</em> was in <em> Olam</em> <em> Beria</em>, which is now the place of <em> ZA</em> <em> de</em> <em> Atzilut</em> and his <em> Garon</em> was in the first four of <em> Yetzira</em>, which is now the place of <em> Nukva</em> <em> de</em> <em> Atzilut</em>. You already know that <em> Nukva</em> <em> de</em> <em> Atzilut</em> is called <em> Gan Eden</em>, thus only his <em> Garon</em> was placed in <em> Gan Eden</em>.",
+      "anchors": []
+    }
+  ]
+}

--- a/content/parts/part-16/chapters/chapter-65/source.en-bb.json
+++ b/content/parts/part-16/chapters/chapter-65/source.en-bb.json
@@ -1,0 +1,14 @@
+{
+  "chapterId": "part-16/chapter-65",
+  "layer": "source",
+  "versionId": "en-bb",
+  "sefariaRef": "Talmud Eser HaSefirot, Section XVI 65",
+  "items": [
+    {
+      "n": 1,
+      "sefariaRef": "Talmud Eser HaSefirot, Section XVI 65",
+      "html": "From there downward his entire <em> Guf</em> was outside <em> Gan Eden</em> in a manner that his whole <em> Guf</em> was place in the last six of <em> Yetzira</em> and in the first four of <em> Assiya</em>. These are now the measure of place of the entire <em> Olam</em> <em> Beria</em>.",
+      "anchors": []
+    }
+  ]
+}

--- a/content/parts/part-16/chapters/chapter-66/source.en-bb.json
+++ b/content/parts/part-16/chapters/chapter-66/source.en-bb.json
@@ -1,0 +1,14 @@
+{
+  "chapterId": "part-16/chapter-66",
+  "layer": "source",
+  "versionId": "en-bb",
+  "sefariaRef": "Talmud Eser HaSefirot, Section XVI 66",
+  "items": [
+    {
+      "n": 1,
+      "sefariaRef": "Talmud Eser HaSefirot, Section XVI 66",
+      "html": "However, the <em> Guf</em> of <em> Adam</em> was divided into two divisions, because <em> Yesod</em> <em> de</em> <em> Bina</em> expands until the <em> Chazeh</em> and the <em> Orot</em> inside it are covered. From the <em> Chazeh</em> down the <em> Orot</em> are uncovered, as we explain regarding the <em> Hassadim</em> that expand in <em> Tifferet de</em> <em> ZA</em>. For that reason his <em> Guf</em> was divided into two <em> Olamot</em>, the covered Upper half was placed in the last six of <em> Yetzira</em> and the revealed lower half was placed in the first four <em> de</em> <em> Assiya</em>.",
+      "anchors": []
+    }
+  ]
+}

--- a/content/parts/part-16/chapters/chapter-67/source.en-bb.json
+++ b/content/parts/part-16/chapters/chapter-67/source.en-bb.json
@@ -1,0 +1,14 @@
+{
+  "chapterId": "part-16/chapter-67",
+  "layer": "source",
+  "versionId": "en-bb",
+  "sefariaRef": "Talmud Eser HaSefirot, Section XVI 67",
+  "items": [
+    {
+      "n": 1,
+      "sefariaRef": "Talmud Eser HaSefirot, Section XVI 67",
+      "html": "It turns out that his <em> Guf</em> was primarily above in <em> Yetzira</em>, as it is known that the <em> Guf</em> implies the <em> Vav</em> of <em> HaVaYaH</em> and <em> Yetzira</em> is also implied in the <em> Ot</em> <em> Vav</em> itself. The <em> Raglaim</em> of <em> Adam ha Rishon</em> were placed at the bottom four of the past <em> Assiya</em> which are now the first six of <em> Yetzira</em>. Thus we have explained the <em> Hitpashtut</em> of <em> Adam ha Rishon</em> in three <em> Olamot</em> <em> Beria</em> <em> Yetzira Assiya</em> when he was created.",
+      "anchors": []
+    }
+  ]
+}

--- a/content/parts/part-16/chapters/chapter-68/source.en-bb.json
+++ b/content/parts/part-16/chapters/chapter-68/source.en-bb.json
@@ -1,0 +1,14 @@
+{
+  "chapterId": "part-16/chapter-68",
+  "layer": "source",
+  "versionId": "en-bb",
+  "sefariaRef": "Talmud Eser HaSefirot, Section XVI 68",
+  "items": [
+    {
+      "n": 1,
+      "sefariaRef": "Talmud Eser HaSefirot, Section XVI 68",
+      "html": "Now we will explain the matter of <em> Adam ha Rishon</em> when he was created, as our sages wrote in the Midrash and the Talmud, how we connect it to what we have explained. Our sages said that the <em> Guf</em> of <em> Adam ha Rishon</em> was created from <em> Eretz Israel</em>, his <em> Agavot</em> (buttocks) from <em> Bavel</em> and from Akra DeAgma (a city in Babylon). To explain that we must also explain what they said in the <em> Tikkunim</em> that <em> Yetzira</em> controlled <em> Eretz Israel</em> and <em> Assiya</em> controlled <em> Hutz la Eretz</em>, <em> Ever ha Yarden</em>, <em> Suria</em> etc. What all these discernments mean. We have explained that before <em> Adam</em> was created the <em> Olamot</em> were higher in degree.",
+      "anchors": []
+    }
+  ]
+}

--- a/content/parts/part-16/chapters/chapter-69/source.en-bb.json
+++ b/content/parts/part-16/chapters/chapter-69/source.en-bb.json
@@ -1,0 +1,14 @@
+{
+  "chapterId": "part-16/chapter-69",
+  "layer": "source",
+  "versionId": "en-bb",
+  "sefariaRef": "Talmud Eser HaSefirot, Section XVI 69",
+  "items": [
+    {
+      "n": 1,
+      "sefariaRef": "Talmud Eser HaSefirot, Section XVI 69",
+      "html": "We have also explained that his <em> Guf</em> was from <em> Eretz Israel</em>. You already know that only <em> Yetzira</em> controls <em> Eretz Israel</em>, not <em> Assiya</em>. Yet, at that time the last six of <em> Yetzira</em> were in the place where the first six of <em> Beria</em> are now.",
+      "anchors": []
+    }
+  ]
+}

--- a/content/parts/part-16/chapters/chapter-70/source.en-bb.json
+++ b/content/parts/part-16/chapters/chapter-70/source.en-bb.json
@@ -1,0 +1,14 @@
+{
+  "chapterId": "part-16/chapter-70",
+  "layer": "source",
+  "versionId": "en-bb",
+  "sefariaRef": "Talmud Eser HaSefirot, Section XVI 70",
+  "items": [
+    {
+      "n": 1,
+      "sefariaRef": "Talmud Eser HaSefirot, Section XVI 70",
+      "html": "The <em> Guf</em> of <em> Adam</em> was of the last six of the past <em> Yetzira</em>, because the <em> Guf</em> means the <em> Ot</em> <em> Vav</em>, and <em> Yetzira</em> is also <em> Ot</em> <em> Vav</em>. Thus, <em> Yetzira</em> controls <em> Eretz Israel</em> and you find that the <em> Guf</em> of <em> Adam</em> was from <em> Eretz Israel</em> which is from <em> Yetzira</em>, which is between two <em> Olamot</em> <em> Beria</em> and <em> Assiya</em>. Also, the <em> Guf</em> of <em> Adam</em> is the middle of the whole of <em> Adam</em>.",
+      "anchors": []
+    }
+  ]
+}

--- a/content/parts/part-16/chapters/chapter-71/source.en-bb.json
+++ b/content/parts/part-16/chapters/chapter-71/source.en-bb.json
@@ -1,0 +1,14 @@
+{
+  "chapterId": "part-16/chapter-71",
+  "layer": "source",
+  "versionId": "en-bb",
+  "sefariaRef": "Talmud Eser HaSefirot, Section XVI 71",
+  "items": [
+    {
+      "n": 1,
+      "sefariaRef": "Talmud Eser HaSefirot, Section XVI 71",
+      "html": "However, the last <em> Sefira</em> of the six <em> Sefirot</em> of <em> Yetzira</em> is called <em> Malchut de</em> <em> Yetzira</em>, <em> Nukva</em> <em> de</em> <em> ZA</em> <em> de</em> <em> Yetzira</em> which is now the sixth <em> Sefira</em> of <em> Olam</em> <em> Beria</em>. This is the meaning of <em> Ever ha Yarden</em>, the place of the children of Gad and the children of Reuben. It is considered <em> Malchut</em> of the past <em> Yetzira</em> with all first three of the past <em> Assiya</em>, which are now the four bottom <em> Sefirot de</em> <em> Beria</em>.",
+      "anchors": []
+    }
+  ]
+}

--- a/content/parts/part-16/chapters/chapter-72/source.en-bb.json
+++ b/content/parts/part-16/chapters/chapter-72/source.en-bb.json
@@ -1,0 +1,14 @@
+{
+  "chapterId": "part-16/chapter-72",
+  "layer": "source",
+  "versionId": "en-bb",
+  "sefariaRef": "Talmud Eser HaSefirot, Section XVI 72",
+  "items": [
+    {
+      "n": 1,
+      "sefariaRef": "Talmud Eser HaSefirot, Section XVI 72",
+      "html": "All these four bottom <em> Sefirot</em> of the current <em> Beria</em> are the meaning of <em> Ever ha Yarden</em>, and they are <em> Tifferet</em> and <em> Netzah</em> and <em> Hod</em> and <em> Yesod</em> of the current <em> Beria</em>. However, <em> Malchut</em> of the current <em> Beria</em> that was then the fourth <em> Sefira</em> <em> de</em> <em> Assiya</em> is called <em> Suria</em> and her degree is worse than <em> Ever ha Yarden</em>.",
+      "anchors": []
+    }
+  ]
+}

--- a/content/parts/part-16/chapters/chapter-73/source.en-bb.json
+++ b/content/parts/part-16/chapters/chapter-73/source.en-bb.json
@@ -1,0 +1,14 @@
+{
+  "chapterId": "part-16/chapter-73",
+  "layer": "source",
+  "versionId": "en-bb",
+  "sefariaRef": "Talmud Eser HaSefirot, Section XVI 73",
+  "items": [
+    {
+      "n": 1,
+      "sefariaRef": "Talmud Eser HaSefirot, Section XVI 73",
+      "html": "It turns out that the past <em> Malchut de</em> <em> Yetzira</em> was the past <em> Ever ha Yarden</em> and the current <em> Malchut de</em> <em> Beria</em> was <em> Behinat</em> <em> Suria</em>. The last six of the past <em> Assiya</em>, which are the first six of the current <em> Yetzira</em>, were <em> Hutz la Eretz</em> since these were then <em> Behinat</em> <em> Assiya</em>. It is known that <em> Assiya</em> hangs in <em> Hutz la Eretz</em> and controls there, and we have already explained that the <em> Raglaim</em> of <em> Adam ha Rishon</em> were from <em> Hutz la Eretz</em>.",
+      "anchors": []
+    }
+  ]
+}

--- a/content/parts/part-16/chapters/chapter-74/source.en-bb.json
+++ b/content/parts/part-16/chapters/chapter-74/source.en-bb.json
@@ -1,0 +1,14 @@
+{
+  "chapterId": "part-16/chapter-74",
+  "layer": "source",
+  "versionId": "en-bb",
+  "sefariaRef": "Talmud Eser HaSefirot, Section XVI 74",
+  "items": [
+    {
+      "n": 1,
+      "sefariaRef": "Talmud Eser HaSefirot, Section XVI 74",
+      "html": "It is known that each <em> Regel</em> (leg) is divided into three <em> Prakin</em>. The two upper <em> Prakin</em> in both <em> Raglaim</em>, called his <em> Agavot</em>, were from <em> Bavel</em> and from Akra DeAgma, as mentioned in the Gmarah.",
+      "anchors": []
+    }
+  ]
+}

--- a/content/parts/part-16/chapters/chapter-75/source.en-bb.json
+++ b/content/parts/part-16/chapters/chapter-75/source.en-bb.json
@@ -1,0 +1,14 @@
+{
+  "chapterId": "part-16/chapter-75",
+  "layer": "source",
+  "versionId": "en-bb",
+  "sefariaRef": "Talmud Eser HaSefirot, Section XVI 75",
+  "items": [
+    {
+      "n": 1,
+      "sefariaRef": "Talmud Eser HaSefirot, Section XVI 75",
+      "html": "Do not be surprised by that because they are very close to <em> Eretz Israel</em>, as it is written in the Midrash and the Yerushalmi about that man who was plowing with his cow. It ran away from him and he chased it until they reached <em> Bavel</em> before night. Thus, the <em> Guf</em> from <em> Eretz Israel</em> is not far from his <em> Agavot</em> from <em> Bavel</em>, since these are the two upper <em> Prakin</em> proximate to the <em> Guf</em>. The other lower four <em> Prakin</em> in both his <em> Raglaim</em> were from the other lands in <em> Hutz la Eretz</em>.",
+      "anchors": []
+    }
+  ]
+}

--- a/content/parts/part-16/chapters/chapter-76/source.en-bb.json
+++ b/content/parts/part-16/chapters/chapter-76/source.en-bb.json
@@ -1,0 +1,14 @@
+{
+  "chapterId": "part-16/chapter-76",
+  "layer": "source",
+  "versionId": "en-bb",
+  "sefariaRef": "Talmud Eser HaSefirot, Section XVI 76",
+  "items": [
+    {
+      "n": 1,
+      "sefariaRef": "Talmud Eser HaSefirot, Section XVI 76",
+      "html": "Now we have explained how <em> Adam ha Rishon</em> took from the entire <em> Olam ha Zeh</em> and his <em> Guf</em> was stretched over three <em> Olamot</em> <em> Beria</em> <em> Yetzira Assiya</em> too, and all is one. Thus we have explained the first <em> Behina</em>, how the <em> Olamot</em> were when <em> Adam ha Rishon</em> was created. We also explained how his <em> Rosh</em> and <em> Garon</em> were inside <em> GE</em> and his <em> Guf</em> in the rest of the <em> Olam</em>.",
+      "anchors": []
+    }
+  ]
+}

--- a/content/parts/part-16/chapters/chapter-77/source.en-bb.json
+++ b/content/parts/part-16/chapters/chapter-77/source.en-bb.json
@@ -1,0 +1,14 @@
+{
+  "chapterId": "part-16/chapter-77",
+  "layer": "source",
+  "versionId": "en-bb",
+  "sefariaRef": "Talmud Eser HaSefirot, Section XVI 77",
+  "items": [
+    {
+      "n": 1,
+      "sefariaRef": "Talmud Eser HaSefirot, Section XVI 77",
+      "html": "Now we will explain the second <em> Behina</em> after <em> Adam ha Rishon</em> was created and the Creator placed him in <em> Gan Eden</em>. It was then half of the sixth day and onward, at which time <em> Kedusha</em> is necessarily added in all the <em> Olamot</em>, as we explain regarding the eve of Shabbat. The <em> Olamot</em> begin to rise above their place from the fifth hour of the eve of Shabbat and <em> Kedusha</em> is added to them. It is as we mention regarding the excess <em> Hey</em> mentioned in verse, “And there was evening and there was morning, the sixth day.” It implies the fifth hour.",
+      "anchors": []
+    }
+  ]
+}

--- a/content/parts/part-16/chapters/chapter-78/source.en-bb.json
+++ b/content/parts/part-16/chapters/chapter-78/source.en-bb.json
@@ -1,0 +1,14 @@
+{
+  "chapterId": "part-16/chapter-78",
+  "layer": "source",
+  "versionId": "en-bb",
+  "sefariaRef": "Talmud Eser HaSefirot, Section XVI 78",
+  "items": [
+    {
+      "n": 1,
+      "sefariaRef": "Talmud Eser HaSefirot, Section XVI 78",
+      "html": "Thus we shall now explain what was renewed that eve of Shabbat after midnight when <em> Adam</em> was created and entered <em> Gan Eden</em> with all his <em> Guf</em>. When he was created only his <em> Rosh</em> and <em> Garon</em> were in <em> Gan Eden</em>, and the rest of his <em> Guf</em> was in <em> Olam ha Zeh</em>. Now, however, he entered <em> Gan Eden</em> entirely.",
+      "anchors": []
+    }
+  ]
+}

--- a/content/parts/part-16/chapters/chapter-79/source.en-bb.json
+++ b/content/parts/part-16/chapters/chapter-79/source.en-bb.json
@@ -1,0 +1,14 @@
+{
+  "chapterId": "part-16/chapter-79",
+  "layer": "source",
+  "versionId": "en-bb",
+  "sefariaRef": "Talmud Eser HaSefirot, Section XVI 79",
+  "items": [
+    {
+      "n": 1,
+      "sefariaRef": "Talmud Eser HaSefirot, Section XVI 79",
+      "html": "The <em> Olamot</em> rose in the following manner: <em> ZA</em> rose to the place that is now the place of <em> AA</em>. <em> Nukva</em> rose to the place that is now the place of <em> Abba</em>, and <em> Beria</em> rose to the place that is now the place of <em> Ima</em>. Also, <em> Yetzira</em> in the place of <em> ZA</em> and <em> Assiya</em> in the place of <em> Malchut</em> <em> Nukva</em> <em> de</em> <em> ZA</em>.",
+      "anchors": []
+    }
+  ]
+}

--- a/content/parts/part-16/chapters/chapter-80/source.en-bb.json
+++ b/content/parts/part-16/chapters/chapter-80/source.en-bb.json
@@ -1,0 +1,14 @@
+{
+  "chapterId": "part-16/chapter-80",
+  "layer": "source",
+  "versionId": "en-bb",
+  "sefariaRef": "Talmud Eser HaSefirot, Section XVI 80",
+  "items": [
+    {
+      "n": 1,
+      "sefariaRef": "Talmud Eser HaSefirot, Section XVI 80",
+      "html": "The first four of <em> Assiya</em> rose because this is the measure of <em> Nukva</em> <em> de</em> <em> ZA</em>, only four <em> Sefirot</em>. The other six <em> Sefirot de</em> <em> Assiya</em> are in the place of the first six of the current <em> Beria</em>. Yet, <em> AVI</em> <em> de</em> <em> Atzilut</em> and everything above them also rose above their degree in this order, and we should not elaborate in them.",
+      "anchors": []
+    }
+  ]
+}

--- a/content/parts/part-16/chapters/chapter-81/source.en-bb.json
+++ b/content/parts/part-16/chapters/chapter-81/source.en-bb.json
@@ -1,0 +1,14 @@
+{
+  "chapterId": "part-16/chapter-81",
+  "layer": "source",
+  "versionId": "en-bb",
+  "sefariaRef": "Talmud Eser HaSefirot, Section XVI 81",
+  "items": [
+    {
+      "n": 1,
+      "sefariaRef": "Talmud Eser HaSefirot, Section XVI 81",
+      "html": "Know, that the principal place of the <em> Olamot</em> and their genuine degree is in this order, and this is their rightful place for all times. The reason is that <em> ZA</em> should grow to be like <em> Arich Anpin</em> and should therefore rise up to there. Also, the place of <em> Arich Anpin</em> should be the place of <em> ZA</em> because by that it becomes <em> Arich</em>.",
+      "anchors": []
+    }
+  ]
+}

--- a/content/parts/part-16/chapters/chapter-82/source.en-bb.json
+++ b/content/parts/part-16/chapters/chapter-82/source.en-bb.json
@@ -1,0 +1,14 @@
+{
+  "chapterId": "part-16/chapter-82",
+  "layer": "source",
+  "versionId": "en-bb",
+  "sefariaRef": "Talmud Eser HaSefirot, Section XVI 82",
+  "items": [
+    {
+      "n": 1,
+      "sefariaRef": "Talmud Eser HaSefirot, Section XVI 82",
+      "html": "<em> Nukva</em> of <em> ZA</em> in the place of <em> Abba</em>, as it is written, “by wisdom founded the earth,” as “Father founded his daughter.” It is also the meaning of “Ye shall keep the sabbath therefore, for it is holy.” “Keep,” which is the <em> Nukva</em> becomes “holy,” which is <em> Abba</em>. This is the meaning of the text “it is holy,” because the <em> Nekeva</em> returns to being holy, and <em> Beria</em> rose in <em> Ima</em>, as you know that <em> Ima</em> nests in her abdomen.” Also, <em> Yetzira</em> in the place of <em> ZA</em> because <em> ZA</em> nests in the angel and <em> Assiya</em> in <em> Nukva</em> <em> de</em> <em> ZA</em> because <em> Malchut</em> nests in the <em> Ofan</em>, which is <em> Assiya</em>.",
+      "anchors": []
+    }
+  ]
+}

--- a/content/parts/part-16/chapters/chapter-83/source.en-bb.json
+++ b/content/parts/part-16/chapters/chapter-83/source.en-bb.json
@@ -1,0 +1,14 @@
+{
+  "chapterId": "part-16/chapter-83",
+  "layer": "source",
+  "versionId": "en-bb",
+  "sefariaRef": "Talmud Eser HaSefirot, Section XVI 83",
+  "items": [
+    {
+      "n": 1,
+      "sefariaRef": "Talmud Eser HaSefirot, Section XVI 83",
+      "html": "You find that this is the worthy place for the order of the degrees of the <em> Olamot</em>, and you now find that all the lower <em> Olamot</em> of <em> Beria</em> <em> Yetzira</em> and <em> Assiya</em> were in the place of <em> Atzilut</em> except the last six of <em> Yetzira</em>. Those were then at the First six of the current <em> Beria</em>.",
+      "anchors": []
+    }
+  ]
+}

--- a/content/parts/part-16/chapters/chapter-84/source.en-bb.json
+++ b/content/parts/part-16/chapters/chapter-84/source.en-bb.json
@@ -1,0 +1,14 @@
+{
+  "chapterId": "part-16/chapter-84",
+  "layer": "source",
+  "versionId": "en-bb",
+  "sefariaRef": "Talmud Eser HaSefirot, Section XVI 84",
+  "items": [
+    {
+      "n": 1,
+      "sefariaRef": "Talmud Eser HaSefirot, Section XVI 84",
+      "html": "This was the meaning of the <em> Ibur</em> of the <em> Ir</em> (town) mentioned in the Talmud. It is because these bottom six protrude and exit <em> Olam</em> <em> Atzilut</em> like a pregnant woman whose <em> Ubar</em> protrudes outside her body.",
+      "anchors": []
+    }
+  ]
+}

--- a/content/parts/part-16/chapters/chapter-85/source.en-bb.json
+++ b/content/parts/part-16/chapters/chapter-85/source.en-bb.json
@@ -1,0 +1,14 @@
+{
+  "chapterId": "part-16/chapter-85",
+  "layer": "source",
+  "versionId": "en-bb",
+  "sefariaRef": "Talmud Eser HaSefirot, Section XVI 85",
+  "items": [
+    {
+      "n": 1,
+      "sefariaRef": "Talmud Eser HaSefirot, Section XVI 85",
+      "html": "Now you find that the bottom four <em> de</em> <em> Beria</em> and the entire <em> Olam</em> <em> Yetzira</em> and <em> Assiya</em> which are the place of twenty-four <em> Sefirot</em> were then all vacant, empty and <em> Halal</em>. It was in the form of Shabbat Zone, which is two thousand <em> Amah</em> except for the last fourteen <em> Sefirot</em>, which became a permanent section for the <em> Klipot</em>. The other ten Upper <em> Sefirot</em> were in the form of Shabbat Zone.",
+      "anchors": []
+    }
+  ]
+}

--- a/content/toc.json
+++ b/content/toc.json
@@ -39810,6 +39810,7 @@
               "availableVersions": {
                 "summary": [],
                 "source": [
+                  "en-bb",
                   "en-ai",
                   "he-jerusalem-1956"
                 ],
@@ -39831,6 +39832,7 @@
               "availableVersions": {
                 "summary": [],
                 "source": [
+                  "en-bb",
                   "en-ai",
                   "he-jerusalem-1956"
                 ],
@@ -39853,6 +39855,7 @@
               "availableVersions": {
                 "summary": [],
                 "source": [
+                  "en-bb",
                   "en-ai",
                   "he-jerusalem-1956"
                 ],
@@ -39873,6 +39876,7 @@
               "availableVersions": {
                 "summary": [],
                 "source": [
+                  "en-bb",
                   "en-ai",
                   "he-jerusalem-1956"
                 ],
@@ -39894,6 +39898,7 @@
               "availableVersions": {
                 "summary": [],
                 "source": [
+                  "en-bb",
                   "en-ai",
                   "he-jerusalem-1956"
                 ],
@@ -39916,6 +39921,7 @@
               "availableVersions": {
                 "summary": [],
                 "source": [
+                  "en-bb",
                   "en-ai",
                   "he-jerusalem-1956"
                 ],
@@ -39937,6 +39943,7 @@
               "availableVersions": {
                 "summary": [],
                 "source": [
+                  "en-bb",
                   "en-ai",
                   "he-jerusalem-1956"
                 ],
@@ -39960,6 +39967,7 @@
               "availableVersions": {
                 "summary": [],
                 "source": [
+                  "en-bb",
                   "en-ai",
                   "he-jerusalem-1956"
                 ],
@@ -39983,6 +39991,7 @@
               "availableVersions": {
                 "summary": [],
                 "source": [
+                  "en-bb",
                   "en-ai",
                   "he-jerusalem-1956"
                 ],
@@ -40005,6 +40014,7 @@
               "availableVersions": {
                 "summary": [],
                 "source": [
+                  "en-bb",
                   "en-ai",
                   "he-jerusalem-1956"
                 ],
@@ -40026,6 +40036,7 @@
               "availableVersions": {
                 "summary": [],
                 "source": [
+                  "en-bb",
                   "en-ai",
                   "he-jerusalem-1956"
                 ],
@@ -40049,6 +40060,7 @@
               "availableVersions": {
                 "summary": [],
                 "source": [
+                  "en-bb",
                   "en-ai",
                   "he-jerusalem-1956"
                 ],
@@ -40071,6 +40083,7 @@
               "availableVersions": {
                 "summary": [],
                 "source": [
+                  "en-bb",
                   "en-ai",
                   "he-jerusalem-1956"
                 ],
@@ -40091,6 +40104,7 @@
               "availableVersions": {
                 "summary": [],
                 "source": [
+                  "en-bb",
                   "en-ai",
                   "he-jerusalem-1956"
                 ],
@@ -40112,6 +40126,7 @@
               "availableVersions": {
                 "summary": [],
                 "source": [
+                  "en-bb",
                   "en-ai",
                   "he-jerusalem-1956"
                 ],
@@ -40134,6 +40149,7 @@
               "availableVersions": {
                 "summary": [],
                 "source": [
+                  "en-bb",
                   "en-ai",
                   "he-jerusalem-1956"
                 ],
@@ -40154,6 +40170,7 @@
               "availableVersions": {
                 "summary": [],
                 "source": [
+                  "en-bb",
                   "en-ai",
                   "he-jerusalem-1956"
                 ],
@@ -40175,6 +40192,7 @@
               "availableVersions": {
                 "summary": [],
                 "source": [
+                  "en-bb",
                   "en-ai",
                   "he-jerusalem-1956"
                 ],
@@ -40198,6 +40216,7 @@
               "availableVersions": {
                 "summary": [],
                 "source": [
+                  "en-bb",
                   "en-ai",
                   "he-jerusalem-1956"
                 ],
@@ -40220,6 +40239,7 @@
               "availableVersions": {
                 "summary": [],
                 "source": [
+                  "en-bb",
                   "en-ai",
                   "he-jerusalem-1956"
                 ],
@@ -40241,6 +40261,7 @@
               "availableVersions": {
                 "summary": [],
                 "source": [
+                  "en-bb",
                   "en-ai",
                   "he-jerusalem-1956"
                 ],
@@ -40263,6 +40284,7 @@
               "availableVersions": {
                 "summary": [],
                 "source": [
+                  "en-bb",
                   "en-ai",
                   "he-jerusalem-1956"
                 ],
@@ -40283,6 +40305,7 @@
               "availableVersions": {
                 "summary": [],
                 "source": [
+                  "en-bb",
                   "en-ai",
                   "he-jerusalem-1956"
                 ],
@@ -40303,6 +40326,7 @@
               "availableVersions": {
                 "summary": [],
                 "source": [
+                  "en-bb",
                   "en-ai",
                   "he-jerusalem-1956"
                 ],
@@ -40323,6 +40347,7 @@
               "availableVersions": {
                 "summary": [],
                 "source": [
+                  "en-bb",
                   "en-ai",
                   "he-jerusalem-1956"
                 ],
@@ -40343,6 +40368,7 @@
               "availableVersions": {
                 "summary": [],
                 "source": [
+                  "en-bb",
                   "en-ai",
                   "he-jerusalem-1956"
                 ],
@@ -40364,6 +40390,7 @@
               "availableVersions": {
                 "summary": [],
                 "source": [
+                  "en-bb",
                   "en-ai",
                   "he-jerusalem-1956"
                 ],
@@ -40386,6 +40413,7 @@
               "availableVersions": {
                 "summary": [],
                 "source": [
+                  "en-bb",
                   "en-ai",
                   "he-jerusalem-1956"
                 ],
@@ -40406,6 +40434,7 @@
               "availableVersions": {
                 "summary": [],
                 "source": [
+                  "en-bb",
                   "en-ai",
                   "he-jerusalem-1956"
                 ],
@@ -40426,6 +40455,7 @@
               "availableVersions": {
                 "summary": [],
                 "source": [
+                  "en-bb",
                   "en-ai",
                   "he-jerusalem-1956"
                 ],
@@ -40446,6 +40476,7 @@
               "availableVersions": {
                 "summary": [],
                 "source": [
+                  "en-bb",
                   "en-ai",
                   "he-jerusalem-1956"
                 ],
@@ -40466,6 +40497,7 @@
               "availableVersions": {
                 "summary": [],
                 "source": [
+                  "en-bb",
                   "en-ai",
                   "he-jerusalem-1956"
                 ],
@@ -40486,6 +40518,7 @@
               "availableVersions": {
                 "summary": [],
                 "source": [
+                  "en-bb",
                   "en-ai",
                   "he-jerusalem-1956"
                 ],
@@ -40507,6 +40540,7 @@
               "availableVersions": {
                 "summary": [],
                 "source": [
+                  "en-bb",
                   "en-ai",
                   "he-jerusalem-1956"
                 ],
@@ -40530,6 +40564,7 @@
               "availableVersions": {
                 "summary": [],
                 "source": [
+                  "en-bb",
                   "en-ai",
                   "he-jerusalem-1956"
                 ],
@@ -40553,6 +40588,7 @@
               "availableVersions": {
                 "summary": [],
                 "source": [
+                  "en-bb",
                   "en-ai",
                   "he-jerusalem-1956"
                 ],
@@ -40575,6 +40611,7 @@
               "availableVersions": {
                 "summary": [],
                 "source": [
+                  "en-bb",
                   "en-ai",
                   "he-jerusalem-1956"
                 ],
@@ -40596,6 +40633,7 @@
               "availableVersions": {
                 "summary": [],
                 "source": [
+                  "en-bb",
                   "en-ai",
                   "he-jerusalem-1956"
                 ],
@@ -40618,6 +40656,7 @@
               "availableVersions": {
                 "summary": [],
                 "source": [
+                  "en-bb",
                   "en-ai",
                   "he-jerusalem-1956"
                 ],
@@ -40639,6 +40678,7 @@
               "availableVersions": {
                 "summary": [],
                 "source": [
+                  "en-bb",
                   "en-ai",
                   "he-jerusalem-1956"
                 ],
@@ -40661,6 +40701,7 @@
               "availableVersions": {
                 "summary": [],
                 "source": [
+                  "en-bb",
                   "en-ai",
                   "he-jerusalem-1956"
                 ],
@@ -40681,6 +40722,7 @@
               "availableVersions": {
                 "summary": [],
                 "source": [
+                  "en-bb",
                   "en-ai",
                   "he-jerusalem-1956"
                 ],
@@ -40701,6 +40743,7 @@
               "availableVersions": {
                 "summary": [],
                 "source": [
+                  "en-bb",
                   "en-ai",
                   "he-jerusalem-1956"
                 ],
@@ -40722,6 +40765,7 @@
               "availableVersions": {
                 "summary": [],
                 "source": [
+                  "en-bb",
                   "en-ai",
                   "he-jerusalem-1956"
                 ],

--- a/content/toc.parts/part-16.json
+++ b/content/toc.parts/part-16.json
@@ -886,6 +886,7 @@
       "availableVersions": {
         "summary": [],
         "source": [
+          "en-bb",
           "en-ai",
           "he-jerusalem-1956"
         ],
@@ -907,6 +908,7 @@
       "availableVersions": {
         "summary": [],
         "source": [
+          "en-bb",
           "en-ai",
           "he-jerusalem-1956"
         ],
@@ -929,6 +931,7 @@
       "availableVersions": {
         "summary": [],
         "source": [
+          "en-bb",
           "en-ai",
           "he-jerusalem-1956"
         ],
@@ -949,6 +952,7 @@
       "availableVersions": {
         "summary": [],
         "source": [
+          "en-bb",
           "en-ai",
           "he-jerusalem-1956"
         ],
@@ -970,6 +974,7 @@
       "availableVersions": {
         "summary": [],
         "source": [
+          "en-bb",
           "en-ai",
           "he-jerusalem-1956"
         ],
@@ -992,6 +997,7 @@
       "availableVersions": {
         "summary": [],
         "source": [
+          "en-bb",
           "en-ai",
           "he-jerusalem-1956"
         ],
@@ -1013,6 +1019,7 @@
       "availableVersions": {
         "summary": [],
         "source": [
+          "en-bb",
           "en-ai",
           "he-jerusalem-1956"
         ],
@@ -1036,6 +1043,7 @@
       "availableVersions": {
         "summary": [],
         "source": [
+          "en-bb",
           "en-ai",
           "he-jerusalem-1956"
         ],
@@ -1059,6 +1067,7 @@
       "availableVersions": {
         "summary": [],
         "source": [
+          "en-bb",
           "en-ai",
           "he-jerusalem-1956"
         ],
@@ -1081,6 +1090,7 @@
       "availableVersions": {
         "summary": [],
         "source": [
+          "en-bb",
           "en-ai",
           "he-jerusalem-1956"
         ],
@@ -1102,6 +1112,7 @@
       "availableVersions": {
         "summary": [],
         "source": [
+          "en-bb",
           "en-ai",
           "he-jerusalem-1956"
         ],
@@ -1125,6 +1136,7 @@
       "availableVersions": {
         "summary": [],
         "source": [
+          "en-bb",
           "en-ai",
           "he-jerusalem-1956"
         ],
@@ -1147,6 +1159,7 @@
       "availableVersions": {
         "summary": [],
         "source": [
+          "en-bb",
           "en-ai",
           "he-jerusalem-1956"
         ],
@@ -1167,6 +1180,7 @@
       "availableVersions": {
         "summary": [],
         "source": [
+          "en-bb",
           "en-ai",
           "he-jerusalem-1956"
         ],
@@ -1188,6 +1202,7 @@
       "availableVersions": {
         "summary": [],
         "source": [
+          "en-bb",
           "en-ai",
           "he-jerusalem-1956"
         ],
@@ -1210,6 +1225,7 @@
       "availableVersions": {
         "summary": [],
         "source": [
+          "en-bb",
           "en-ai",
           "he-jerusalem-1956"
         ],
@@ -1230,6 +1246,7 @@
       "availableVersions": {
         "summary": [],
         "source": [
+          "en-bb",
           "en-ai",
           "he-jerusalem-1956"
         ],
@@ -1251,6 +1268,7 @@
       "availableVersions": {
         "summary": [],
         "source": [
+          "en-bb",
           "en-ai",
           "he-jerusalem-1956"
         ],
@@ -1274,6 +1292,7 @@
       "availableVersions": {
         "summary": [],
         "source": [
+          "en-bb",
           "en-ai",
           "he-jerusalem-1956"
         ],
@@ -1296,6 +1315,7 @@
       "availableVersions": {
         "summary": [],
         "source": [
+          "en-bb",
           "en-ai",
           "he-jerusalem-1956"
         ],
@@ -1317,6 +1337,7 @@
       "availableVersions": {
         "summary": [],
         "source": [
+          "en-bb",
           "en-ai",
           "he-jerusalem-1956"
         ],
@@ -1339,6 +1360,7 @@
       "availableVersions": {
         "summary": [],
         "source": [
+          "en-bb",
           "en-ai",
           "he-jerusalem-1956"
         ],
@@ -1359,6 +1381,7 @@
       "availableVersions": {
         "summary": [],
         "source": [
+          "en-bb",
           "en-ai",
           "he-jerusalem-1956"
         ],
@@ -1379,6 +1402,7 @@
       "availableVersions": {
         "summary": [],
         "source": [
+          "en-bb",
           "en-ai",
           "he-jerusalem-1956"
         ],
@@ -1399,6 +1423,7 @@
       "availableVersions": {
         "summary": [],
         "source": [
+          "en-bb",
           "en-ai",
           "he-jerusalem-1956"
         ],
@@ -1419,6 +1444,7 @@
       "availableVersions": {
         "summary": [],
         "source": [
+          "en-bb",
           "en-ai",
           "he-jerusalem-1956"
         ],
@@ -1440,6 +1466,7 @@
       "availableVersions": {
         "summary": [],
         "source": [
+          "en-bb",
           "en-ai",
           "he-jerusalem-1956"
         ],
@@ -1462,6 +1489,7 @@
       "availableVersions": {
         "summary": [],
         "source": [
+          "en-bb",
           "en-ai",
           "he-jerusalem-1956"
         ],
@@ -1482,6 +1510,7 @@
       "availableVersions": {
         "summary": [],
         "source": [
+          "en-bb",
           "en-ai",
           "he-jerusalem-1956"
         ],
@@ -1502,6 +1531,7 @@
       "availableVersions": {
         "summary": [],
         "source": [
+          "en-bb",
           "en-ai",
           "he-jerusalem-1956"
         ],
@@ -1522,6 +1552,7 @@
       "availableVersions": {
         "summary": [],
         "source": [
+          "en-bb",
           "en-ai",
           "he-jerusalem-1956"
         ],
@@ -1542,6 +1573,7 @@
       "availableVersions": {
         "summary": [],
         "source": [
+          "en-bb",
           "en-ai",
           "he-jerusalem-1956"
         ],
@@ -1562,6 +1594,7 @@
       "availableVersions": {
         "summary": [],
         "source": [
+          "en-bb",
           "en-ai",
           "he-jerusalem-1956"
         ],
@@ -1583,6 +1616,7 @@
       "availableVersions": {
         "summary": [],
         "source": [
+          "en-bb",
           "en-ai",
           "he-jerusalem-1956"
         ],
@@ -1606,6 +1640,7 @@
       "availableVersions": {
         "summary": [],
         "source": [
+          "en-bb",
           "en-ai",
           "he-jerusalem-1956"
         ],
@@ -1629,6 +1664,7 @@
       "availableVersions": {
         "summary": [],
         "source": [
+          "en-bb",
           "en-ai",
           "he-jerusalem-1956"
         ],
@@ -1651,6 +1687,7 @@
       "availableVersions": {
         "summary": [],
         "source": [
+          "en-bb",
           "en-ai",
           "he-jerusalem-1956"
         ],
@@ -1672,6 +1709,7 @@
       "availableVersions": {
         "summary": [],
         "source": [
+          "en-bb",
           "en-ai",
           "he-jerusalem-1956"
         ],
@@ -1694,6 +1732,7 @@
       "availableVersions": {
         "summary": [],
         "source": [
+          "en-bb",
           "en-ai",
           "he-jerusalem-1956"
         ],
@@ -1715,6 +1754,7 @@
       "availableVersions": {
         "summary": [],
         "source": [
+          "en-bb",
           "en-ai",
           "he-jerusalem-1956"
         ],
@@ -1737,6 +1777,7 @@
       "availableVersions": {
         "summary": [],
         "source": [
+          "en-bb",
           "en-ai",
           "he-jerusalem-1956"
         ],
@@ -1757,6 +1798,7 @@
       "availableVersions": {
         "summary": [],
         "source": [
+          "en-bb",
           "en-ai",
           "he-jerusalem-1956"
         ],
@@ -1777,6 +1819,7 @@
       "availableVersions": {
         "summary": [],
         "source": [
+          "en-bb",
           "en-ai",
           "he-jerusalem-1956"
         ],
@@ -1798,6 +1841,7 @@
       "availableVersions": {
         "summary": [],
         "source": [
+          "en-bb",
           "en-ai",
           "he-jerusalem-1956"
         ],

--- a/scripts/import-kabbalahmedia.ts
+++ b/scripts/import-kabbalahmedia.ts
@@ -141,6 +141,11 @@ import {
   type KmTreeArticle,
   type KmTreePart,
 } from "./lib/km-tree.ts";
+import {
+  groupKmUnnumberedWholePartBlocks,
+  hasUnnumberedKmItems,
+  parseDeclaredItemRange,
+} from "./lib/km-unnumbered-whole-part-parser.ts";
 import { firstSegmentPerAnswer } from "./lib/qa-consolidation.ts";
 import { writeTocSplitFiles } from "./lib/toc-splits.ts";
 import { validateContent } from "./validate-content.ts";
@@ -601,33 +606,65 @@ const processWholePartDialect = async (
         );
       },
       (blocks) => {
-        // Two dialects, tried in order. The styled one keys on `h5`; the flat
-        // one exists because some conversions lost every heading style, and
-        // the heading level was never the structure (issue #81). Whichever
-        // produces items, the SAME alignment check below decides whether they
-        // are believed — which is what makes it safe to try a second reading
-        // rather than refusing outright.
+        // Three dialects, tried in order (issue #81). The styled one keys on
+        // numbered `h5`; the flat one exists because some conversions lost
+        // every heading style; the unnumbered one carries seifim as `h5` with
+        // no numeral at all. The heading level was never the structure.
+        //
+        // A document may also cover only PART of a part and say so —
+        // part 16's front matter reads `Items 42-85`. When it does, the parse
+        // is aligned against exactly those chapters, and the range's size is a
+        // second, independent statement of the item count that must agree with
+        // the first.
+        //
+        // Whichever dialect produces items, the SAME checks below decide
+        // whether they are believed. That is what makes it safe to try a
+        // further reading rather than refusing outright.
+        const declaredRange = parseDeclaredItemRange(blocks);
+        const scopedGround = declaredRange
+          ? groundEntries.filter(
+              (entry) =>
+                entry.number >= declaredRange.from &&
+                entry.number <= declaredRange.to,
+            )
+          : groundEntries;
+
+        if (declaredRange && scopedGround.length === 0) {
+          return {
+            ok: false,
+            kind: "unmatched",
+            reason: `document declares items ${declaredRange.from}-${declaredRange.to}, which match no chapter of this part`,
+          };
+        }
+
         const items = hasNumberedKmItems(blocks)
           ? groupKmChapterBlocks(blocks).items
           : hasFlatNumberedItems(blocks)
             ? groupKmFlatWholePartBlocks(blocks)
-            : undefined;
+            : hasUnnumberedKmItems(blocks)
+              ? groupKmUnnumberedWholePartBlocks(
+                  blocks,
+                  declaredRange?.from ?? 1,
+                )
+              : undefined;
 
         if (!items) {
           return {
             ok: false,
             kind: "structure-unsupported",
-            reason: "no numbered source items, styled or flat",
+            reason: "no source items — numbered, flat or unnumbered",
           };
         }
         const alignmentError =
-          validateNumberedOrderAlignment(items, groundEntries) ??
-          validateTranslationPlausibility(items, groundEntries);
+          validateNumberedOrderAlignment(items, scopedGround) ??
+          validateTranslationPlausibility(items, scopedGround);
         return alignmentError
           ? {
               ok: false,
               kind: "unmatched",
-              reason: alignmentError,
+              reason: declaredRange
+                ? `${alignmentError} (document declares items ${declaredRange.from}-${declaredRange.to})`
+                : alignmentError,
             }
           : { ok: true, value: items };
       },

--- a/scripts/lib/km-unnumbered-whole-part-parser.ts
+++ b/scripts/lib/km-unnumbered-whole-part-parser.ts
@@ -1,0 +1,126 @@
+/**
+ * The third whole-part docx dialect: seifim that are not numbered in the text
+ * at all, carried by `h5` blocks, with a `Ohr Pnimi` marker paragraph between
+ * each seif and its commentary (issue #81).
+ *
+ *     <h5> * It is written in the Zohar (Kedoshim) about the secrets…   <- seif
+ *     <p>  Ohr Pnimi                                                     <- marker
+ *     <p>  Meaning the first seven fallen Melachim…                      <- commentary
+ *     <h5> Adam ha Rishon had no part of Olam ha Zeh…                    <- next seif
+ *
+ * Position carries the alignment here, because nothing else does. That makes
+ * it the most dangerous of the three dialects: a single missed or extra seif
+ * shifts every chapter after it, silently, and the text still reads like
+ * scripture. Two things stand between it and that.
+ *
+ * **The declared range.** These documents cover part of a part and say so in
+ * their front matter — part 16's reads `Items 42-85`, and it holds exactly 44
+ * `h5` blocks. `parseDeclaredItemRange` reads that line, and the caller aligns
+ * the parse against those chapters rather than the whole part. A document
+ * whose declared range and `h5` count disagree is refused: two independent
+ * statements of the same fact that must agree, which is precisely what
+ * position-based alignment otherwise lacks.
+ *
+ * **The front matter.** These documents open with a page-number table of
+ * contents (part 8's runs 98 blocks). It is `p`, never `h5`, so keying on
+ * `h5` steps over it for free — unlike the flat dialect, where it had to be
+ * defended against explicitly (`validateTranslationPlausibility`).
+ *
+ * Note the transliteration: these are Bnei Baruch's OLDER English edition
+ * (`Maatzil`, `Melachim`, `Olam Beria`) where parts 6 and 7 import from the
+ * newer one (`Emanator`, `the ARI`). Both are official; they read differently.
+ */
+import type { KmSourceItem } from "./km-chapter-parser.ts";
+import type { DocBlock } from "./km-doc-blocks.ts";
+
+/** Same marker paragraphs the flat dialect uses; see `km-flat-whole-part-parser.ts`. */
+const SECTION_MARKERS = new Set(["Inner Light", "Ohr Pnimi"]);
+
+/** `Items 42-85` in the front matter — the document's own statement of what it covers. */
+const DECLARED_RANGE_RE = /^\s*Items?\s+(\d+)\s*[-–—]\s*(\d+)\s*$/i;
+
+const stripTags = (html: string): string =>
+  html
+    .replace(/<[^>]*>/g, "")
+    .replace(/\s+/g, " ")
+    .trim();
+
+const appendHtml = (base: string, addition: string): string =>
+  base.length > 0 ? `${base} ${addition}` : addition;
+
+export interface DeclaredItemRange {
+  /** 1-based first chapter number this document covers. */
+  from: number;
+  /** 1-based last chapter number, inclusive. */
+  to: number;
+}
+
+/**
+ * The `Items N-M` line, or `undefined` when the document makes no such claim.
+ * Only the front matter is searched — the phrase could otherwise appear in
+ * running prose.
+ */
+export const parseDeclaredItemRange = (
+  blocks: DocBlock[],
+  frontMatterBlocks = 12,
+): DeclaredItemRange | undefined => {
+  for (const block of blocks.slice(0, frontMatterBlocks)) {
+    const match = DECLARED_RANGE_RE.exec(stripTags(block.html));
+    if (!match) continue;
+
+    const from = Number(match[1]);
+    const to = Number(match[2]);
+    if (from >= 1 && to >= from) return { from, to };
+  }
+  return undefined;
+};
+
+/**
+ * True when a document carries `h5` seifim that the numbered dialects cannot
+ * read — at least one `h5`, and none of them numbered. The second half is
+ * what keeps this from stealing documents `km-chapter-parser.ts` handles.
+ */
+export const hasUnnumberedKmItems = (blocks: DocBlock[]): boolean => {
+  const headings = blocks.filter((block) => block.tag === "h5");
+  return (
+    headings.length > 0 &&
+    !headings.some((block) => /^\s*\d+\.?\s/.test(stripTags(block.html)))
+  );
+};
+
+/**
+ * Source items in document order, numbered from `startNumber` — the declared
+ * range's first chapter, or 1 when the document covers the whole part.
+ *
+ * Commentary is read only to know where a seif ends; the whole-part dialects
+ * write source alone (see the `tes-import-kabbalahmedia` skill).
+ */
+export const groupKmUnnumberedWholePartBlocks = (
+  blocks: DocBlock[],
+  startNumber = 1,
+): KmSourceItem[] => {
+  const items: KmSourceItem[] = [];
+  let current: KmSourceItem | undefined;
+  let inCommentary = false;
+
+  for (const block of blocks) {
+    if (block.tag === "h5") {
+      current = { n: startNumber + items.length, html: block.html };
+      items.push(current);
+      inCommentary = false;
+      continue;
+    }
+
+    if (SECTION_MARKERS.has(stripTags(block.html))) {
+      inCommentary = true;
+      current = undefined;
+      continue;
+    }
+
+    if (current && !inCommentary) {
+      current.html = appendHtml(current.html, block.html);
+    }
+  }
+
+  return items;
+};

--- a/tests/unit/import-kabbalahmedia.spec.ts
+++ b/tests/unit/import-kabbalahmedia.spec.ts
@@ -65,6 +65,11 @@ import {
   parseKmPartNumber,
   type KmSqData,
 } from "../../scripts/lib/km-tree.ts";
+import {
+  groupKmUnnumberedWholePartBlocks,
+  hasUnnumberedKmItems,
+  parseDeclaredItemRange,
+} from "../../scripts/lib/km-unnumbered-whole-part-parser.ts";
 import type {
   CommentaryItem,
   SourceSegment,
@@ -1545,5 +1550,123 @@ describe("validateTranslationPlausibility", () => {
         { number: 1, sefariaRef: "x 1" },
       ]),
     ).toBeUndefined();
+  });
+});
+
+// Issue #81. Parts 8 and 16 carry seifim as `h5` with no numeral at all, so
+// POSITION is the only thing aligning them — the most dangerous of the three
+// dialects, since one missed seif shifts every chapter after it and the text
+// still reads like scripture.
+describe("groupKmUnnumberedWholePartBlocks", () => {
+  const h5 = (html: string) => ({ tag: "h5", html });
+  const p = (html: string) => ({ tag: "p", html });
+
+  it("takes each h5 as a seif and ends it at the marker", () => {
+    const items = groupKmUnnumberedWholePartBlocks([
+      p("PART SIXTEEN"),
+      h5("* It is written in the Zohar."),
+      p("Ohr Pnimi"),
+      p("Meaning the first seven fallen Melachim."),
+      h5("Adam ha Rishon had no part of Olam ha Zeh."),
+    ]);
+
+    expect(items).toEqual([
+      { n: 1, html: "* It is written in the Zohar." },
+      { n: 2, html: "Adam ha Rishon had no part of Olam ha Zeh." },
+    ]);
+  });
+
+  it("numbers from the declared range's first chapter", () => {
+    // Part 16's document covers items 42-85 of a 272-chapter part. Numbering
+    // from 1 would align its first seif to chapter 1 — every one of the 44
+    // wrong, and every one of them plausible prose.
+    const items = groupKmUnnumberedWholePartBlocks(
+      [h5("First covered seif."), h5("Second.")],
+      42,
+    );
+
+    expect(items.map((item) => item.n)).toEqual([42, 43]);
+  });
+
+  it("joins a seif's continuation paragraphs but never its commentary", () => {
+    const items = groupKmUnnumberedWholePartBlocks([
+      h5("Opening."),
+      p("Continuation."),
+      p("Ohr Pnimi"),
+      p("Commentary that must stay out."),
+      h5("Next seif."),
+    ]);
+
+    expect(items[0]?.html).toBe("Opening. Continuation.");
+  });
+
+  it("steps over a page-number table of contents, which is never h5", () => {
+    const items = groupKmUnnumberedWholePartBlocks([
+      p("1. * 4"),
+      p("2. 4"),
+      p("3. 5"),
+      h5("The first real seif."),
+    ]);
+
+    expect(items).toHaveLength(1);
+    expect(items[0]?.html).toBe("The first real seif.");
+  });
+});
+
+describe("hasUnnumberedKmItems", () => {
+  it("is true for h5 seifim carrying no numeral", () => {
+    expect(
+      hasUnnumberedKmItems([
+        { tag: "h5", html: "* It is written in the Zohar." },
+      ]),
+    ).toBe(true);
+  });
+
+  it("is false when the h5 items ARE numbered — that is the styled dialect", () => {
+    expect(
+      hasUnnumberedKmItems([{ tag: "h5", html: "1. AK contains AB, SAG." }]),
+    ).toBe(false);
+  });
+
+  it("is false for a document with no h5 at all", () => {
+    expect(hasUnnumberedKmItems([{ tag: "p", html: "1. AK contains." }])).toBe(
+      false,
+    );
+  });
+});
+
+describe("parseDeclaredItemRange", () => {
+  it("reads the document's own statement of what it covers", () => {
+    expect(
+      parseDeclaredItemRange([
+        { tag: "p", html: "PART SIXTEEN" },
+        { tag: "p", html: "The Three Olamot Beria Yetzira Assiya" },
+        { tag: "p", html: "Items 42-85" },
+      ]),
+    ).toEqual({ from: 42, to: 85 });
+  });
+
+  it("accepts an en dash, which docx conversion likes to produce", () => {
+    expect(
+      parseDeclaredItemRange([{ tag: "p", html: "Items 42–85" }])?.to,
+    ).toBe(85);
+  });
+
+  it("is undefined for a document that covers a whole part", () => {
+    expect(
+      parseDeclaredItemRange([{ tag: "p", html: "PART SIX" }]),
+    ).toBeUndefined();
+  });
+
+  it("ignores the phrase outside the front matter", () => {
+    // Only the opening blocks are searched — "Items 1-9" could otherwise
+    // appear in a cross-reference in running commentary and silently rescope
+    // the whole document.
+    const blocks = [
+      ...Array.from({ length: 12 }, () => ({ tag: "p", html: "prose" })),
+      { tag: "p", html: "Items 1-9" },
+    ];
+
+    expect(parseDeclaredItemRange(blocks)).toBeUndefined();
   });
 });


### PR DESCRIPTION
Refs #81. Part 16's **44 chapters** of official Bnei Baruch English, and the third and last whole-part dialect.

Follows #134 (parts 6 and 7, 127 chapters).

## The dialect

Parts 8 and 16 carry seifim as `h5` blocks with **no numeral at all**, separated from their commentary by an `Ohr Pnimi` marker:

```
<h5> * It is written in the Zohar (Kedoshim) about the secrets of the Torah…   ← seif
<p>  Ohr Pnimi                                                                  ← marker
<p>  Meaning the first seven fallen Melachim that fell into the separated BYA…  ← commentary
<h5> Adam ha Rishon had no part of Olam ha Zeh…                                 ← next seif
```

**Position is the only thing aligning this.** That makes it the most dangerous of the three dialects: one missed or extra seif shifts every chapter after it, silently, and the text still reads like scripture. So it does not go in without two independent checks.

## 1. The document declares its own range

Part 16 has 272 chapters. This document is not short — it is **explicitly partial**, and says so:

```
<p> PART SIXTEEN
<p> The Three Olamot Beria Yetzira Assiya
<p> Items 42-85
```

`Items 42-85` is 44 items, and the document holds **exactly 44 `h5` blocks**. The parse is aligned against chapters 42–85 and numbered from 42, so the declared range and the `h5` count become **two independent statements of the same fact that have to agree** — which is precisely what position-based alignment otherwise lacks.

Numbering from 1 instead would align the first seif to chapter 1: all 44 wrong, and every one of them plausible prose.

Only the front matter is searched. `Items 1-9` appearing in a cross-reference in running commentary must not silently rescope a whole document; a test pins that.

## 2. The front matter defends itself

These documents open with a page-number table of contents — part 8's runs **98 blocks**. It is `p`, never `h5`, so keying on `h5` steps over it for free. That is a pleasant contrast with the flat dialect in #134, where the same table of contents had to be defended against explicitly with `validateTranslationPlausibility`.

## Verified at both boundaries

| chapter | Hebrew | English |
| --- | --- | --- |
| 41 | — | **correctly absent** |
| 42 | `*בזהר קדושים בדפ"ג ע"א וז"ל בסתרי תורה אדם קדמאה` | `* It is written in the Zohar (Kedoshim) about the secretes of the Torah: "Adam ha Rishon` |
| 43 | `הנה אדם הראשון לא היה לו שום חלק מן האי עלמא, שהוא עולם העשיה` | `Adam ha Rishon had no part of Olam ha Zeh, which is Olam Assiya` |
| 60 | `גם נלע"ד ששמעתי ממורי ז"ל תשובה אחרת בזה` | `I also believe I had heard from my teacher a different answer regarding this` |
| 85 | `ונמצאו עתה פנויים ארבעה תחתונות דבריאה וכל עולם היצירה ועשיה` | `Now you find that the bottom four de Beria and the entire Olam Yetzira and Assiya` |
| 86 | — | **correctly absent** |

The two absences matter as much as the four matches: they are what proves the offset landed where the document said it would.

```
task check   # green — 966 tests / 78 files, generate, verify:fonts, 10 e2e
```

## Part 8 stays refused, deliberately

Two reasons, and it is worth being explicit that this is a decision rather than an oversight:

1. Its table of contents **is** numbered, so the flat dialect claims the document first and `validateTranslationPlausibility` rejects it (median 0.018 of the Hebrew's length) before the unnumbered reading is ever reached.
2. More fundamentally, its document has **80 `h5` blocks against part 8's 94 chapters**. Fourteen short. Until that is reconciled, a positional alignment would shift every seif after the first gap.

Refusing is the correct state. Both facts are recorded on #81.

## What a reviewer should double-check

- **The transliteration differs from parts 6 and 7.** These are Bnei Baruch's *older* English edition — `Maatzil`, `Melachim`, `Olam ha Zeh` — where #134 imported the newer one (`Emanator`, `the ARI`, `in its self`). Both are official; a reader moving between part 7 and part 16 will notice. Worth an editorial decision at some point, but not one I should make.
- **`content/COVERAGE.md` remains stale** — `--part` runs do not rewrite it, by design. Now two PRs behind.
- **228 of part 16's 272 chapters are still unimported**, and there is only one whole-part document for the part, so no sibling covers items 1–41 or 86–272. That is an upstream publishing gap, not a parser gap.
- **`groupKmUnnumberedWholePartBlocks` trusts `h5` completely.** If a document styles one seif as `h4` or `p`, the count check and the declared range are what catch it — which is exactly what happens on part 8.
