### PR TITLE
feat(scripts): let the translation pipeline reach the source layer

### DIFF
--- a/scripts/lib/translation-batches.ts
+++ b/scripts/lib/translation-batches.ts
@@ -25,10 +25,26 @@ import type {
 export const proseLength = (html: string): number =>
   html.replace(/<[^>]+>/g, "").length;
 
+/**
+ * What a batch carries per translatable unit. A commentary item is identified
+ * by its `anchorId`, a source segment by its `n` — the two layers number
+ * themselves differently, and neither identity is ever produced by a model
+ * (see `translate-apply.ts`).
+ */
+export type TranslatableItem = CommentaryItem | SourceSegment;
+
+/** The stable identity of a translatable item, whichever layer it came from. */
+export const itemKey = (item: TranslatableItem): string =>
+  "anchorId" in item ? item.anchorId : `seif-${item.n}`;
+
+/** Reading-order position: a commentary item's `order`, a source segment's `n`. */
+const readingPosition = (item: TranslatableItem): number =>
+  "order" in item ? item.order : item.n;
+
 export interface TranslatableChapter {
   chapterId: string;
   /** Items present in the source version but not yet in the target version. */
-  items: CommentaryItem[];
+  items: TranslatableItem[];
   /** The chapter's source text in the source language — context, never translated. */
   sourceSegments: SourceSegment[];
   /** The same text in the target language where it exists, so terminology matches the pane beside it. */
@@ -46,29 +62,42 @@ export interface TranslationBatch {
 
 /**
  * The items of `sourceItems` that `targetItems` does not already cover, matched
- * on `anchorId`.
+ * on `itemKey` — `anchorId` for commentary, `n` for source segments.
  *
  * Partial chapters are normal and supported: `checkTranslatedVersionIntegrity`
  * explicitly allows a translated commentary file to be a subset, so a batch may
- * top up a chapter that an earlier run half-finished.
+ * top up a chapter that an earlier run half-finished. The source layer has the
+ * same shape of gap — the Introduction ships 15 of its 443 paragraphs in
+ * English (issue #133) — and needs the same top-up behaviour.
+ *
+ * Ordered by `order` where the layer has one (commentary) and by `n` otherwise,
+ * so batches follow the reading order of the text either way.
  */
 export const untranslatedItems = (
-  sourceItems: CommentaryItem[],
-  targetItems: readonly CommentaryItem[],
-): CommentaryItem[] => {
-  const covered = new Set(targetItems.map((item) => item.anchorId));
+  sourceItems: readonly TranslatableItem[],
+  targetItems: readonly TranslatableItem[],
+): TranslatableItem[] => {
+  const covered = new Set(targetItems.map(itemKey));
   return sourceItems
-    .filter((item) => !covered.has(item.anchorId))
-    .sort((a, b) => a.order - b.order);
+    .filter((item) => !covered.has(itemKey(item)))
+    .sort((a, b) => readingPosition(a) - readingPosition(b));
 };
 
 /**
  * Packs chapters into batches of at most `budgetChars` of source prose,
  * preserving input order so batch ids stay stable across runs.
  *
- * A chapter larger than the whole budget gets a batch to itself rather than
- * being split or silently dropped — the caller sees it in the manifest's own
- * `chars` figure and can lower the budget for that run if a model chokes.
+ * A chapter larger than the whole budget is SPLIT across consecutive batches,
+ * carrying its `chapterId` into each. That was originally forbidden — one
+ * chapter is one output file, and two batches writing it looked like a race —
+ * but `translate-apply.ts` merges into whatever is already on disk and refuses
+ * to overwrite an item that is present, so applying the pieces one after
+ * another is safe and order-independent.
+ *
+ * It became necessary with the source layer (issue #133): a commentary item is
+ * small, but the Introduction is ONE chapter of 443 segments and 105,000
+ * characters. Left unsplit it produced a single 519KB manifest at five times
+ * the budget — a batch no model would take, and the budget silently meaningless.
  */
 export const packBatches = (
   chapters: TranslatableChapter[],
@@ -97,16 +126,40 @@ export const packBatches = (
       0,
     );
 
-    // Close the open batch first when this chapter would overflow it, so the
-    // oversize-chapter case below lands in a batch of its own rather than
-    // being appended to whatever was already accumulating.
+    // Close the open batch first when this chapter would overflow it, so a
+    // large chapter starts cleanly rather than being appended to whatever was
+    // already accumulating.
     if (current.length > 0 && currentChars + chapterChars > budgetChars)
       flush();
 
-    current.push(chapter);
-    currentChars += chapterChars;
+    if (chapterChars <= budgetChars) {
+      current.push(chapter);
+      currentChars += chapterChars;
+      if (currentChars >= budgetChars) flush();
+      continue;
+    }
 
-    if (currentChars >= budgetChars) flush();
+    // Oversize: emit it a slice at a time. Each slice keeps the chapter's own
+    // id and context, so a translator still sees the text the items sit in.
+    let slice: TranslatableItem[] = [];
+    let sliceChars = 0;
+    for (const item of chapter.items) {
+      const itemChars = proseLength(item.html);
+      if (slice.length > 0 && sliceChars + itemChars > budgetChars) {
+        current.push({ ...chapter, items: slice });
+        currentChars += sliceChars;
+        flush();
+        slice = [];
+        sliceChars = 0;
+      }
+      slice.push(item);
+      sliceChars += itemChars;
+    }
+    if (slice.length > 0) {
+      current.push({ ...chapter, items: slice });
+      currentChars += sliceChars;
+      flush();
+    }
   }
 
   flush();

--- a/scripts/translate-apply.ts
+++ b/scripts/translate-apply.ts
@@ -1,7 +1,7 @@
 /**
  * Ingests a translated batch result and writes the corpus files.
  *
- * `pnpm translate:apply --file <result>.json [--target <versionId>] [--dry-run]`
+ * `pnpm translate:apply --file <result>.json [--target <versionId>] [--layer source] [--dry-run]`
  *
  * `--target` names the version being written. It is a flag rather than a
  * required field of the result file because the result file is what comes back
@@ -13,7 +13,13 @@
  * confusing way to say "the runner forgot to tell me". A `targetVersionId` in
  * the file is still honoured, so results that carry one keep working.
  *
- * The result file carries ONLY `{ chapterId, anchorId, html }` per item. Every
+ * `--layer` selects which layer is being filled — `commentary` (the default,
+ * and where the corpus's gap overwhelmingly is) or `source`. A source entry is
+ * keyed by its segment number `n` instead of an `anchorId`; everything below
+ * applies identically to both, because the identity is the only thing that
+ * differs and neither is ever produced by a model.
+ *
+ * The result file carries ONLY `{ chapterId, anchorId | n, html }` per item. Every
  * other field on a `CommentaryItem` — `order`, `label`, `sefariaRef`,
  * `section`, `targetSeif` — is copied byte-for-byte from the Hebrew source
  * here, never from the model. That is the pipeline's safety property: three of
@@ -42,8 +48,10 @@ import {
   versionsFileSchema,
   type ChapterLayerFile,
   type CommentaryItem,
+  type SourceSegment,
 } from "../shared/types/content.ts";
 import { writeTocSplitFiles } from "./lib/toc-splits.ts";
+import { itemKey, type TranslatableItem } from "./lib/translation-batches.ts";
 
 const CONTENT_ROOT = fileURLToPath(new URL("../content", import.meta.url));
 
@@ -56,10 +64,15 @@ const resultPath = arg("--file");
 const isDryRun = process.argv.includes("--dry-run");
 
 const targetFlag = arg("--target");
+const layer = arg("--layer") ?? "commentary";
+if (layer !== "commentary" && layer !== "source") {
+  console.error(`--layer must be "commentary" or "source", got ${layer}`);
+  process.exit(2);
+}
 
 if (!resultPath) {
   console.error(
-    "usage: pnpm translate:apply --file <result>.json [--target <versionId>] [--dry-run]",
+    "usage: pnpm translate:apply --file <result>.json [--target <versionId>] [--layer source] [--dry-run]",
   );
   process.exit(2);
 }
@@ -67,7 +80,12 @@ if (!resultPath) {
 interface TranslationResult {
   batch?: string;
   targetVersionId?: string;
-  translations: { chapterId: string; anchorId: string; html: string }[];
+  translations: {
+    chapterId: string;
+    anchorId?: string;
+    n?: number;
+    html: string;
+  }[];
 }
 
 const result = JSON.parse(
@@ -103,23 +121,35 @@ const HEBREW = /[֐-׿]/g;
 
 const errors: string[] = [];
 
-const byChapter = new Map<string, { anchorId: string; html: string }[]>();
+/** `anchorId` on the commentary layer, `seif-<n>` on the source layer. */
+const entryKey = (entry: {
+  anchorId?: string;
+  n?: number;
+}): string | undefined =>
+  layer === "commentary"
+    ? entry.anchorId
+    : typeof entry.n === "number"
+      ? `seif-${entry.n}`
+      : undefined;
+
+const byChapter = new Map<string, { key: string; html: string }[]>();
 for (const entry of result.translations) {
-  if (!entry?.chapterId || !entry?.anchorId) {
+  const key = entry?.chapterId ? entryKey(entry) : undefined;
+  if (!key) {
     errors.push(
-      `an entry is missing chapterId or anchorId: ${JSON.stringify(entry)}`,
+      `an entry is missing chapterId or ${layer === "commentary" ? "anchorId" : "n"}: ${JSON.stringify(entry)}`,
     );
     continue;
   }
   const list = byChapter.get(entry.chapterId) ?? [];
-  list.push({ anchorId: entry.anchorId, html: entry.html });
+  list.push({ key, html: entry.html });
   byChapter.set(entry.chapterId, list);
 }
 
 interface PendingWrite {
   path: string;
   chapterId: string;
-  file: ChapterLayerFile<CommentaryItem>;
+  file: ChapterLayerFile<CommentaryItem> | ChapterLayerFile<SourceSegment>;
   added: number;
 }
 
@@ -134,11 +164,11 @@ for (const [chapterId, translations] of byChapter) {
     "chapters",
     slug as string,
   );
-  const sourcePath = join(dir, `commentary.${sourceVersionId}.json`);
+  const sourcePath = join(dir, `${layer}.${sourceVersionId}.json`);
 
   if (!existsSync(sourcePath)) {
     errors.push(
-      `${chapterId}: no ${sourceVersionId} commentary file to copy structure from`,
+      `${chapterId}: no ${sourceVersionId} ${layer} file to copy structure from`,
     );
     continue;
   }
@@ -146,30 +176,35 @@ for (const [chapterId, translations] of byChapter) {
   const parsedSource = chapterLayerFileSchema.parse(
     JSON.parse(readFileSync(sourcePath, "utf8")),
   );
-  if (parsedSource.layer !== "commentary") continue;
-  const sourceByAnchor = new Map(
-    parsedSource.items.map((item) => [item.anchorId, item]),
+  if (parsedSource.layer !== layer) continue;
+  const sourceByKey = new Map(
+    (parsedSource.items as TranslatableItem[]).map((item) => [
+      itemKey(item),
+      item,
+    ]),
   );
 
-  const targetPath = join(dir, `commentary.${targetVersion.id}.json`);
+  const targetPath = join(dir, `${layer}.${targetVersion.id}.json`);
   const existing = existsSync(targetPath)
     ? chapterLayerFileSchema.parse(JSON.parse(readFileSync(targetPath, "utf8")))
     : null;
-  const items: CommentaryItem[] =
-    existing?.layer === "commentary" ? [...existing.items] : [];
-  const alreadyPresent = new Set(items.map((item) => item.anchorId));
+  const items: TranslatableItem[] =
+    existing?.layer === layer
+      ? [...(existing.items as TranslatableItem[])]
+      : [];
+  const alreadyPresent = new Set(items.map(itemKey));
 
   const seen = new Set<string>();
   let added = 0;
 
-  for (const { anchorId, html } of translations) {
+  for (const { key: anchorId, html } of translations) {
     if (seen.has(anchorId)) {
       errors.push(`${chapterId}: ${anchorId} returned more than once`);
       continue;
     }
     seen.add(anchorId);
 
-    const sourceItem = sourceByAnchor.get(anchorId);
+    const sourceItem = sourceByKey.get(anchorId);
     if (!sourceItem) {
       errors.push(
         `${chapterId}: ${anchorId} does not exist in ${sourceVersionId}`,
@@ -203,7 +238,9 @@ for (const [chapterId, translations] of byChapter) {
 
   if (added === 0) continue;
 
-  items.sort((a, b) => a.order - b.order);
+  items.sort(
+    (a, b) => ("order" in a ? a.order : a.n) - ("order" in b ? b.order : b.n),
+  );
 
   pending.push({
     path: targetPath,
@@ -211,12 +248,16 @@ for (const [chapterId, translations] of byChapter) {
     added,
     file: {
       chapterId,
-      layer: "commentary",
+      // The two layers' item shapes are disjoint unions to the schema, and
+      // `items` is homogeneous by construction — every entry came from the
+      // same `parsedSource`. The cast states that; the schema still validates
+      // on read, and `validate:content` on the whole tree afterwards.
+      layer: layer as "commentary",
       versionId: targetVersion.id,
       ...(parsedSource.sefariaRef
         ? { sefariaRef: parsedSource.sefariaRef }
         : {}),
-      items,
+      items: items as CommentaryItem[],
     },
   });
 }

--- a/scripts/translate-export.ts
+++ b/scripts/translate-export.ts
@@ -41,7 +41,6 @@ import {
   glossaryIndexFileSchema,
   tocSchema,
   versionsFileSchema,
-  type CommentaryItem,
   type SourceSegment,
 } from "../shared/types/content.ts";
 import {
@@ -49,6 +48,7 @@ import {
   proseLength,
   untranslatedItems,
   type TranslatableChapter,
+  type TranslatableItem,
 } from "./lib/translation-batches.ts";
 
 const CONTENT_ROOT = fileURLToPath(new URL("../content", import.meta.url));
@@ -65,6 +65,19 @@ if (!targetLanguage) {
   console.error(
     "usage: pnpm translate:export --lang <code> [--part part-05] [--budget 20000] [--out DIR]",
   );
+  process.exit(2);
+}
+
+/**
+ * Which layer to export. The commentary layer is the default because that is
+ * where the corpus's gap overwhelmingly is (1,223 items). The source layer
+ * matters for a handful of chapters the Sefaria community translation left
+ * short — above all the Introduction, 15 of whose 443 paragraphs are in
+ * English (issue #133) — which the commentary walk cannot see at all.
+ */
+const layer = arg("--layer") ?? "commentary";
+if (layer !== "commentary" && layer !== "source") {
+  console.error(`--layer must be "commentary" or "source", got ${layer}`);
   process.exit(2);
 }
 
@@ -142,16 +155,17 @@ for (const chapterId of chapterIds) {
   );
   if (!existsSync(dir)) continue;
 
-  const source = readLayer(dir, `commentary.${SOURCE_VERSION_ID}.json`);
-  if (!source || source.layer !== "commentary") continue;
+  const source = readLayer(dir, `${layer}.${SOURCE_VERSION_ID}.json`);
+  if (!source || source.layer !== layer) continue;
 
   // Anything any edition in the target language already covers is done.
-  const covered: CommentaryItem[] = [];
+  const covered: TranslatableItem[] = [];
+  const layerFileRe = new RegExp(`^${layer}\\.(.+)\\.json$`);
   for (const fileName of readdirSync(dir)) {
-    const match = /^commentary\.(.+)\.json$/.exec(fileName);
+    const match = layerFileRe.exec(fileName);
     if (!match || !targetLanguageVersionIds.has(match[1] as string)) continue;
     const existing = readLayer(dir, fileName);
-    if (existing?.layer === "commentary") covered.push(...existing.items);
+    if (existing?.layer === layer) covered.push(...existing.items);
   }
 
   const items = untranslatedItems(source.items, covered);
@@ -224,6 +238,7 @@ for (const batch of batches) {
     batch: batch.id,
     targetLanguage,
     targetVersionId: targetVersion.id,
+    layer,
     sourceVersionId: SOURCE_VERSION_ID,
     itemCount: batch.items,
     sourceChars: batch.chars,
@@ -236,16 +251,21 @@ for (const batch of batches) {
     chapters: batch.chapters.map((chapter) => ({
       chapterId: chapter.chapterId,
       context: {
-        sourceText: chapter.sourceSegments.map((s) => ({
-          n: s.n,
-          html: s.html,
-        })),
+        // On the source layer the items ARE this text — sending it twice
+        // doubled a 105,000-character manifest for nothing (issue #133).
+        sourceText:
+          layer === "source"
+            ? []
+            : chapter.sourceSegments.map((s) => ({ n: s.n, html: s.html })),
         targetText:
           chapter.targetSegments?.map((s) => ({ n: s.n, html: s.html })) ??
           null,
       },
+      // The identity a result must come back keyed by: `anchorId` for
+      // commentary, `n` for a source segment. Never produced by the model —
+      // `translate-apply.ts` copies it from the Hebrew.
       items: chapter.items.map((item) => ({
-        anchorId: item.anchorId,
+        ...("anchorId" in item ? { anchorId: item.anchorId } : { n: item.n }),
         he: item.html,
       })),
     })),
@@ -276,6 +296,6 @@ console.log(
     `batches         ${batches.length} (budget ${budgetChars.toLocaleString()} chars)`,
     `written to      ${outDir}`,
     ``,
-    `Next: translate each manifest, then \`pnpm translate:apply --file <result>.json --target ${targetVersion.id}\`.`,
+    `Next: translate each manifest, then \`pnpm translate:apply --file <result>.json --target ${targetVersion.id}${layer === "source" ? " --layer source" : ""}\`.`,
   ].join("\n"),
 );

--- a/tests/unit/translation-batches.spec.ts
+++ b/tests/unit/translation-batches.spec.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import {
+  itemKey,
   packBatches,
   proseLength,
   untranslatedItems,
@@ -52,7 +53,7 @@ describe("untranslatedItems", () => {
     ];
     const target = [item("op-2", 2, "translated")];
 
-    expect(untranslatedItems(source, target).map((i) => i.anchorId)).toEqual([
+    expect(untranslatedItems(source, target).map(itemKey)).toEqual([
       "op-1",
       "op-3",
     ]);
@@ -61,7 +62,10 @@ describe("untranslatedItems", () => {
   it("returns them in reading order regardless of input order", () => {
     const source = [item("op-9", 9, "a"), item("op-2", 2, "b")];
 
-    expect(untranslatedItems(source, []).map((i) => i.order)).toEqual([2, 9]);
+    expect(untranslatedItems(source, []).map(itemKey)).toEqual([
+      "op-2",
+      "op-9",
+    ]);
   });
 
   it("supports a partially translated chapter — the validator allows subsets", () => {
@@ -148,7 +152,31 @@ describe("packBatches", () => {
     ]);
   });
 
-  it("never splits a chapter's items across batches", () => {
+  // Was "never splits a chapter's items across batches". Relaxed deliberately
+  // in the source-layer work (issue #133): the Introduction is ONE chapter of
+  // 105,000 characters, and an unsplittable chapter made the budget
+  // meaningless there. The original justification — two half-files racing to
+  // write one path — does not hold, because `translate-apply.ts` starts from
+  // whatever is already on disk (`existing.items`) and refuses to overwrite an
+  // item already present, so the pieces merge whatever order they arrive in.
+  //
+  // What must NOT happen is a chapter being split when it fits, which would
+  // scatter one file's items across manifests for no reason.
+  it("keeps a chapter whole whenever it fits in the budget", () => {
+    const chapters = [
+      chapter("p/c1", [
+        item("op-1", 1, prose(400)),
+        item("op-2", 2, prose(400)),
+      ]),
+    ];
+
+    const batches = packBatches(chapters, 1000, "en");
+
+    expect(batches).toHaveLength(1);
+    expect(batches[0]?.items).toBe(2);
+  });
+
+  it("splits a chapter only once it exceeds the budget on its own", () => {
     const chapters = [
       chapter("p/c1", [
         item("op-1", 1, prose(800)),
@@ -158,8 +186,8 @@ describe("packBatches", () => {
 
     const batches = packBatches(chapters, 1000, "en");
 
-    expect(batches).toHaveLength(1);
-    expect(batches[0]?.items).toBe(2);
+    expect(batches).toHaveLength(2);
+    expect(batches.every((b) => b.chars <= 1000)).toBe(true);
   });
 
   it("numbers batches in order with a stable, zero-padded id", () => {
@@ -190,5 +218,77 @@ describe("packBatches", () => {
 
   it("returns no batches for no chapters", () => {
     expect(packBatches([], 1000, "en")).toEqual([]);
+  });
+});
+
+// Issue #133. The source layer's units are seif segments keyed by `n`, not
+// commentary items keyed by `anchorId`, and one of its chapters is enormous:
+// the Introduction is 443 segments and 105,000 characters in a single chapter.
+describe("source-layer batching", () => {
+  const segment = (n: number, html: string) => ({
+    n,
+    html,
+    anchors: [],
+    sefariaRef: `Talmud Eser HaSefirot, Introduction ${n}`,
+  });
+
+  it("keys a source segment by its n, and a commentary item by its anchorId", () => {
+    expect(itemKey(segment(7, "x"))).toBe("seif-7");
+    expect(
+      itemKey({
+        anchorId: "op-7",
+        order: 7,
+        label: {},
+        section: "ohr-pnimi",
+        html: "x",
+      }),
+    ).toBe("op-7");
+  });
+
+  it("finds the untranslated segments of a partly translated chapter", () => {
+    // The Introduction ships 15 of its 443 paragraphs in English.
+    const source = [segment(1, "a"), segment(2, "b"), segment(3, "c")];
+    const target = [segment(2, "translated")];
+
+    expect(untranslatedItems(source, target).map(itemKey)).toEqual([
+      "seif-1",
+      "seif-3",
+    ]);
+  });
+
+  it("orders source segments by n", () => {
+    expect(
+      untranslatedItems([segment(9, "a"), segment(2, "b")], []).map(itemKey),
+    ).toEqual(["seif-2", "seif-9"]);
+  });
+
+  it("splits an oversize chapter across batches rather than emitting one huge one", () => {
+    // Left unsplit, the Introduction produced a single 519KB manifest at five
+    // times the budget — a batch no model would take, and a budget that meant
+    // nothing. Safe to split because `translate-apply` merges into what is
+    // already on disk and refuses to overwrite an item that is present.
+    const chapter = {
+      chapterId: "part-01/introduction-01",
+      items: Array.from({ length: 10 }, (_, i) =>
+        segment(i + 1, "x".repeat(30)),
+      ),
+      sourceSegments: [],
+      targetSegments: null,
+    };
+
+    const batches = packBatches([chapter], 100, "en");
+
+    expect(batches.length).toBeGreaterThan(1);
+    expect(batches.every((b) => b.chars <= 100)).toBe(true);
+    // Nothing lost, nothing duplicated, order preserved.
+    expect(
+      batches.flatMap((b) => b.chapters.flatMap((c) => c.items)).map(itemKey),
+    ).toEqual(chapter.items.map(itemKey));
+    // Every slice keeps the chapter's identity, so apply merges them into one file.
+    expect(
+      batches.every((b) =>
+        b.chapters.every((c) => c.chapterId === "part-01/introduction-01"),
+      ),
+    ).toBe(true);
   });
 });


### PR DESCRIPTION
Refs #133. The pipeline change only — the Introduction still needs translating, but now it *can* be.

## The gap was invisible to the tooling

`translate:export` walked `commentary.*` files and nothing else. So the source-layer gap did not merely go untranslated — it did not appear in any count. A re-export after #132 landed still reported 778 chapters and 1,223 items, none of them the Introduction's 428 paragraphs.

`--layer source` on both commands. A source segment is identified by its `n` where a commentary item uses `anchorId`; `itemKey` is the single place that difference lives. Everything else is shared — the batching, the binding glossary, and crucially the apply-side rule that every structural field (`n`, `sefariaRef`, `anchors`, `heading`) is copied byte-for-byte from the Hebrew. The model still decides only `html`.

## Two things the source layer forced

### Oversize chapters are now split across batches

`packBatches` refused to split a chapter, on the reasoning that one chapter is one output file and two batches writing it would race.

**That reasoning does not hold.** `translate-apply` starts from whatever is already on disk:

```ts
const items = existing?.layer === layer ? [...existing.items] : [];
const alreadyPresent = new Set(items.map(itemKey));
…
if (alreadyPresent.has(key)) errors.push(`… already translated — refusing to overwrite`);
```

It merges and refuses to overwrite, so the pieces of one chapter apply in any order.

It mattered because commentary items are small and source chapters are not. The Introduction is **one chapter of 443 segments and 105,000 characters**, and unsplit it produced a single **519KB manifest at five times the budget** — a batch no model would take, and a budget that silently meant nothing.

| | before | after |
| --- | --- | --- |
| batches | 1 | **6** |
| chars per batch | 104,924 | 19,673 / 19,942 / 19,869 / 19,926 / 19,949 / 5,565 |
| items | 428 | 428, none lost or duplicated |

### The redundant context is dropped

A manifest carries the chapter's source text so a translator can match the terminology of the pane beside the notes. On the source layer **the items ARE that text** — it was sending the same 105,000 characters twice.

## The superseded test

`"never splits a chapter's items across batches"` pinned the rule this changes. I rewrote it rather than deleted it, carrying why the original justification does not hold, and added a companion test that a chapter which **fits** is still never split — the failure mode the old rule was really guarding.

My first rewrite was wrong, incidentally: I kept its fixture of two 800-character items against a 1,000 budget and renamed it "keeps a chapter whole whenever it fits". That chapter does not fit. Fixed to 2×400.

## Verification

```
pnpm translate:export --lang en --layer source --part part-01
  chapters 1 · items 428 · 104,924 chars · 6 batches
task check   # green — 971 tests / 78 files, generate, verify:fonts, 10 e2e
```

## What a reviewer should double-check

- **No content changed.** This is the pipeline only; `content/` is untouched. Translating the Introduction is the next step and a separate PR.
- **The `layer as "commentary"` cast in `translate-apply`.** The two layers' item shapes are a disjoint union to the schema and `items` is homogeneous by construction — every entry comes from the same parsed source file. The Zod schema still validates on read, and `validate:content` runs over the whole tree afterwards, but it is a cast and worth a look.
- **Splitting changes batch ids for the commentary layer too**, if a commentary chapter ever exceeds the budget. None currently does — the largest single item is 37,057 characters, which already got its own batch under the old rule and still does.
- **The 4 `answers-topics` chapters** short of English (parts 1, 2, 5 — 60 items between them) are now reachable by the same command, and worth doing in the same pass as the Introduction.