### PR TITLE
feat(content): translate Ohr Pnimi batch 9 — part 5 closes, part 6 opens on the Partzuf SAG

### DIFF
--- a/content/parts/part-05/chapters/chapter-62/commentary.en-ai.json
+++ b/content/parts/part-05/chapters/chapter-62/commentary.en-ai.json
@@ -1,0 +1,52 @@
+{
+  "chapterId": "part-05/chapter-62",
+  "layer": "commentary",
+  "versionId": "en-ai",
+  "sefariaRef": "Ohr Penimi on Talmud Eser HaSefirot 5:62",
+  "items": [
+    {
+      "anchorId": "op-1",
+      "order": 1,
+      "label": {
+        "he": "1",
+        "en": "1"
+      },
+      "sefariaRef": "Ohr Penimi on Talmud Eser HaSefirot 5:62:1",
+      "section": "ohr-pnimi",
+      "html": "<b>That the male couples with the Nukva only in the secret of VAK, etc., it is the form of a Vav, etc., the Nukva is the form of a Dalet</b>: For the male is drawn from a male, who is the aspect of the light of Hochma, as above; but since he couples for the sake of these ZON only from the aspect of the VAK in him, the male therefore has only the VAK of Hochma, and he is therefore called by the name <b>Vav</b>. And the female is drawn from the Nukva of the vessel of Keter, who is the level of Bina, and she is called by the name <b>Dalet</b>; for although she has GAR, her VAK are nevertheless included in the GAR."
+    },
+    {
+      "anchorId": "op-2",
+      "order": 2,
+      "label": {
+        "he": "2",
+        "en": "2"
+      },
+      "sefariaRef": "Ohr Penimi on Talmud Eser HaSefirot 5:62:2",
+      "section": "ohr-pnimi",
+      "html": "<br><b>Thus the filling of Yod, which is Vav-Dalet</b>. And by this the matter of the ascents of the lights of the Partzuf of Bina has been explained: that he says that if five lights rise, they all rise to the male. And the reason was explained — that it is because the ZON in this Partzuf have only one vessel, which is the vessel of the male, called <b>Yod</b>. It was also explained that all these five lights that rose to the vessel of Keter are included in the upper lights, which are the ZON of Hochma, called <b>Vav</b> and <b>Dalet</b>. It was also explained that this is the secret of the Vav-Dalet of the filling of Yod: for when they rise to the vessel of the male, which is called <b>Yod</b>, and the lights that rise are called Vav-Dalet, then the coupling returns to the Partzuf, as above. And this is the conclusion he wished to convey to us in this discourse. And further on he brings likewise the ascents of the Partzuf of Hochma to the vessel of the Nukva of Keter."
+    },
+    {
+      "anchorId": "op-3",
+      "order": 3,
+      "label": {
+        "he": "3",
+        "en": "3"
+      },
+      "sefariaRef": "Ohr Penimi on Talmud Eser HaSefirot 5:62:3",
+      "section": "ohr-pnimi",
+      "html": "<br><b>When the four lower lights rise into this letter Hey, then she is filled with the letter Yod and becomes Hey-Yod</b>. This is the conclusion of the second division, when four lights rise, that is, in the Partzuf of Hochma; then they rise to the Nukva of the vessel of Keter. And it was explained that the vessel of the Nukva of Keter is called Hey, and that the lights that rise to her are the secret of her filling, since they restore the upper coupling to her. And it was explained why these four illuminations are called by the name <b>Yod</b> — namely after the highest Sefira among these lights, which is the aspect of the male of the vessel of Hochma (which is phase three, and the light of Hochma that is drawn by way of an illumination from the ZON of Keter to the ZON of Hochma, as above), which is called <b>Yod</b>, and all the lights that rise are included in it. And therefore this <b>Hey</b> is filled with the letter <b>Yod</b> and becomes <b>Hey-Yod</b>, as explained.<br>And the ARI states above (page 352, item 55) three divisions in the matter of the ascent of the lights upward and their inclusion in the ZON of Keter. The first, that they rise and are included in the Nukva of Keter. The second, that they are included in the male of Keter. The third, that some of them are included in the Nukva and some in the male. And only the first two divisions are what have been explained here, while the third division he did not explain to us at all.<br>However, this third division he has already explained to us above, page 296, item 7, for there he began to speak of these three kinds of inclusion. For he states there three kinds of inclusion: the first is that the ZON are included one in the other in a single vessel; the second is that their illuminations are included one in the other while they are in two vessels; the third is that they are included one in the other when they are two lights without vessels, study it there. And the explanation of these words is as above. For the first inclusion, that the ZON are included in a single vessel, is in the Partzuf of Bina of AK, where there is no striking of the record and the light of Bina one against the other, and therefore no vessel emerged for the female of Keter, and the female therefore clothes in the vessel of the male, as above. And the second inclusion, that the ZON have two vessels, is in the Partzuf of Hochma of AK, where there is a striking of the record and the light of Hochma one against the other, and two vessels emerged, one for the male and one for the female, as above. And the third inclusion is at the time of Lo Mati in Keter, when the ZON themselves rise to the Malchut of the Rosh; for then they are found expanding and emerging from their vessels of the Guf, and they are two lights without vessels.<br>And the first two inclusions the ARI did not explain there at all, and this is because he relied upon what is explained here at length, as above; for these two inclusions are the first two divisions here, which have been well explained before us. And as for the third division, which he did not explain here, it is the third inclusion there, which the ARI explained there at length. And he explains there that the ZON that rose to the Rosh have two couplings: the first coupling, in which the female is included in the male, and the coupling emerges on the coarseness of phase four, according to the measure of the male, when they draw the light at the level of the upper Keter; and the second coupling, in which the male is included in the female, and the coupling emerges on the measure of the coarseness of the female, that is, on phase three, when they draw the light only at the level of Hochma — study it there, and in the Inner Light there, page 297, the passage beginning “that refines.”<br>And it was explained there, in the Inner Light, page 294, the passage beginning “Lo Mati,” that in this ascent of the ZON to the Rosh all the Sefirot below Keter are included as well, except that all of them are nullified in the ZON of Keter and are therefore not counted, study it there. And here all five lights that are in the Partzuf rose, and the light of Hesed, which includes the seven lower ones, is likewise included in these ZON, study it there. And then the five lights are found, some of them included in the vessel of the female and some included in the vessel of the male: that is, at the time when the female was included in the male and the coupling was made in the aspect of the male, then the five lights were included in the male; and in the second coupling, when the male was included in the female and the coupling was made in the aspect of the female, the five lights were included in the female as well — so that the five lights were included, some of them in the male through the first coupling and some in the female through the second coupling, as explained."
+    },
+    {
+      "anchorId": "op-4",
+      "order": 4,
+      "label": {
+        "he": "4",
+        "en": "4"
+      },
+      "sefariaRef": "Ohr Penimi on Talmud Eser HaSefirot 5:62:4",
+      "section": "ohr-pnimi",
+      "html": "<br><b>The form of this Hey is like this, Vav-Dalet, and therefore it is ten</b>: For there is a Hey whose form is Vav-Dalet, and there is a Hey whose form is Yod-Dalet. And he says that this Hey, which alludes to the Nukva of Keter, has the form Vav-Dalet, which is ten in gematria, alluding to the fact that this Hey has ten vessels — that is, that all the ten Sefirot of the level are included in the Hey, as written above, that the whole new level that emerged in the second expansion, which is the level of Hochma, is the aspect of the light of the Nukva of Keter."
+    }
+  ]
+}

--- a/content/parts/part-06/chapters/chapter-01/commentary.en-ai.json
+++ b/content/parts/part-06/chapters/chapter-01/commentary.en-ai.json
@@ -1,0 +1,85 @@
+{
+  "chapterId": "part-06/chapter-01",
+  "layer": "commentary",
+  "versionId": "en-ai",
+  "sefariaRef": "Ohr Penimi on Talmud Eser HaSefirot 6:1",
+  "items": [
+    {
+      "anchorId": "op-1",
+      "order": 1,
+      "label": {
+        "he": "1",
+        "en": "1"
+      },
+      "sefariaRef": "Ohr Penimi on Talmud Eser HaSefirot 6:1:1",
+      "section": "ohr-pnimi",
+      "html": "<b>AK includes</b>: This discourse, with which I have begun — although it is the deepest of all the discourses of the ARI in the world of Nekudim, and it would have been fitting to place it at the end of the part — is nevertheless the discourse in which the ARI gave us the key upon which he goes on to explain all the matters that come before us in the ten Sefirot of Nekudim. And therefore the student must know it and remember it well before he begins to study the discourses themselves.<br>And first one must know which of the Partzufim of AK the ARI is speaking of here, for there are five Partzufim in AK, as is known. However, the ARI has already informed us that in the first two Partzufim of AK — which are the Partzuf of Keter of AK and the Partzuf AB of AK — we have no permission to speak, as is brought in Etz Chaim, Gate 5, Chapter 1. And the study begins only with the Partzuf SAG, which is from the aspect of the Ozen [ear] downward, that is, that his level is up to Bina, for the Bina of the Rosh is called Ozen, as is known. And by this we shall know that the ARI is speaking here of the Partzuf SAG of AK, and that all the matters and details that are explained before us turn only upon this Partzuf.<br>And this is what he says, that he includes AB, SAG, MA and BON in his self — which are the four levels that emerge on the four known phases: phase three, which draws the level of Hochma, called HaVaYaH of AB; and phase two, which draws the level of Bina, called HaVaYaH of SAG; and phase one, which draws the level of ZA, called HaVaYaH of MA; and the level of Malchut, which is called BON. And each of them is comprised of all four, as he goes on to explain."
+    },
+    {
+      "anchorId": "op-2",
+      "order": 2,
+      "label": {
+        "he": "2",
+        "en": "2"
+      },
+      "sefariaRef": "Ohr Penimi on Talmud Eser HaSefirot 6:1:2",
+      "section": "ohr-pnimi",
+      "html": "<br><b>And lights also come out of him outward, which are his branches</b>. Which are called the hairs of the Reisha [head] and the hairs of the Dikna [beard], emanated from the Rosh of this SAG of AK, as is written before us. But know that all that is spoken of here is only from the aspect of the roots of these details, which apply in the world of Atzilut; and although they are not here in actuality, they were nevertheless rooted here."
+    },
+    {
+      "anchorId": "op-3",
+      "order": 3,
+      "label": {
+        "he": "3",
+        "en": "3"
+      },
+      "sefariaRef": "Ohr Penimi on Talmud Eser HaSefirot 6:1:3",
+      "section": "ohr-pnimi",
+      "html": "<br><b>And the AB is in his Mochin</b>. And one must remember here all that was explained concerning the emanation of the first three Partzufim of AK, brought in the words of the ARI in extreme brevity in Part 5: that the first Partzuf of AK he calls there the first expansion, and the Partzuf AB of AK he calls the second expansion, and the Partzuf SAG of AK he calls there the second aspect of the second expansion — study it there, page 307, item 21, and page 311, item 27. And in general one must remember all the matters brought there in the words of the ARI, and all that is explained in the Inner Light there, for I shall not repeat anything here but shall bring only the names.<br>And you already know that every lower one clothes its upper one only from the Peh downward, that is, from the place where it was rooted and from which it emerged, which is the Malchut of the Rosh of its upper one, from which the lower one emerges and is emanated. And therefore the Keter of the Rosh of SAG, which is called Ozen — since the light of Bina, which is called Ozen, clothes in the vessel of Keter, as is known — clothes the Partzuf above it, which is called AB, from the Peh downward. And know that this Guf of AB that is clothed in the Rosh of SAG becomes a Neshama and Mochin for the Rosh of SAG. And this is what he says, “and the AB is in his Mochin, corresponding to AA and Aba of Atzilut,” for the Guf of AB that is clothed in the Rosh of SAG is the aspect of Mochin for the Rosh of SAG."
+    },
+    {
+      "anchorId": "op-4",
+      "order": 4,
+      "label": {
+        "he": "4",
+        "en": "4"
+      },
+      "sefariaRef": "Ohr Penimi on Talmud Eser HaSefirot 6:1:4",
+      "section": "ohr-pnimi",
+      "html": "<br><b>Corresponding to AA and Aba of Atzilut</b>. For AA is the AB of MA that is in Atzilut, and Aba is the AB of BON that is in Atzilut, since the five Partzufim of MA and the five Partzufim of BON join together there, as is written in its place. And this is what he says, that the aspect of the Guf of AB that is clothed in the Rosh of SAG is discerned as corresponding to AA and Aba of Atzilut.<br>And know that this discourse is meant to explain the correspondence of the five Partzufim of SAG of AK to the five Partzufim that are in Atzilut, in order to know how to learn the one from the other: how the branches are connected to and cascade from their roots, and also how to learn the upper one from the lower one. And the benefit of this is immeasurably great."
+    },
+    {
+      "anchorId": "op-5",
+      "order": 5,
+      "label": {
+        "he": "5",
+        "en": "5"
+      },
+      "sefariaRef": "Ohr Penimi on Talmud Eser HaSefirot 6:1:5",
+      "section": "ohr-pnimi",
+      "html": "<br><b>A likeness of the discernment of Atik of Atzilut</b>. The Partzuf of Keter of Atzilut is called by the name Atik. And he says that above the Partzuf AB of AK there is a further, first Partzuf, that is, the Partzuf of Keter of AK, which corresponds to the Partzuf Atik that is in Atzilut."
+    },
+    {
+      "anchorId": "op-6",
+      "order": 6,
+      "label": {
+        "he": "6",
+        "en": "6"
+      },
+      "sefariaRef": "Ohr Penimi on Talmud Eser HaSefirot 6:1:6",
+      "section": "ohr-pnimi",
+      "html": "<br><b>And his SAG is from the Ozen downward to his Tabur</b>. That is, that the Partzuf SAG of AK, whose level is up to Bina, which is called Ozen, as above, and of which all that is spoken of here treats, is completed and ends at the Tabur. And one must understand very well the essence of this Tabur at which the Partzuf SAG ends, for this Tabur is the whole axis upon which all the details of the world of Nekudim turn.<br>And know that in truth <b>(2)</b> SAG still extends down to the end of the feet of the inner AK, which is called the Partzuf of Keter; only that afterwards, in the restriction of NHY that will be explained further on, it rose and ended at the Tabur. It is only the feet of the Partzuf AB that were cut off there. And this is because from there downward is the place of the Malchut of the inner AK, who is phase four; and since the Malchut of the Partzuf AB had only the coarseness of phase three, it could not therefore illuminate to phase four of the Malchut of the inner AK, whose place is called by the name Tabur, as is known; and therefore the feet of the Partzuf AB ended above the Tabur.<br>But the Partzuf SAG, whose whole level is up to Bina — and it is known that the restriction was only upon the light of Hochma alone and not upon the light of Bina — the Partzuf SAG can therefore expand and illuminate also below the Tabur <b>(3)</b>, even though it has no screen of phase four. And you already know that the Partzuf AB is the second expansion of the inner AK, which expands and fills the vessels that were emptied in the first departure, in the secret of the second expansion, as written in the preceding parts. And therefore the aspects of the ZON of the inner AK that are found from the Tabur downward remained without light, for the second expansion, which is AB, cannot illuminate to them, since it has no aspect of the screen required for the vessels of phase four, as above. And therefore the lights of the Partzuf SAG came and filled the lack of AB, for they expanded to those same vessels of ZON below the Tabur, which could not be filled from AB. And so the lights of the vessels of the Partzuf of Keter of AK, which is called the inner AK, having departed, could not be filled again except through two Partzufim, AB and SAG: AB filled it down to the Tabur, and SAG filled it from the Tabur downward, to the end of his feet.<br>And SAG itself is divided into Taamim and Nekudot, which are the Keter of the Guf and the nine lower Sefirot of the Guf, from Hochma downward, as above in the words of the ARI, page 309, item 24, and in the Inner Light there, the passage beginning “the expansion of the light,” study it there well. For only the first expansion of the Partzuf, before it begins to diminish, is the direct light of that Partzuf, which is called the light of mercy; but from that moment when the screen begins to refine and its level to diminish — although the upper light does not cease coupling with it in the four phases of its refinement, and brings out along its way the four levels of Hochma, Bina, ZA and Malchut — these are nevertheless no longer aspects of the light of mercy, and they are therefore called Nekudot.<br>And since the lights clothed in the Sefirot of the first three Partzufim of the ten Sefirot of AK only by way of Mati and Lo Mati — that is, that at first the light expanded only to the vessel of Keter, and afterwards, at Lo Mati in Keter, which means that the measure of the coarseness of its screen refined, then the light is Mati in Hochma — it turns out that only in the vessel of Keter did the light expand in the aspect of mercy, which is called Taamim; but to the vessel of Hochma the light came only after the refinement of the screen and the diminution of the level, and likewise in the remaining Sefirot. Therefore all the Sefirot below Keter are called by the name Nekudot, being already of the aspects of reflected light and judgment, as is written at length in the words of the ARI above, Part 4, Chapter 3, study the whole of that passage there.<br>And it was explained above in the Inner Light, Part 5, page 340, the passage beginning “and we shall explain,” that two lights descended and clothed in the vessel of Keter, which are called ZON: the male has phase three of clothing and his level is up to Hochma, and the female has the coarseness of phase two and her level is up to Bina, study it there well.<br>And therefore the vessel of Keter, too, had to end at the Tabur, level with the feet of AB; and this is for the same reason as was said concerning AB, for since the male has there in the vessel of Keter the level of Hochma, the restriction applies to it as it does to the Partzuf AB, and it must end above the Tabur, since it cannot illuminate to the vessels of ZON of phase four.<br>And you find that what the ARI writes further on, that the Partzuf SAG expands down to the feet of AK, is said only of the aspects of the Nekudot of SAG, which are the nine lower Sefirot from Hochma downward; but the Taamim of SAG, which are the Keter of the Guf of SAG, were cut off at the Tabur, for it cannot illuminate from the Tabur downward because of the light of Hochma that is in it, as above. Only after the ZON of Keter refined from phase three and phase two in them to phase two and phase one — which was given to the vessel of Hochma of SAG, in which lights there is already nothing at all of the level of Hochma — then those lights of SAG expanded to the vessels of ZON that are in the inner AK from below the Tabur; and likewise the lights that are in the remaining levels, Bina and ZA and Malchut.<br>And it is explained further on in the words of the ARI that these four levels — HB, ZA and Malchut of SAG — which expanded below the Tabur, returned and rose to the place of the Taamim of SAG that is above the Tabur, and did not expand any further from the Tabur downward. And this is what he says here, that SAG ends at the Tabur — his intention being after the ascent of the lights above the Tabur, as above. And these ascents of the lights are what are called further on by the name of the restriction of NHY. And understand all the above well, and go over the matter until it is as though kept in a box; for you will need all of the above in every single word of the explanation of the Nekudim and of the breaking of the vessels, and it is impossible to go back over such length every time."
+    },
+    {
+      "anchorId": "op-7",
+      "order": 7,
+      "label": {
+        "he": "7",
+        "en": "7"
+      },
+      "sefariaRef": "Ohr Penimi on Talmud Eser HaSefirot 6:1:7",
+      "section": "ohr-pnimi",
+      "html": "<br><b>And his MA and BON are from the Tabur downward, corresponding to ZON of Atzilut</b>. Namely the ten Sefirot of Nekudim, which are discerned as the aspect of MA and BON of this SAG, as written in its place. And they correspond to the ZON of Atzilut, which clothe the Partzuf AA likewise from his Tabur downward. And the reason for all these matters will be explained further on."
+    }
+  ]
+}

--- a/content/parts/part-06/chapters/chapter-02/commentary.en-ai.json
+++ b/content/parts/part-06/chapters/chapter-02/commentary.en-ai.json
@@ -1,0 +1,41 @@
+{
+  "chapterId": "part-06/chapter-02",
+  "layer": "commentary",
+  "versionId": "en-ai",
+  "sefariaRef": "Ohr Penimi on Talmud Eser HaSefirot 6:2",
+  "items": [
+    {
+      "anchorId": "op-1",
+      "order": 1,
+      "label": {
+        "he": "1",
+        "en": "1"
+      },
+      "sefariaRef": "Ohr Penimi on Talmud Eser HaSefirot 6:2:1",
+      "section": "ohr-pnimi",
+      "html": "<b>The hairs of his head correspond to the branches of AB, and the hairs of the Dikna are from AHP, corresponding to the branches of SAG</b>: The matter of these hairs of the head and of the Dikna did not emerge immediately with the emanation of the Partzuf, but after the restriction of NHY and the ascent of the lower Hey to the Eynaim, which will be explained further on. For the lower Hey, which is the screen that is joint of phase two and phase four together, rose to the Hochma of the Rosh of SAG, which is called Eynaim, and coupled there with the upper light and raised reflected light from Hochma to Keter, that is, from the Eynaim to the Galgalta, which draws only the level of ZA. And then the ten Sefirot of the Rosh of SAG were divided into Galgalta and Eynaim, and into Ozen, Hotem and Peh. For since <b>(4)</b> the place of the coupling was made in the Eynaim, and the Eynaim served in the place of the Peh of the Rosh, the three Sefirot AHP became an aspect of Guf, and they receive from this Malchut that stands in the Eynaim, who bestows to them from above downward; and there remained there in the aspect of a Rosh, that is, of the aspect of from below upward, only the two Sefirot, Galgalta and Eynaim, alone. Thus the ten Sefirot of the Rosh were divided into two aspects, Rosh and Guf: for only the Keter and Hochma among them remained in the aspect of a Rosh, whereas the Bina, ZA and Malchut among them emerged from the aspect of the Rosh and became the aspect of Sefirot of the Guf.<br>And although this coupling, which divided the ten Sefirot of the Rosh into the two aspects of Rosh and Guf, was made in the Hochma of the Rosh of SAG itself, no change whatever was made in it itself, for there is no absence in spirituality, as is known. Rather only an addition was made here; for the ten Sefirot of branches that are upon the Rosh of SAG, which are called the ten Sefirot of hairs, are discerned, and it is they that were divided into the two above aspects of Rosh and Guf — where the Keter and Hochma among them, which remained in the aspect of a Rosh, are discerned as the branches of AB in the aspect of the hairs of the head, and the three Sefirot among them, which are AHP and which became an aspect of Guf, are discerned as the aspects of the hairs of the Dikna, and as the branches of SAG.<br>And this is what he says <b>(5)</b>: and the hairs of his head correspond to the branches of AB, and the hairs of the Dikna are from AHP, corresponding to the branches of SAG. Namely that same division of the ten Sefirot of the Rosh into two aspects, GE and AHP, that came about in the Rosh of SAG, as above; and this renewal is called by the name of hairs, where the aspects of Galgalta and Eynaim that remained in the aspect of a Rosh are reckoned as the branches of AB, and the aspect of Ozen, Hotem and Peh among them, which emerged outside the Rosh, are reckoned as the branches of SAG. And the reason for the matter will be explained before us."
+    },
+    {
+      "anchorId": "op-2",
+      "order": 2,
+      "label": {
+        "he": "2",
+        "en": "2"
+      },
+      "sefariaRef": "Ohr Penimi on Talmud Eser HaSefirot 6:2:2",
+      "section": "ohr-pnimi",
+      "html": "<br><b>In which AVI are included; for between the two of them they took, etc., and they are included in the Mazal of the Dikna of AA</b>. He informs us here that, just as AVI of Atzilut were included in and emerged from the ten Sefirot of the Dikna of AA, so the ten Sefirot of Nekudim emerged from the secret of the hairs of the Dikna of the Rosh of SAG. And know that there are three aspects of AVI: the inner AVI, and the upper AVI, and YESHSUT. And all these three are included in the hairs of the Dikna. For there are thirteen corrections of the Dikna, which are three HaVaYaHs — that is, three aspects of ten Sefirot: the first ten Sefirot are in the aspect of the first four corrections, which end at the Shibolet HaZakan [the strand of the beard], and from this Shibolet HaZakan the inner AVI emerged, who are the GAR of Nekudim. And from the second ten Sefirot, which are the four middle corrections, which end at the upper Mazal, called Notzer Hesed, the upper AVI emerged. And from the last ten Sefirot, <b>(6)</b> which are the five lower corrections, which end at the lower Mazal, called VeNakeh, Israel Saba and Tevuna of Atzilut emerged.<br>And this is what he says, “and they are included in the Mazal of the Dikna of AA.” For the above AVI are together called Aba, and the above YESHSUT are together called Ima; and Aba is included in the upper Mazal, as above, and Ima is included in the lower Mazal, as above, and so both of them are found included in the Mazal. But as for the four upper corrections, which end at the Shibolet HaZakan, they belong to the inner AVI, as above, and from them emerged only the GAR of Nekudim, who are the aspect of the inner AVI. And remember these words, for you will need them in every single word that comes further on."
+    },
+    {
+      "anchorId": "op-3",
+      "order": 3,
+      "label": {
+        "he": "3",
+        "en": "3"
+      },
+      "sefariaRef": "Ohr Penimi on Talmud Eser HaSefirot 6:2:3",
+      "section": "ohr-pnimi",
+      "html": "<br><b>(7)</b> And at that time SAG still expanded down to the feet of AK: This was already explained above, page 390, the passage beginning “and his SAG,” study it there well."
+    }
+  ]
+}

--- a/content/parts/part-06/chapters/chapter-03/commentary.en-ai.json
+++ b/content/parts/part-06/chapters/chapter-03/commentary.en-ai.json
@@ -1,0 +1,52 @@
+{
+  "chapterId": "part-06/chapter-03",
+  "layer": "commentary",
+  "versionId": "en-ai",
+  "sefariaRef": "Ohr Penimi on Talmud Eser HaSefirot 6:3",
+  "items": [
+    {
+      "anchorId": "op-1",
+      "order": 1,
+      "label": {
+        "he": "1",
+        "en": "1"
+      },
+      "sefariaRef": "Ohr Penimi on Talmud Eser HaSefirot 6:3:1",
+      "section": "ohr-pnimi",
+      "html": "<b>At first it was so in AK: the first three in him, which are AB — Keter</b>: The words here are the same matter that was brought above, only with a change of wording; and I have copied them only because there are in them some small novelties. And here too it turns upon the Partzuf SAG of AK, and it connects with it also the Partzuf AB of AK that is clothed in it. And you already know that the Partzuf SAG clothes from the Peh downward of the Rosh of AB, that is, the aspect of the three Sefirot HGT of the Guf of AB. And this is what he says, the first three in him, which are AB, Keter. For it is the HGT of AB that become the GAR of the Partzuf SAG, which the Rosh of SAG clothes from outside; and the Peh, which is the Malchut of the Rosh of AB, is the aspect of the Keter of the Rosh of SAG that is above it, and the HGT of AB are the inner Mochin in it, as above."
+    },
+    {
+      "anchorId": "op-2",
+      "order": 2,
+      "label": {
+        "he": "2",
+        "en": "2"
+      },
+      "sefariaRef": "Ohr Penimi on Talmud Eser HaSefirot 6:3:2",
+      "section": "ohr-pnimi",
+      "html": "<br><b>And SAG — Hochma and Bina</b>. That is, that in the Partzuf SAG itself there are Hochma and Bina. And although the whole level of SAG is only the level of Bina alone, there is nevertheless in it an aspect of male and female — that is, that the screen which rose to the Malchut of the Rosh of AB for the need of the coupling for the Partzuf SAG is composed of two upper records, which are: a record of phase three of clothing alone, lacking drawing; and a complete record of phase two. And therefore two couplings were made upon them: the first at the level of Hochma, and the second at the level of Bina. And they are called ZON: the record of phase three of clothing, on which the level of Hochma emerged, is called male; and the record of phase two, which is complete also in the aspect of drawing, is called female, on which the chief light of the Partzuf SAG emerged, which is the level of Bina. And these ZON clothed only in the vessel of Keter of the Guf of SAG, and nothing reaches from them to the remaining nine lower Sefirot of SAG for as long as the ZON of the vessel of Keter have not refined to phase two and to phase one, as is all written at length above, page 340, the passage beginning “and we shall explain,” study it there well.<br>And this is what he says, “SAG — Hochma and Bina,” for a Partzuf is always named after the highest Sefirot in it, as is known; and since the above Sefirot ZON have in them the level of Hochma and Bina, SAG is therefore called by the name of Hochma and Bina.<br>And he informs us of this so that we may understand what is written further on, that this SAG afterwards became an aspect of AB. And it is known that the level of AB is up to Hochma; so how is it possible that AB should be made from SAG? And therefore he mentions here that in this SAG there are Hochma and Bina, for the male is phase three of clothing, which is the aspect of AB, and it therefore became afterwards an aspect of AB. And remember this."
+    },
+    {
+      "anchorId": "op-3",
+      "order": 3,
+      "label": {
+        "he": "3",
+        "en": "3"
+      },
+      "sefariaRef": "Ohr Penimi on Talmud Eser HaSefirot 6:3:3",
+      "section": "ohr-pnimi",
+      "html": "<br><b>From its half downward, which are the Nekudot in it, was clothed from the Tabur of AK downward, inside MA and BON of AK</b>. And you must remember the explanation of Taamim and Nekudot brought above in the words of the ARI (Part 4, Chapter 3, item 11): that the first expansion into the Partzuf, before the screen begins to refine, is called by the name Taamim, and it is direct light and mercy; but at the time when the screen begins to refine, when the upper light is drawn from the Emanator and couples with the screen in the degrees of its refinement, the four levels that emerge at that time — which are Hochma, Bina, ZA and Malchut — are called Nekudot, since they are the aspect of reflected light and judgment; study it there and in the Inner Light there, and see in the Inner Light, page 309, the passage beginning “the expansion.”<br>And with this you will understand that only the lights that are in the vessel of Keter of the Guf of SAG are called by the name Taamim, whereas all the nine lower Sefirot that are below the Keter of the Guf of SAG are called Nekudot. You also know that the vessel of Keter of the Guf of SAG expands down to the Tabur, that is, down to the end of the feet of the Guf of AB, which place of ending is called Tabur. And this is what he says, “from its half downward, which are the Nekudot in it, was clothed from the Tabur of AK downward” — that is, its nine lower Sefirot, for all the nine lower Sefirot are called here by the name Nekudot, and all of them descended below the Tabur and clothed in the inner MA and BON of AK, as is well written above, page 390, in the passage beginning “but the Partzuf,” study it there well."
+    },
+    {
+      "anchorId": "op-4",
+      "order": 4,
+      "label": {
+        "he": "4",
+        "en": "4"
+      },
+      "sefariaRef": "Ohr Penimi on Talmud Eser HaSefirot 6:3:4",
+      "section": "ohr-pnimi",
+      "html": "<br><b>And all this is the internality of AK</b>. That is, that all this is the aspect of the Partzuf SAG in its own structure, and does not include the branches that emerge outward from it, which he explains afterwards."
+    }
+  ]
+}

--- a/content/parts/part-06/chapters/chapter-04/commentary.en-ai.json
+++ b/content/parts/part-06/chapters/chapter-04/commentary.en-ai.json
@@ -1,0 +1,41 @@
+{
+  "chapterId": "part-06/chapter-04",
+  "layer": "commentary",
+  "versionId": "en-ai",
+  "sefariaRef": "Ohr Penimi on Talmud Eser HaSefirot 6:4",
+  "items": [
+    {
+      "anchorId": "op-1",
+      "order": 1,
+      "label": {
+        "he": "1",
+        "en": "1"
+      },
+      "sefariaRef": "Ohr Penimi on Talmud Eser HaSefirot 6:4:1",
+      "section": "ohr-pnimi",
+      "html": "<b>The hairs of the Keter that surround his head from the outside, down to the forehead and to the ears</b>: It was already explained above, page 392, the passage beginning “and although,” that the hairs are divided into two aspects, Rosh and Guf: that down to the ears, which is Bina, is reckoned as the aspect of a Rosh, since the place of the coupling was in the openings of the Eynaim, which are the Hochma of the Rosh; and therefore the lights expanded from there downward to the Ozen, Hotem and Peh, in the aspect of clothing, which is called Guf. And you already know that the difference between a Rosh and a Guf is very great. And this is what he says, that the hairs extend down to the ears — for down to there it is reckoned as the aspect of a Rosh, but from the ears downward it is already reckoned as the aspect of a Guf, as he goes on to write."
+    },
+    {
+      "anchorId": "op-2",
+      "order": 2,
+      "label": {
+        "he": "2",
+        "en": "2"
+      },
+      "sefariaRef": "Ohr Penimi on Talmud Eser HaSefirot 6:4:2",
+      "section": "ohr-pnimi",
+      "html": "<br><b>The hairs of the beard, which are extended from the general SAG that is called Nekudim</b>. And you must know that these AHP, which emerged from the aspect of a Rosh into the aspect of a Guf, as above, are always called by the name of the general SAG. And the reason is as the ARI writes further on, that this whole SAG of AK with which we are occupied <b>(8)</b> is reckoned entirely as an aspect of AB, except for the Nekudot in it, which are its lower half, called further on by the name YESHSUT; it alone is reckoned as SAG, for it alone emerged by way of the openings of the Eynaim into the aspect of AHP of the Guf. And this YESHSUT is what is everywhere called the general SAG, and it is the Rosh of the ten Sefirot of Nekudim, as is written before us at length.<br>And it was explained above that the beginning of the coupling in the openings of the Eynaim, which brought out the AHP into the aspect of a Guf, was made in the Rosh of SAG itself, only in the secret of the hairs: that the hairs of the head down to the ears are discerned as the aspect of from below upward, which is a Rosh, <b>(9)</b> and it is therefore still discerned as an aspect of AB, since no change whatever is yet noticeable in it because of the ascent of the lower Hey to the openings of the Eynaim; but from the openings of the Eynaim downward, which are the hairs of the Dikna, they are already reckoned as the aspect of AHP that emerged from the Rosh and became an aspect of Guf. Therefore the AHP of the hairs, which are called by the name of the hairs of the Dikna, are alone reckoned as the general SAG, which is the aspect of the Nekudim. And all this will be explained further on at length, for that is its place.<br>And this is what he says, and afterwards he brought out the hairs of the beard, which are extended from the general SAG, called Nekudim. That is, that from the aspect of the ears downward the hairs of the beard were extended in the aspect of the general SAG, called Nekudim; but those hairs that emerge from the openings of the Eynaim — that is, from the Malchut that is in Hochma, from below upward — are still reckoned as AB and are not the branches of the general SAG, as above. So that the hairs of the head are branches extended from AB, and the hairs of the Dikna are branches extended from the general SAG. And remember this."
+    },
+    {
+      "anchorId": "op-3",
+      "order": 3,
+      "label": {
+        "he": "3",
+        "en": "3"
+      },
+      "sefariaRef": "Ohr Penimi on Talmud Eser HaSefirot 6:4:3",
+      "section": "ohr-pnimi",
+      "html": "<br><b>The generality of the three Mochin in it</b>. That is, the first three Sefirot, KHB, of Nekudim, which are made from these hairs of the beard — and not from them themselves, but only from the generality in them, which is gathered in the fourth correction of the hairs of the beard, called the Shibolet HaZakan, as is all written at length further on. And this is what he says, that from them the generality of the three Mochin in it was made."
+    }
+  ]
+}

--- a/content/parts/part-06/chapters/chapter-05/commentary.en-ai.json
+++ b/content/parts/part-06/chapters/chapter-05/commentary.en-ai.json
@@ -1,0 +1,30 @@
+{
+  "chapterId": "part-06/chapter-05",
+  "layer": "commentary",
+  "versionId": "en-ai",
+  "sefariaRef": "Ohr Penimi on Talmud Eser HaSefirot 6:5",
+  "items": [
+    {
+      "anchorId": "op-1",
+      "order": 1,
+      "label": {
+        "he": "1",
+        "en": "1"
+      },
+      "sefariaRef": "Ohr Penimi on Talmud Eser HaSefirot 6:5:1",
+      "section": "ohr-pnimi",
+      "html": "<b>And first there are extended the secret of the Taamim of SAG, which are AHP down to his Tabur</b>: That is, that first, before the branches of the general SAG had yet emerged outward — that is, the hairs of the head and of the Dikna — the Taamim of SAG emerged, which are the level of AHP down to his Tabur, and which are the aspect of direct light and mercy, as is written at length above, page 390, in the Inner Light, the passage beginning “and behold, SAG”; see there that there is there likewise an aspect of a male whose level is up to Hochma, and that nevertheless the Partzuf is called by the name AHP, since the chief light and level is discerned from the aspect of the female — for the whole expansion to the Guf is only from the aspect of the female, who has aspects of coarseness of drawing, and the female has only the level of AHP, which is the level of Bina. And as for its ending at the Tabur, this was already explained there at length, study it there."
+    },
+    {
+      "anchorId": "op-2",
+      "order": 2,
+      "label": {
+        "he": "2",
+        "en": "2"
+      },
+      "sefariaRef": "Ohr Penimi on Talmud Eser HaSefirot 6:5:2",
+      "section": "ohr-pnimi",
+      "html": "<br><b>Since they are clothed inside MA and BON</b>. And the matter of this clothing was already explained above, page 390, the passage beginning “and know.” For AB did not return and fill the vessels that were emptied from the Tabur downward in the inner AK, for the reason that AB has no screen of phase four and therefore cannot illuminate from the Tabur downward, where the place of phase four is. And therefore the vessels of ZON that are in the inner AK from the Tabur downward remained without light. Only afterwards, after the Partzuf SAG expanded, its nine lower Sefirot — which have in them only the level of the light of Bina, upon which light there was no restriction — are what descended below the Tabur of AK and filled the ZON that are there with light, study it there. And this is what he says, that he did not bring out the remaining discernments that are below the Taamim of SAG, which are the nine lower Sefirot of SAG, since they are clothed inside MA and BON — that is, as explained, that the nine lower Sefirot of SAG are clothed in the ZON below the Tabur of the inner AK, which are called MA and BON. And remember these words, for this matter of the clothing of the nine lower Sefirot of SAG in the inner MA and BON is a fundamental matter for all the events of the world of Nekudim."
+    }
+  ]
+}

--- a/content/toc.json
+++ b/content/toc.json
@@ -3285,6 +3285,7 @@
                   "he-jerusalem-1956"
                 ],
                 "commentary": [
+                  "en-ai",
                   "he-jerusalem-1956"
                 ]
               }
@@ -3402,6 +3403,7 @@
                   "he-jerusalem-1956"
                 ],
                 "commentary": [
+                  "en-ai",
                   "he-jerusalem-1956"
                 ]
               }
@@ -3428,6 +3430,7 @@
                   "he-jerusalem-1956"
                 ],
                 "commentary": [
+                  "en-ai",
                   "he-jerusalem-1956"
                 ]
               }
@@ -3454,6 +3457,7 @@
                   "he-jerusalem-1956"
                 ],
                 "commentary": [
+                  "en-ai",
                   "he-jerusalem-1956"
                 ]
               }
@@ -3480,6 +3484,7 @@
                   "he-jerusalem-1956"
                 ],
                 "commentary": [
+                  "en-ai",
                   "he-jerusalem-1956"
                 ]
               }
@@ -3506,6 +3511,7 @@
                   "he-jerusalem-1956"
                 ],
                 "commentary": [
+                  "en-ai",
                   "he-jerusalem-1956"
                 ]
               }

--- a/content/toc.parts/part-05.json
+++ b/content/toc.parts/part-05.json
@@ -1459,6 +1459,7 @@
           "he-jerusalem-1956"
         ],
         "commentary": [
+          "en-ai",
           "he-jerusalem-1956"
         ]
       }

--- a/content/toc.parts/part-06.json
+++ b/content/toc.parts/part-06.json
@@ -38,6 +38,7 @@
           "he-jerusalem-1956"
         ],
         "commentary": [
+          "en-ai",
           "he-jerusalem-1956"
         ]
       }
@@ -64,6 +65,7 @@
           "he-jerusalem-1956"
         ],
         "commentary": [
+          "en-ai",
           "he-jerusalem-1956"
         ]
       }
@@ -90,6 +92,7 @@
           "he-jerusalem-1956"
         ],
         "commentary": [
+          "en-ai",
           "he-jerusalem-1956"
         ]
       }
@@ -116,6 +119,7 @@
           "he-jerusalem-1956"
         ],
         "commentary": [
+          "en-ai",
           "he-jerusalem-1956"
         ]
       }
@@ -142,6 +146,7 @@
           "he-jerusalem-1956"
         ],
         "commentary": [
+          "en-ai",
           "he-jerusalem-1956"
         ]
       }


### PR DESCRIPTION
Ninth batch of the #87 Ohr Pnimi English translation run. **Part 5's Inner Light is now complete**, and part 6 begins.

**23 items, 19,045 source chars**, across six chapters:

| chapter | items | subject |
| --- | --- | --- |
| `part-05/chapter-62` | 4 | the last chapter of part 5 — the Vav-Dalet filling of Yod, and the third kind of inclusion the ARI never spelled out |
| `part-06/chapter-01` | 7 | the key discourse: AK includes AB/SAG/MA/BON, and why SAG ends at the Tabur |
| `part-06/chapter-02` | 3 | the hairs of the head and the Dikna, and the thirteen corrections |
| `part-06/chapter-03` | 4 | SAG as Hochma and Bina, Taamim vs Nekudot |
| `part-06/chapter-04` | 3 | the hairs of the beard as the general SAG |
| `part-06/chapter-05` | 2 | the nine lower Sefirot of SAG clothed in MA and BON |

**Part 6 has en-bb target text**, so this batch's terminology is anchored to the official Bnei Baruch English rather than inferred: AK, AB/SAG/MA/BON, Mochin, AA, Aba, Atzilut, Galgalta, Atik, `אזן` → Ozen [ear], Tabur, ZON, hairs, `דיקנא` → Dikna [beard], AHP, `או"א` → AVI, Mazal, Taamim [tastes], Nekudot, Nekudim, `טמיר` → concealed.

New calls beyond what the target text fixes:

- `גו"ע` → **GE**; `נקבי עינים` → **the openings of the Eynaim**; `ה' תתאה` → **the lower Hey**; `צמצום נה"י` → **the restriction of NHY**.
- `שבולת הזקן` → **Shibolet HaZakan [the strand of the beard]**; the two Mazalot keep their names, **Notzer Hesed** and **VeNakeh**.
- `או"א הפנימים` → **the inner AVI**, distinguished from the upper AVI and YESHSUT already in use.
- `שערות רישא` → **the hairs of the Reisha [head]** where the Aramaic is used; plain "hairs of the head" where the Hebrew is.
- `אור רחמים` → **the light of mercy**; `ה"פ` → **the five Partzufim**; `ע"ח` → **Etz Chaim**.
- `כמו מונחים בקופסא` → "until it is as though kept in a box."
- The inline editor footnote markers `(ב)`, `(ג)`, `(ד)` … render as **(2)**, **(3)**, **(4)** — matching how en-bb already renders `(א)` as `(1)` in `chapter-01`'s source text.

`task check` passes: lint, format, typecheck, validate:content, prerender, fonts, and the 10 e2e specs.