### PR TITLE
docs: make the translation run reproducible from the repo alone

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -97,6 +97,16 @@ typecheck` **and** `vue-tsc -p tsconfig.scripts.json` for
 A first `pnpm install` in a fresh clone prints `ERR_PNPM_IGNORED_BUILDS` and
 stops build scripts short — that's expected; see the `tes-pnpm-setup` skill.
 
+## Translation work
+
+Translating content (`translate:export` / `translate:apply`) is governed by
+**`docs/translation-pipeline.md`** — the mechanics, the orchestration
+playbook, and the four verification gates (`scripts/translation-gates/`).
+Terminology decisions accumulated across the run are binding and live in
+**`docs/translation-terminology.md`**; read it before translating anything,
+append to it when you settle a new term. The `en-ai` output must keep its
+"AI translated" badge (automatic via `content/versions.json`).
+
 ## Dev server ports
 
 `nuxt.config.ts` pins `devServer.port` to **6217** and Vite's HMR websocket to

--- a/docs/translation-pipeline.md
+++ b/docs/translation-pipeline.md
@@ -132,4 +132,94 @@ untranslated commentary lives in parts 7–16**. Its 125 terms are binding
 everywhere, but it has not seen the vocabulary of the parts being translated.
 
 Translate one part, review it against the Hebrew, then scale. `--part` exists
-for exactly that.
+for exactly that. Two supplements to the manifest glossary are binding for
+English and live in this repo:
+
+- **`docs/translation-terminology.md`** — every terminology call settled since
+  the run began. Read it before translating; append new decisions after.
+- **`scripts/translation-gates/`** — mechanical verification scripts (below).
+
+## Running a session — the orchestration playbook
+
+Proven shape (2026-08-15): an orchestrator fans batches out to **4–6
+translator agents concurrently**, gates every returned batch, then applies,
+checks and ships once per round. 267 items merged in one such session versus
+97 sequential. If a single AI is doing the work alone the same gates and rules
+apply — only the fan-out disappears.
+
+Each round:
+
+1. `git checkout main && git pull --ff-only`, then re-export. **Batch ids are
+   not stable** — the export recomputes what is untranslated, so after every
+   apply everything renumbers. Always take `en-001..N` fresh; never assume
+   "batch N" still means anything.
+2. Split each manifest before handing it over: extract `chapters` into its own
+   file and put the `instructions` + `glossary` into a shared brief written
+   once. **Never hand a translator the raw manifest** — it is ~3,300 lines and
+   the glossary alone consumes a whole read budget.
+3. Give each translator: the brief, its chapters file, its **exact item
+   count**, and the part-specific pane guidance (below). Require the output
+   file to be **rewritten every 3–5 items** — agents die mid-batch (server
+   errors, session limits) and incremental writes are what makes a partial
+   batch recoverable. A partial batch is shippable; the exporter re-lists
+   whatever is missing next round.
+4. Gate every returned batch (next section). Fix what the gates flag.
+5. Apply all batches, run `task check` **once**, one PR per round, merge,
+   re-export.
+
+### The four gates
+
+`task check` cannot see a wrong word. These can — run all four on every batch:
+
+1. **`scripts/translation-gates/driftcheck.py`** — item-set equality and
+   order, tag counts (`<b>`/`<br>`/`<small>`) against the source, straight
+   quotes, Hebrew leakage outside bracketed glosses, banned terms, required
+   citation renderings, and the expansion ratio. The ratio bounds
+   (1.35–2.30, median ≈1.79) were **measured over the merged corpus** — if
+   they ever need adjusting, recalibrate from real data, don't guess. Run as
+   `TX_SCRATCH=<dir> python3 scripts/translation-gates/driftcheck.py en-001 …`
+   where `<dir>` holds `chs-<batch>.json` (the extracted chapters) and
+   `out-<batch>.json` (the returned translations).
+2. **Independent gematria recomputation** — verify every `דף X` page number
+   and every letter marker against the English with your own letter table,
+   not the translator's. Across ~200 checks this has caught zero translator
+   errors and one genuine source lacuna — it is cheap and keeps everyone
+   honest.
+3. **`scripts/translation-gates/lemmacheck.py`** — n-gram overlap of each
+   bolded lemma against the pane line it quotes (`context.targetText`).
+   Catches lemma drift nothing else can see.
+4. **Corpus arbitration** — before settling any disputed term, count it in
+   both layers (`grep -ro … *.en-ai.json | wc -l` vs `*.en-bb.json`, from the
+   repo root) and let the corpus decide. Record the outcome in
+   `docs/translation-terminology.md`.
+
+### The prose/lemma rule — the central editorial decision
+
+Some parts' `source.en-ai` pane came from an earlier translation effort with
+different vocabulary than this commentary corpus.
+
+- **Running prose follows the corpus** — the commentary must read as one work.
+- **A bolded `<b>` lemma follows the pane**, because a lemma quotes the Ari
+  and the reader matches those words against the adjacent pane.
+- **Unless the pane is self-inconsistent** (part 8 always is — it writes
+  Chochma/Hochma, Abba/Aba, smallness/Katnut in adjacent chapters). Then use
+  the settled corpus form everywhere, lemmas included.
+- **Where the pane is unreliable, the Hebrew decides**: spelled-out
+  `אריך אנפין` → Arich Anpin, abbreviated `א"א` → AA — same rule for every
+  name.
+- From part 9 on the manifest context carries official `en-bb` `targetText`;
+  where it exists it is **better evidence than the glossary** — anchor
+  vocabulary to it.
+
+### Standing translator instructions
+
+- **Printer's errors are everywhere in parts 7–9** (`אף` for `דף`, `כבד` for
+  `כבר`, unclosed parentheses). Never silently emend — translate what is
+  printed and report the suspected error.
+- Two-sense abbreviations are read from the sentence, never applied blindly:
+  `ה"ר` is usually "first Hey" but in part 8 often `ה' ראשונות` → "the first
+  five"; `ה"ס` is usually "is the secret of" but sometimes `ה' ספירות` →
+  "five Sefirot".
+- Expansion runs ≈1.75× the Hebrew character count — every abbreviation
+  Baal HaSulam compresses expands to a full English phrase. The run is
+  generation-bound; bigger batch budgets save nothing, only parallelism helps.

--- a/docs/translation-terminology.md
+++ b/docs/translation-terminology.md
@@ -1,0 +1,220 @@
+# Settled terminology — Ohr Pnimi → English (`en-ai`)
+
+Accumulated across the merged translation batches (PRs #131, #138–#151 and
+onward). Deviating here is the single most common failure. These are settled
+calls; do not re-derive them.
+
+Maintenance rules, learned the hard way:
+
+- **Count before adding an entry.** Check a candidate form against both layers
+  from the repo root — `grep -ro "<term>" content/parts/*/chapters/*/*.en-ai.json | wc -l`
+  (the pane the reader sees) and the same over `*.en-bb.json` (the official
+  English) — and record which won. Six early entries in this file were wrong
+  because a part-local convention was written down as global.
+- **Append each session's new decisions here** and ship the update with the
+  session's last PR. This file plus the manifest's own glossary is the entire
+  terminology state — there is no other copy.
+
+## Names / layers
+
+- `הרב` → **the ARI** (never "the Rav"). Phase ordinals as words: **phase
+  four**, never "phase 4".
+- `מטי`/`לא מטי` → `Mati [reaching]` / `Lo Mati [not reaching]`, glossed once
+  then bare.
+- `ג"ר` → GAR [first three]; `ו"ק` → VAK [six ends]; `רת"ס` → RTS
+  [Rosh-Toch-Sof]; `מ"ן` → MAN [Mayin Nukvin]. Gloss on first use, bare after.
+- Sefirot keep Hebrew names: Hesed, **Gevura**, Tifferet, Netzah, Hod, Yesod,
+  **Daat**.
+  `חב"ד`→HBD, `חג"ת`→HGT, `נהי"מ`→NHYM, `כח"ב`→KHB.
+- `ע"ב`/`ס"ג` → AB / SAG. `או"א עילאין` → **the upper AVI**.
+  `יש"ס ותבונה` → Israel Saba and Tevuna; the pair = **YESHSUT**.
+- `זעיר אנפין` → Zeir Anpin when spelled out; `ז"א` → ZA otherwise.
+- `כגנ"י`/`חבחתה"מ` → **expand to the full Sefira list**, never transliterate.
+- Part 6 vocabulary (anchored to the official en-bb English): AK, AB / SAG /
+  MA / BON, Mochin, AA, Aba, Atzilut, Galgalta, Atik, Neshama. `אזן`→Ozen
+  [ear]; `חוטם`→Hotem; `פה`→Peh; `אח"פ`→AHP; `גו"ע`→GE; `דיקנא`→Dikna [beard];
+  `שערות`→hairs; `רישא`→Reisha [head]; `טעמים`→Taamim [tastes];
+  `נקודות`→Nekudot; `נקודים`→Nekudim; `או"א`→AVI (inner AVI / upper AVI /
+  YESHSUT are three distinct things); `מזלא`→Mazal, the two being **Notzer
+  Hesed** (upper) and **VeNakeh** (lower); `שבולת הזקן`→the Shibolet of the beard (see round 1 below); `נקבי עינים`→**Nikvey Einayim** (glossary-locked, 40 occurrences
+  in the official English — do NOT write "the openings of the
+  Eynaim"); bare `עינים`→Einayim; `ה"ת`→**bottom Hey**;
+  `ה' תתאה`→the lower Hey; `צמצום נה"י`→the restriction of NHY;
+  `אור רחמים`→the light of mercy; `ה"פ`→the five Partzufim; `ע"ח`→Etz Chaim;
+  `טמיר`→concealed.
+
+## Concepts
+
+`נשיקין`→Neshikin [kissing]; `תגין`→Tagin [crowns]; `הבל`→vapour;
+`אב"א`/`פב"פ`→"back to back"/"face to face" in words; `אחורים`→**posterior**;
+`הפיכת פנים`→turning of the face; `המשכה`→drawing; `התלבשות`→clothing;
+`הזדככות`→refinement; `רשימו`→**record**; `ניצוצין`→sparks; `צנורות`→pipes;
+`יניקה`→nursing; `ה"ח`/`ה"ג`→the five Hassadim / five Gevurot; `ממותק`→sweetened;
+`מדת הרחמים`/`מדת הדין`→the quality of mercy / of judgment; `מילוי`→filling;
+`שם י"ה`→the name YH; `שם הויה`→the name HaVaYaH (spelled fillings hyphenate
+letter names: Yod-Vav-Dalet, Hey-Yod); `אספקלריא שאינה מאירה`→a mirror that
+does not illuminate; `חצי דופן`→half of the wall; `הקוטב`→the axis;
+`חניות`→stops; `גופא`/`שקיו דאילנא`→the body / the watering of the tree;
+`מעי`→womb; `אויר העולם`→the air of the world; `פלג גופא`→half a body;
+`עולם הנקודים`→the world of Nekudim; `שביה"כ`→the breaking of the vessels;
+`עולם התיקון`→the world of correction; `אבי"ע`→ABYA; `נרנח"י`→NRNHY;
+`עולם הצמצום`→the world of the restriction. Also **coarseness** for עביות.
+
+Feminine grammar for Malchut / Bina / Nukva. `א"ס ב"ה` → Ein Sof.
+
+## Citations
+
+- `דף רצ"ז` → **page 297** (Hebrew-letter page numbers become Arabic numerals
+  via gematria); `ד"ה` → **the passage beginning**; `עש"ה` → **study it there
+  well**; `עכ"ל` → **End of quote**; `וז"ל` → **and these are his words**;
+  `אכמ"ל` → this is not the place to elaborate; `על בוריו` → thoroughly;
+  `בדיבור הסמוך` → in the adjacent item; `ה"ס` → is the secret of.
+- Inline Hebrew-letter markers → their gematria value in Arabic numerals:
+  `(ב)`→**(2)**, `(ג)`→**(3)**, `(יא)`→**(11)**. Never keep the Hebrew letter,
+  never renumber sequentially.
+- Hebrew letters survive into English ONLY as letter glosses: `<b>Hey</b>`,
+  `<b>Vav</b>`, `<b>Dalet</b>`, `<b>Yod</b>`, with `<b>Yod</b> [י]` style where
+  the source makes a shape/letter pun. Keep the source's `<b>` tags.
+
+## Added in round 1 of the parallel run (PR #146) — also settled
+
+- `שבולת הזקן` → **the Shibolet of the beard**, with a `[strand]` gloss on
+  first use in an item. This beats the official "Shibolet HaZakan" because the
+  en-ai source layer — the text the reader sees in the pane — uses it 27 times.
+- `ה"ת` → **bottom Hey**; `ה"ר` → **first Hey** (both glossary-locked).
+- `אורחא` → Orcha [path]; `חזה` → Chazeh [chest]; `עיבור` → Ibur
+  [impregnation]; `התכללות` → inclusion; `בירורים` → sortings;
+  `עלמין דפרודא` → the worlds of separation; `נסתם` → was blocked;
+  `בקיעה` → breaching / breaking through; `שיתוף` → partnership;
+  `מזיקים` → harmful forces; `קוצי דשערי` → the locks of hair.
+- `טנת"א` → expand to **Taamim, Nekudot, Tagin and letters**;
+  `עסמ"ב` → expand to **AB, SAG, MA and BON**; `בי"ע` → **BYA**.
+- `אריך אנפין` → Arich Anpin spelled out, `א"א` → **AA** abbreviated (same
+  rule as Zeir Anpin / ZA).
+- Vowel names transliterate: Holam, Shuruk, Melafum, Kamatz, Patach.
+- `ע"ש` → **See there** (only `עש"ה` is locked to "study it there well").
+- `כלים דפנים` → the anterior vessels (pairs with `אחורים` → posterior).
+- `עצמות` → **self** (the glossary reserves "essence" for `מהות`).
+- `זצ"ל` and similar honorifics are **dropped**, per the honorifics convention.
+
+**When this file and the manifest disagree, the manifest's glossary wins, and
+`targetText` wins over both.** `targetText` is the en-ai _source_ layer, not
+the official English — it is what the reader sees in the pane beside your
+notes, which is exactly why matching it matters. Report any conflict you hit.
+
+## Precedence, refined (round 2)
+
+`targetText` decides terms this file does **not** settle. It does **not**
+overturn a term this file settles that the wider corpus also backs — a couple
+of local hits lose to a hundred corpus-wide ones. Round 2 saw exactly this:
+two `targetText` instances of "the measure of mercy" against 119 corpus
+occurrences of "the **quality** of mercy / of judgment". The settled form won.
+
+When you hit such a clash, follow this file and **report it** rather than
+switching. Genuinely unsettled phrasing local to your chapters — e.g. "the
+measure of evil", which appears nowhere else — still follows `targetText`.
+
+## Added in round 2 (PR #148) — settled
+
+- **Positional states stay plain English**: `אב"א`→back to back, `פב"פ`→face
+  to face, `אב"פ`→back to face, `פב"א`→face to back. Part 7's pane
+  transliterates ("Achor be Achor") in places — do **not** follow it; plain
+  English wins 119:71 even inside part 7 and 535:110 corpus-wide.
+- `חו"ב` → **HB** in running prose (same rule as HBD / HGT / KHB). The one
+  exception: inside a bolded lemma quoting the Ari, render it exactly as the
+  pane renders that line, even if that means spelling it out.
+- `בחינה` splits: **phase** for `בחי"א`–`בחי"ד` and `ד' בחינות` (locked), and
+  **discernment** for generic `בחינת X` as a noun. `נבחן ל־` → "is regarded
+  as" / "is reckoned as".
+- `ס"א`/`סטרא אחרא` → Sitra Achra [the other side]; `נוגה` → Noga
+  [brightness]; `סיגים` → dross; `שמרים` → lees; `אתבסמו` → sweetened;
+  `מ"ה החדש` → the new MA; `מלך הדר` → the king Hadar; `הקב"ה` → the Creator;
+  `חז"ל` → our sages; `שירים` → remainders; `הנהגה` → conduct.
+- `רדל"א` → Radla [the unknown head]; `רישין` → Reishin [heads];
+  `יה"ו` → YHV [Yod-Hey-Vav] on first use, bare after; `ט"ת` → the nine lower
+  ones; `כלים דאחור` → the posterior vessels; `גלגלתא ועינים` spelled out →
+  Galgalta ve Einayim (abbreviated `גו"ע` stays GE); `ע"ה` → with the kollel.
+- `שעטנ"ז ג"ץ` → Shatnez Gatz; `בד"ק חי"ה` → Badak Haya;
+  `בדק הבית` → Bedek HaBayit [the repair of the House].
+- `מיעוט`/`התמעטות` → diminution; `סיתום` → blockage; `פגם` → flaw;
+  `אחיזה` → grip; `צ"ע` → this requires examination; `מסובב` → consequence.
+- `יניקה` is **nursing** in the Ibur-Yenika sense but **sucking** where the
+  shells do it — different act, different word.
+- Honorifics (`זצ"ל`, `מכתי"ק`) are dropped; a manuscript note becomes
+  "(A note in the author's own handwriting: …)".
+
+**Do not silently emend the Hebrew.** Round 2 hit a printed `חו"ב` where the
+sense demanded `חו"ג`, and a stray `עשר` that fits no reading. Translate what
+is there, or drop only what is unreadable, and report it.
+
+## Added in round 3 (PR pending) — settled
+
+- `מ"ן` → **MAN [Mayin Nukvin]**, glossed once then bare. NOT "[female
+  waters]" — the pane uses `MAN [Mayin Nukvin]` 72 times against 21.
+- `הבל` → **breath**, not vapour, outside part 6. The pane says breath 99:32
+  corpus-wide and 8:0 in part 8. Part 6's existing "vapour" matches part 6's
+  own pane and stays.
+- `אמא` → Ima; `נו"ה` → NH; `כחב"ד` → KHBD; `הרח"ו` → Rav Chaim Vital;
+  `מ"ד` → MAD [male waters]; `רעוא דמצחא` → Raava DeMitzcha [the will of the
+  forehead]; `אד"ר` → the Idra Rabba; `רה"י`/`רה"ר` → private / public domain;
+  `הריון` → pregnancy; `עברה` → Evra [wrath] (keeps the Ibur/Evra pun);
+  `רקיע` → firmament; `שבירה` → breaking; `הארה` → illumination.
+- Spelling: **Aba**, not Abba (1820:175) — even where a part-7 pane writes
+  "Abba" in running prose.
+
+### The lemma rule, stated plainly
+
+A bolded lemma quotes the Ari. The reader matches those words against the pane
+beside them, so **inside a lemma use the pane's wording for that line**, even
+where this file says otherwise in prose. Outside the lemma, this file wins.
+Round 3 realigned 14 lemma terms this way (posterior→backs, Einayim of
+AVI→eyes of Aba and Ima, GAR→the three first ones, breaking→shattering,
+vapour→breath, back to face→"back within face").
+
+## Added in round 4 — settled
+
+- **`ה"ר` is two different things.** The glossary locks `ה"ר` → "first Hey",
+  but in part 8 it abbreviates `ה' ראשונות` → **the first five**. The Ari's own
+  line reads `מה' ראשונות דכתר דב"ן` and the pane renders "the first five of
+  the Keter of BON". Read the sentence; do not apply the lock blindly.
+- `קטנות`/`גדלות` → **Katnut / Gadlut** (470:144 and 679:194 against
+  smallness/greatness), even where a pane translates them.
+- `נוקבא` → **Nukva** (1626 corpus); `טבור` → **Tabur** (566:237 against navel).
+- `בוצינא דקרדנותא` → Butzina de Kardinuta [the lamp of darkness];
+  `ג' גו ג'` → “three within three”; `ביטול` → nullification; `עצם` →
+  substance; `ראשים` → Roshim; `כתרים` → Ketarim; `חו"ג` → HG;
+  `דחג"ת` → DHGT; `הקצבות` → allotments; `אגלידא הפרסא` → the Parsa congealed.
+- `געסמ"ב` → expand to Galgalta, AB, SAG, MA and BON.
+
+Part 8's pane is the least consistent yet — within a single round it wrote
+Chochma/Hochma, Abba/Aba, Aba ve Ima/AVI/Abba and Ima, the female/Nukva,
+smallness/Katnut, selected/sorting, Ibur/gestation. The unreliability
+exception therefore applies often in part 8: use the settled form, including
+inside lemmas, and say so in your report.
+
+## `בחינה` — settled, do not re-litigate (round 5)
+
+The manifest glossary gives `בחינה` → "phase" (659 variants vs 9) and notes
+that en-bb uses "discernment" only for `הבחן/הבחנה`. **That describes en-bb,
+not this corpus.** Measured over 636 aligned items of parts 1-6 commentary:
+
+    Hebrew   בחינה-family 1,671   בחי"א-ד 803   הבחנה/הבחן 58
+    English  phase 1,310          discernment 433
+
+433 "discernment" against 58 `הבחנה` can only be rendering `בחינה`. The split
+below is therefore what the corpus already does, and it stays:
+
+- `בחי"א`–`בחי"ד`, `ד' בחינות` → **phase one … phase four**, **four phases**.
+- generic nominal `בחינת X` → **the discernment of X**.
+- `נבחן ל־` → "is regarded as" / "is reckoned as".
+- `הבחן`/`הבחנה` (the act) → discernment, naturally.
+
+## More read-the-sentence abbreviations
+
+Like round 4's `ה"ר`, these carry two senses. Read the clause, don't apply a
+lock blindly:
+
+- `ה"ס` → usually **"is the secret of"**, but `עם ה"ס: גבורה, ת"ת, נצח, הוד,
+יסוד` is `ה' ספירות` → **five Sefirot**.
+- `ה"ר` → usually "first Hey", but in part 8 often `ה' ראשונות` → **the first
+  five**.

--- a/scripts/translation-gates/driftcheck.py
+++ b/scripts/translation-gates/driftcheck.py
@@ -1,0 +1,184 @@
+#!/usr/bin/env python3
+"""Mechanical drift check for a returned Ohr Pnimi translation batch.
+
+Usage: python3 driftcheck.py en-001 [en-002 ...]
+
+Checks only what is greppable and objectively wrong. A clean run does NOT mean
+the English is good; it means the batch is worth reading closely.
+"""
+import json
+import re
+import sys
+from collections import Counter
+
+import os
+SCRATCH = os.environ.get("TX_SCRATCH") or os.getcwd()  # set TX_SCRATCH, or run from the dir holding chs-*.json / out-*.json
+
+HEB = re.compile(r"[֐-׿]")
+TAGS = ("<b>", "</b>", "<br>", "<br/>", "<br />", "<small>", "</small>")
+
+# term -> human explanation. Case-insensitive substring bans.
+BANNED = {
+    r"\bthe Rav\b": "must be 'the ARI'",
+    r"\bphase [1-5]\b": "phase ordinals spelled as words (phase four)",
+    r"\bReshimo\b": "רשימו is 'record'",
+    r"\bReshimot\b": "רשימו is 'record'",
+    r"\bimprint\b": "רשימו is 'record'",
+    r"\bbackside\b": "אחורים is 'posterior'",
+    r"\bback side\b": "אחורים is 'posterior'",
+    r"\bZeir Anpin \(ZA\)": "gloss style: no parenthetical acronyms",
+    r"\bs\.v\.\b": "ד\"ה is 'the passage beginning'",
+    r"\bibid\b": "not a convention in this run",
+    r"\bTranslator": "no translator notes",
+    r"\bNote:": "no notes of your own",
+    r"\bi\.e\.\b": "spell it out",
+    r"\be\.g\.\b": "spell it out",
+    r"\bAri\b(?!sing)": "capitalised as 'the ARI'",
+    r"\bYeshsut\b": "YESHSUT",
+    # Glossary-locked forms. The wider en-ai corpus and the official English
+    # both use the right-hand form; this run's early batches drifted.
+    r"\bGvura": "גבורה is 'Gevura' (glossary canonicalEn; 545 hits corpus-wide vs 68)",
+    r"\bDa[’']at\b": "Daat, no apostrophe (712 hits corpus-wide vs 65)",
+    r"openings of the Ey": "נקבי עינים is 'Nikvey Einayim' (glossary-locked)",
+    r"upper Aba and Ima": "או\"א עילאין is 'the upper AVI' (official English)",
+    r"\bYesod of Nukva\b(?# harmless, placeholder)": None,
+}
+BANNED = {k: v for k, v in BANNED.items() if v}
+
+# Required renderings when the Hebrew trigger is present in the source item.
+CITATION = {
+    "ד\"ה": (r"the passage beginning", "ד\"ה → 'the passage beginning'"),
+    "עש\"ה": (r"study\s+(?:it\s+)?there\b", "עש\"ה → 'study it there well'"),
+    "עכ\"ל": (r"End of quote", "עכ\"ל → 'End of quote'"),
+    "וז\"ל": (r"and these are his words", "וז\"ל → 'and these are his words'"),
+    "אכמ\"ל": (r"not the place to elaborate", "אכמ\"ל → 'this is not the place to elaborate'"),
+}
+
+
+def count_tags(s):
+    c = Counter()
+    for t in TAGS:
+        c[t] = s.count(t)
+    c["<br>"] = c["<br>"] + c["<br/>"] + c["<br />"]
+    del c["<br/>"], c["<br />"]
+    return c
+
+
+def check(batch):
+    src = json.load(open(f"{SCRATCH}/chs-{batch}.json"))
+    try:
+        out = json.load(open(f"{SCRATCH}/out-{batch}.json"))
+    except FileNotFoundError:
+        print(f"[{batch}] MISSING out-{batch}.json")
+        return 1
+
+    items = {}
+    order = []
+    for ch in src["chapters"]:
+        for it in ch["items"]:
+            k = (ch["chapterId"], it["anchorId"])
+            items[k] = it["he"]
+            order.append(k)
+
+    problems = []
+    if out.get("batch") != batch:
+        problems.append(f"batch field is {out.get('batch')!r}, expected {batch!r}")
+
+    tr = out.get("translations", [])
+    got = [(t.get("chapterId"), t.get("anchorId")) for t in tr]
+    if len(tr) != len(order):
+        problems.append(f"item count {len(tr)} != manifest {len(order)}")
+    missing = [k for k in order if k not in set(got)]
+    extra = [k for k in got if k not in items]
+    dupes = [k for k, n in Counter(got).items() if n > 1]
+    for k in missing:
+        problems.append(f"MISSING item {k[0]} {k[1]}")
+    for k in extra:
+        problems.append(f"EXTRA item {k[0]} {k[1]} (not in manifest)")
+    for k in dupes:
+        problems.append(f"DUPLICATE item {k[0]} {k[1]}")
+    if got and got != order and not missing and not extra and not dupes:
+        problems.append("items are not in source order")
+
+    for t in tr:
+        k = (t.get("chapterId"), t.get("anchorId"))
+        he = items.get(k)
+        if he is None:
+            continue
+        html = t.get("html") or ""
+        tag = f"{k[0]} {k[1]}"
+
+        if not html.strip():
+            problems.append(f"{tag}: empty html")
+            continue
+
+        sc, tc = count_tags(he), count_tags(html)
+        for name in ("<b>", "</b>", "<br>", "<small>", "</small>"):
+            if sc[name] != tc[name]:
+                problems.append(f"{tag}: {name} count {tc[name]} != source {sc[name]}")
+
+        if '"' in html:
+            problems.append(f"{tag}: {html.count(chr(34))} straight double quote(s) — use “ ”")
+        # straight apostrophe: Da'at and other transliterated ayin/aleph
+        # markers legitimately use it (168 merged items agree); possessives
+        # should be curly. Minor, so labelled as such.
+        stripped = re.sub(r"\b(?:Da|Ba|Ta|Ma|Sa)'(?:at|al|am|an)\b", "", html)
+        if "'" in stripped:
+            problems.append(
+                f"{tag}: minor — {stripped.count(chr(39))} straight apostrophe(s) outside a transliteration; use ’"
+            )
+
+        heb = HEB.findall(html)
+        if heb:
+            # letter glosses like [י] are allowed; flag anything longer than a
+            # single bracketed letter run
+            bare = re.sub(r"\[[֐-׿]{1,4}\]", "", html)
+            left = HEB.findall(bare)
+            if left:
+                snippets = re.findall(r".{0,25}[֐-׿]+.{0,25}", bare)[:3]
+                problems.append(
+                    f"{tag}: {len(left)} Hebrew char(s) outside a bracketed gloss: {snippets}"
+                )
+
+        # Source-conditional: "thickness"/"roughness" are only wrong when they
+        # render עביות. עובי (physical thickness of the three lines) is a
+        # different word and legitimately reads "thickness".
+        if "עביות" in he:
+            for w in ("roughness", "thickness"):
+                if re.search(rf"\b{w}\b", html):
+                    problems.append(f"{tag}: {w!r} where the source has עביות — use 'coarseness'")
+
+        for pat, why in BANNED.items():
+            for m in re.finditer(pat, html):
+                problems.append(f"{tag}: banned {m.group(0)!r} — {why}")
+
+        for trigger, (need, why) in CITATION.items():
+            if trigger in he and not re.search(need, html, re.I):
+                problems.append(f"{tag}: source has {trigger} but output lacks — {why}")
+
+        # gematria page refs: 'page' followed by non-digit
+        for m in re.finditer(r"page\s+(?!\d)(\S+)", html):
+            problems.append(f"{tag}: 'page {m.group(1)}' — page refs must be Arabic numerals")
+
+        # Expansion sanity. Measured over the 168 already-merged items:
+        # min 1.42, p5 1.59, median 1.79, p95 1.94, max 2.13. Outside
+        # 1.35-2.30 means a clause was dropped or something was invented.
+        ratio = len(html) / max(len(he), 1)
+        if ratio < 1.35:
+            problems.append(f"{tag}: expansion {ratio:.2f}x looks compressed — clause dropped? (len {len(html)} vs he {len(he)})")
+        elif ratio > 2.30:
+            problems.append(f"{tag}: expansion {ratio:.2f}x looks padded — added commentary? (len {len(html)} vs he {len(he)})")
+
+    if problems:
+        print(f"[{batch}] {len(problems)} problem(s):")
+        for p in problems:
+            print("   -", p)
+    else:
+        print(f"[{batch}] clean — {len(tr)} items, mechanical checks pass")
+    return len(problems)
+
+
+if __name__ == "__main__":
+    total = sum(check(b) for b in sys.argv[1:])
+    print(f"\ntotal problems: {total}")
+    sys.exit(1 if total else 0)

--- a/scripts/translation-gates/lemmacheck.py
+++ b/scripts/translation-gates/lemmacheck.py
@@ -1,0 +1,49 @@
+#!/usr/bin/env python3
+"""Flag bolded lemmas whose wording drifts from the pane line they quote.
+
+A lemma quotes the Ari's text. The reader sees that same line rendered in the
+pane beside it, so the words must match. Low n-gram overlap means they don't.
+"""
+import json, re, sys
+
+import os
+SCRATCH = os.environ.get("TX_SCRATCH") or os.getcwd()  # set TX_SCRATCH, or run from the dir holding chs-*.json / out-*.json
+strip = lambda s: re.sub(r"\s+", " ", re.sub(r"<[^>]+>", "", s)).strip()
+norm = lambda s: re.sub(r"[^a-z ]", "", s.lower())
+
+
+def grams(s, n=4):
+    w = norm(s).split()
+    return {" ".join(w[i:i + n]) for i in range(max(0, len(w) - n + 1))}
+
+
+def check(batch, threshold=0.55):
+    src = json.load(open(f"{SCRATCH}/chs-{batch}.json"))
+    panes = {
+        c["chapterId"]: strip(" ".join(x["html"] for x in (c["context"].get("targetText") or [])))
+        for c in src["chapters"]
+    }
+    out = json.load(open(f"{SCRATCH}/out-{batch}.json"))
+    flagged = 0
+    for t in out["translations"]:
+        pane = panes.get(t["chapterId"], "")
+        if not pane:
+            continue
+        m = re.search(r"<b>(.*?)</b>", t["html"], re.S)
+        if not m:
+            continue
+        lem = strip(m.group(1))
+        g = grams(lem)
+        if len(g) < 3:
+            continue
+        overlap = len(g & grams(pane)) / len(g)
+        if overlap < threshold:
+            flagged += 1
+            print(f"  {t['chapterId']} {t['anchorId']}: {overlap:.0%} of lemma matches the pane")
+            print(f"     lemma: {lem[:150]}")
+    print(f"[{batch}] {flagged} lemma(s) below {threshold:.0%} overlap")
+    return flagged
+
+
+if __name__ == "__main__":
+    sys.exit(1 if sum(check(b) for b in sys.argv[1:]) else 0)


### PR DESCRIPTION
Closes nothing, unblocks everything: a cold agent (or a different AI entirely) picking up issue #87 previously had only `docs/translation-pipeline.md` — the mechanics — while the gate scripts, the settled terminology, and the run playbook lived outside the repo on one machine. This moves all of it in.

- **`scripts/translation-gates/`** — `driftcheck.py` (item-set equality, tag counts, straight quotes, Hebrew leakage, banned terms, citation renderings, measured expansion bounds) and `lemmacheck.py` (n-gram overlap of bolded lemmas against the pane they quote). Standalone python3, no deps.
- **`docs/translation-terminology.md`** — every terminology call settled across the merged batches, plus the count-before-adding maintenance rule that stopped the run's own drift.
- **`docs/translation-pipeline.md`** — new sections: the fan-out session playbook, the four verification gates, the prose/lemma rule, and standing translator instructions (printer's errors, two-sense abbreviations, expansion expectations).
- **`AGENTS.md`** — a short Translation work section pointing at the above.

Docs + standalone scripts only; no app code touched. Lint and format:check pass locally; CI runs the full gate.