### PR TITLE
docs: make a translation round reproducible from the repo alone

### DIFF
--- a/docs/translation-pipeline.md
+++ b/docs/translation-pipeline.md
@@ -135,6 +135,12 @@ Translate one part, review it against the Hebrew, then scale. `--part` exists
 for exactly that. Two supplements to the manifest glossary are binding for
 English and live in this repo:
 
+- **`docs/translation-rules.md`** — the translator-facing contract: what not
+  to transliterate, how the pane governs a lemma, citation and page-number
+  conventions, tag/quote mechanics, and the two standing prohibitions (never
+  drop what you cannot parse; never normalise an abbreviation to make a
+  passage read consistently). `translation-split.py` appends it to every
+  brief.
 - **`docs/translation-terminology.md`** — every terminology call settled since
   the run began. Read it before translating; append new decisions after.
 - **`scripts/translation-gates/`** — mechanical verification scripts (below).
@@ -153,10 +159,20 @@ Each round:
    not stable** — the export recomputes what is untranslated, so after every
    apply everything renumbers. Always take `en-001..N` fresh; never assume
    "batch N" still means anything.
-2. Split each manifest before handing it over: extract `chapters` into its own
-   file and put the `instructions` + `glossary` into a shared brief written
-   once. **Never hand a translator the raw manifest** — it is ~3,300 lines and
-   the glossary alone consumes a whole read budget.
+2. Split each manifest before handing it over:
+
+   ```sh
+   TX_SCRATCH=<dir> python3 scripts/translation-split.py en-001 en-002 …
+   TX_SCRATCH=<dir> python3 scripts/translation-gates/cites.py en-001 en-002 …
+   ```
+
+   The first writes `brief.md` (the manifest's instructions and glossary,
+   followed by `docs/translation-rules.md`) plus one `chs-<batch>.json` per
+   batch. The second writes `cites-<batch>.md`. **Never hand a translator the
+   raw manifest** — it is ~3,300 lines and the glossary alone consumes a whole
+   read budget. Give each translator the brief, its chapters file, its
+   citation table, and its exact item count.
+
 3. Give each translator: the brief, its chapters file, its **exact item
    count**, and the part-specific pane guidance (below). Require the output
    file to be **rewritten every 3–5 items** — agents die mid-batch (server
@@ -181,10 +197,19 @@ Each round:
    where `<dir>` holds `chs-<batch>.json` (the extracted chapters) and
    `out-<batch>.json` (the returned translations).
 2. **Independent gematria recomputation** — verify every `דף X` page number
-   and every letter marker against the English with your own letter table,
-   not the translator's. Across ~200 checks this has caught zero translator
-   errors and one genuine source lacuna — it is cheap and keeps everyone
-   honest.
+   against the English with your own letter table, written fresh and kept
+   _outside_ `scripts/translation-gates/`; the independence is the whole
+   point. Do not skip it because the run has been clean: its record of "zero
+   translator errors in ~290 refs" turned out to be an artefact of the
+   checker not knowing that past 999 the thousand is written as a bare `א'`.
+   Taught that form, it found 12 real errors in a single round.
+
+   Upstream of it, **`scripts/translation-gates/cites.py`** pre-computes every
+   `דף` and `אות` citation in a batch into a table the translator copies from,
+   so nobody does gematria by hand. Instruction alone did not fix this class —
+   an agent with the rule in its brief _and_ its prompt still shipped five
+   errors; the table fixed it in one round.
+
 3. **`scripts/translation-gates/lemmacheck.py`** — n-gram overlap of each
    bolded lemma against the pane line it quotes (`context.targetText`).
    Catches lemma drift nothing else can see.

--- a/docs/translation-rules.md
+++ b/docs/translation-rules.md
@@ -1,0 +1,119 @@
+## Run rules (binding — these override anything above that conflicts)
+
+### DO NOT TRANSLITERATE what this corpus translates
+
+Translators keep reading one glossed occurrence in a pane and generalising it
+into a global rule. Use: `כלי`→vessel, `כלים`→vessels, `זווג`→coupling,
+`מסך`→screen, `עביות`→coarseness, `רשימו`→record, `אחורים`→posterior,
+`יניקה`→nursing, `נסירה`→sawing.
+
+Before transliterating any term because the pane seems to, run from the repo
+root:
+
+```sh
+grep -ro "<term>" content/parts/*/chapters/*/commentary.en-ai.json | wc -l
+```
+
+If it returns 0, **do not use it**. Glob `commentary.en-ai.json` explicitly —
+never `*.en-ai.json`, which sums in a different translation effort's
+vocabulary and gives the wrong answer.
+
+### Terminology source of truth
+
+Read `docs/translation-terminology.md` (repo root) before you start. Every
+call in it is settled; do not re-derive or re-litigate. `בחינה` →
+**discernment** has been challenged twice and upheld twice.
+
+### The pane, and what it does and does not govern
+
+`context.targetText` is **not** official English — it is an earlier
+translation effort's vocabulary, in every part.
+
+- **Running prose follows the corpus**, never the pane.
+- **A bolded `<b>` lemma follows the pane's phrasing** — same verbs, same word
+  order — because the reader sees that line beside your note.
+- **Unless that chapter's own pane is self-inconsistent** (it prints two
+  renderings of the same Hebrew). Test per chapter, by counting. Then the
+  settled corpus form wins everywhere, lemmas included.
+- **A settled technical term and a name's spelling never follow the pane**,
+  lemma or not: `Ibur [impregnation]` not "pregnancy"/"gestation", `Hochma`
+  not "Chochma", `Aba` not "Abba", `Hassadim` not "Hasadim", `Tevuna` not
+  "Tvuna", `YHV` not "YAHU", `AB, SAG, MA` not "AV, SAG, MAH". The reader
+  matches words; these are the same word.
+- **Where the pane is unreliable, the Hebrew decides**: spelled-out
+  `אריך אנפין` → Arich Anpin, abbreviated `א"א` → AA.
+
+### Settled names and forms
+
+`בוצינא דקרדינותא` / `בוצד"ק` → **Butzina de Kardinuta [the lamp of
+darkness]** (never "Botzedek", "Butzadak", "Botzina", "hardened candle").
+`מנצפ"ך` → **MaNTzePaCh**. `תנה"י` → **TNHY**. `נרנח"י` → **NRNHY**, glossed
+once. `רוחא קדמאה` → **Rucha Kadmaa [the first Ruach]**. `עלי עליון` → **the
+upper of the upper**. `בס"ה` → **in the secret of**. `אה"ר` → **Adam
+HaRishon**. `מיין דוכרין` → **Mayin Duchrin [male waters]**.
+Gloss forms the corpus uses: `Gadlut [greatness/adulthood]`,
+`Katnut [smallness/infancy]`, `Tzelem [image]`, `Taamim [tastes]`.
+
+### Citations and numbers
+
+- `ד"ה` → **the passage beginning** (never "s.v.", never "Sub Header").
+- `עש"ה` → study it there well; `ע"ש` (bare) → see there; `עכ"ל` → End of
+  quote; `וז"ל` → and these are his words; `אכמ"ל` → this is not the place to
+  elaborate.
+- `דף` + Hebrew letters → **Arabic numeral** page number by gematria (א=1 … י=10,
+  כ=20 … ק=100, ר=200, ש=300, ת=400; gershayim are punctuation, so `רצ"ז` =
+  297). Past 999 the page is the **word** `אלף` plus a numeral: `דף אלף ז'` is
+  page **1007**. `דף ד"ה` is the idiom "the passage beginning", not a page.
+- Write citations as **“(page 683, item 93)”** — lowercase "page", Arabic
+  numerals (corpus 144 : 0).
+- `כי חפץ חסד הוא` → **“for He desires mercy”**.
+- Two-sense abbreviations are read from the sentence: `ה"ר` is usually "first
+  Hey" but often `ה' ראשונות` → "the first five"; `ה"ס` is usually "is the
+  secret of" but sometimes `ה' ספירות` → "five Sefirot".
+
+### Mechanics
+
+- Preserve `<b>`, `<br>`, `<small>` **counts exactly** — a gate compares them
+  against the source. Include the item's **leading `<br>`** if the Hebrew has
+  one, and every `<br>` between paragraphs.
+- **Bolded single letters are the letter itself**, not item markers: `<b>ו</b>`
+  → `<b>Vav</b>`. Keep every one bolded, at the matching point in the sentence.
+  One item had 9 `<b>` pairs in the Hebrew and came back with 1.
+- **Curly quotes only** — `“ ”` for quotation (corpus 906 : 44 over single
+  curly), `’` for apostrophes. A straight `"` or `'` fails the gate.
+- No Hebrew in the output except a single bracketed letter gloss like `[י]`.
+- **No editorial notes in the html, ever.** Report suspicions in your reply.
+
+### Never drop anything
+
+Printer's errors are everywhere (`אף` for `דף`, `כבד` for `כבר`, `בחיבות` for
+`בחינות`, unclosed parentheses). Translate what is printed and report the
+suspicion — but **never omit a clause, a citation or a letter because you
+cannot parse it.** Two agents in one round dropped `ב"ש ת"ת` ("the two thirds
+of Tifferet") and the `ת` of `תנה"י` as unreadable; both are ordinary
+abbreviations the corpus had already settled. No gate can see an omission —
+grep the corpus first, then translate it.
+
+Equally, **never normalise an abbreviation to make a passage read
+consistently**: `ג"ש העליונים … וב"ש תחתונים` is "the upper three thirds …
+the bottom two thirds", however odd that looks.
+
+- Be internally consistent: the same construction gets the same English in
+  every item of your batch.
+- Expansion runs ≈1.75× the Hebrew character count (gate bounds 1.35–2.30).
+  Far under means a dropped clause; far over means invented commentary.
+
+### Page numbers past 999
+
+The thousand is written as a bare `א'` or the word `אלף`, and the hundreds
+follow without repeating `דף`: `דף א' קע"ג` is page **1173**, `דף אלף ז'` is
+page **1007**, `דף א' ד"ה …` is page **1000**. Never read these as two
+separate page numbers — the book runs past page 1,200.
+
+- `אויר` → **air** (corpus 98 : 0 against "Avir"). Transliterate it only where
+  the item is discussing the word itself ("You already know that Avir
+  means…"), the same way `‘Atarot’ means ‘Ketarim’` is handled.
+- `וז"ל` → **“and these are his words”** — his, even when the source quoted is
+  a book (the Zohar), never "its words".
+- **`יש"ס ותבונה` pair → `YESHSUT`, all caps.** "Yeshsut" is banned by the
+  gate; one batch shipped 39 of them.

--- a/scripts/translation-split.py
+++ b/scripts/translation-split.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python3
+"""Split export manifests into a translator brief plus one file per batch.
+
+Usage: TX_SCRATCH=<dir> python3 scripts/translation-split.py [--lang en] en-001 en-002 …
+
+Writes into <dir>:
+  brief.md          the manifest's instructions + glossary, then docs/translation-rules.md
+  chs-<batch>.json  that batch's chapters, extracted from the manifest
+
+Never hand a translator the raw manifest — it is ~3,300 lines and the
+glossary alone consumes a whole read budget.
+"""
+import json
+import os
+import sys
+
+REPO = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+OUT = os.environ.get("TX_SCRATCH") or os.getcwd()
+
+args = sys.argv[1:]
+lang = "en"
+if "--lang" in args:
+    i = args.index("--lang")
+    lang = args[i + 1]
+    del args[i:i + 2]
+SRC = os.path.join(REPO, ".translation", lang)
+batches = args
+if not batches:
+    sys.exit("usage: TX_SCRATCH=<dir> python3 scripts/translation-split.py [--lang en] en-001 …")
+
+m = json.load(open(f"{SRC}/{batches[0]}.json"))
+g = m["glossary"]
+
+lines = ["# Ohr Pnimi → English — translator brief\n", m["instructions"], "\n## Glossary conventions\n"]
+lines.append("```json\n" + json.dumps(g["conventions"], ensure_ascii=False, indent=1) + "\n```\n")
+lines.append("## Known gaps\n")
+lines.append("```json\n" + json.dumps(g["knownGaps"], ensure_ascii=False, indent=1) + "\n```\n")
+lines.append(f"## Binding glossary ({len(g['entries'])} terms)\n")
+lines.append("| Hebrew | canonicalEn | strategy | note |")
+lines.append("| --- | --- | --- | --- |")
+for e in g["entries"]:
+    note = (e.get("note") or "").replace("\n", " ").replace("|", "/")
+    lines.append(f"| {e['he']} | {e['canonicalEn']} | {e['strategy']} | {note} |")
+rules = open(os.path.join(REPO, "docs", "translation-rules.md"), encoding="utf-8").read()
+open(f"{OUT}/brief.md", "w").write("\n".join(lines) + "\n\n" + rules)
+
+report = []
+for b in batches:
+    d = json.load(open(f"{SRC}/{b}.json"))
+    json.dump(d["chapters"], open(f"{OUT}/chs-{b}.json", "w"), ensure_ascii=False)
+    n = sum(len(c["items"]) for c in d["chapters"])
+    parts = sorted({c["chapterId"].split("/")[0] for c in d["chapters"]})
+    chs = [c["chapterId"] for c in d["chapters"]]
+    has_target = sum(1 for c in d["chapters"] if c.get("context", {}).get("targetText"))
+    report.append(
+        {
+            "batch": b,
+            "items": n,
+            "chars": d["sourceChars"],
+            "parts": parts,
+            "chapters": f"{chs[0]} … {chs[-1]}" if len(chs) > 1 else chs[0],
+            "chapterCount": len(chs),
+            "chaptersWithTargetText": has_target,
+        }
+    )
+print(json.dumps(report, ensure_ascii=False, indent=1))


### PR DESCRIPTION
Answering "could another AI pick this up?" — not quite, until now. The repo had the four gates and the terminology file, but the two artefacts a translator actually reads were only ever in a session scratch directory.

## What was missing

- **`scripts/translation-split.py`** — builds `brief.md` (the manifest's instructions and glossary, then the run rules) plus one `chs-<batch>.json` per batch. Without it there is no way to hand a translator anything but the raw 3,300-line manifest.
- **`docs/translation-rules.md`** — the translator-facing contract, distinct from the terminology file: what not to transliterate and how to check, how the pane governs a lemma (and when it does not), citation and page-number conventions, tag/quote mechanics, and the two standing prohibitions — never drop what you cannot parse, never normalise an abbreviation to make a passage read consistently. The splitter appends it to every brief.

## Also

- The round procedure now names all three tools with their exact invocations, including `cites.py`, which was in the repo but unmentioned there.
- Corrected the gate-2 note. It claimed "zero translator errors in ~290 page refs". That was an artefact: the checker did not know that past 999 the thousand is written as a bare `א'`, so it could not express the error class. Taught the form, it found 12 real errors in one round. The doc now says so, because the old sentence invites skipping the gate.

## Verification

`task check` passes. `translation-split.py` and `cites.py` were both run against the live `.translation/en` manifests into a temp scratch dir and produce the expected `brief.md` (559 lines, rules section intact), `chs-*.json`, and `cites-*.md`.