### PR TITLE
feat(reader): collapsible, tabbed third pane — Inner Observation, Questions, Answers

### DIFF
--- a/app/assets/css/main.css
+++ b/app/assets/css/main.css
@@ -742,6 +742,31 @@ a[href],
   @apply rounded-button border px-1.5 py-0.5 text-xs font-medium;
 }
 
+/*
+ * `ThirdPaneTabs` — the third pane's Inner Observation / Questions /
+ * Answers tablist, which sits where every other pane prints a single
+ * layer title. It therefore wears the same `tes-eyebrow` type as those
+ * titles: the reader should read it as "this pane's heading, which happens
+ * to be switchable", not as a second navigation bar competing with the
+ * toolbar above it.
+ *
+ * `-mx-1` pulls the first tab's padding back so its text aligns with the
+ * other panes' titles rather than sitting a few pixels inboard of them.
+ */
+.tes-third-pane-tab {
+  @apply rounded-button px-1 font-display text-sm tracking-wide uppercase first:-ms-1;
+}
+
+.tes-third-pane-tab:focus-visible {
+  @apply outline outline-2 outline-teal;
+}
+
+/* Underlined rather than filled: a filled chip at this size reads as a
+   button to press, and these are a heading's segments. */
+.tes-third-pane-tab-active {
+  @apply text-(--text-primary) underline decoration-teal decoration-2 underline-offset-4;
+}
+
 /* `MobilePanePill`'s per-pane tab — the selected/unselected tint stays
    conditional at the call site. */
 /*

--- a/app/components/reader/InnerObservationPane.vue
+++ b/app/components/reader/InnerObservationPane.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 // Inner Observation (Histaklut Pnimit) is PART-scoped, not chapter-scoped —
-// see the content model skill / `useInnerObservationContent`: every chapter
+// see the content model skill / `usePartScopedSections`: every chapter
 // in a part shares the exact same Inner Observation content, concatenated
 // from that part's own `kind: "inner-observation"` chapters in section
 // order, each rendered under its own title heading. None of the corpus's
@@ -11,7 +11,7 @@
 // restarts at 1, so ids here would collide with the Source pane's).
 //
 // `state` exists because the bodies are deliberately not server-rendered
-// (see `useInnerObservationContent`'s module doc — issue #84 measured
+// (see `usePartScopedSections`'s module doc — issue #84 measured
 // part-scoped content SSR'd into every chapter of its part at ~411MB of the
 // built site). Prerendered HTML and the hydrating client render both show
 // the skeleton;
@@ -22,14 +22,14 @@
 // held apart from `"ready"` with no sections for exactly the same reason:
 // a chunk that 404s (a redeploy under a cached HTML document) must say so,
 // not claim the part has nothing. Its recovery is a page reload, which the
-// parent owns (`reload`) — see `useInnerObservationContent` for why an
+// parent owns (`reload`) — see `usePartScopedSections` for why an
 // in-place retry provably cannot work for a failed `import()`.
 //
 // A11y: the skeleton is decorative (`aria-hidden`) and the three states are
 // announced instead by one persistent polite live region, which is what
 // makes the *transition* audible — a `role="status"` that is destroyed the
 // moment the content arrives announces the wait but never its end.
-import type { InnerObservationLoadState } from "~/composables/useInnerObservationContent";
+import type { PartSectionsLoadState } from "~/composables/usePartScopedSections";
 import type { LocalizedText } from "~/utils/localization";
 import type { SourceSegment } from "~~/shared/types/content";
 
@@ -50,7 +50,7 @@ export interface InnerObservationSectionView {
 const props = withDefaults(
   defineProps<{
     sections: InnerObservationSectionView[];
-    state?: InnerObservationLoadState;
+    state?: PartSectionsLoadState;
   }>(),
   { state: "ready" },
 );

--- a/app/components/reader/MobilePanePill.vue
+++ b/app/components/reader/MobilePanePill.vue
@@ -55,7 +55,19 @@ interface Segment {
   iconClass: string;
 }
 
-const props = defineProps<{ panes: PaneId[] }>();
+const props = withDefaults(
+  defineProps<{
+    panes: PaneId[];
+    /**
+     * The third pane's label. It is tabbed (Inner Observation / Questions /
+     * Answers) and five parts have no Inner Observation at all, so naming
+     * it unconditionally after its first tab would label a pane after
+     * content it does not contain. The page decides; this stays dumb.
+     */
+    thirdPaneLabelKey?: string;
+  }>(),
+  { thirdPaneLabelKey: "reader.mobilePane.innerObservation" },
+);
 
 const SEGMENT_BY_PANE: Record<PaneId, Segment> = {
   source: {
@@ -79,7 +91,11 @@ const SEGMENT_BY_PANE: Record<PaneId, Segment> = {
 };
 
 const segments = computed<Segment[]>(() =>
-  props.panes.map((pane) => SEGMENT_BY_PANE[pane]),
+  props.panes.map((pane) =>
+    pane === "inner-observation"
+      ? { ...SEGMENT_BY_PANE[pane], labelKey: props.thirdPaneLabelKey }
+      : SEGMENT_BY_PANE[pane],
+  ),
 );
 
 const { t } = useI18n();

--- a/app/components/reader/MobileSwipePanes.vue
+++ b/app/components/reader/MobileSwipePanes.vue
@@ -79,7 +79,7 @@ import {
 import type { PaneId } from "~/utils/readerAnchorState";
 import { STUDY_MODE_MEDIA_QUERY } from "~/utils/readerMode";
 
-const props = defineProps<{ panes: PaneId[] }>();
+const props = defineProps<{ panes: PaneId[]; thirdPaneLabelKey?: string }>();
 
 const { activePane, setActivePane } = useReaderState();
 
@@ -257,13 +257,44 @@ watch(activePane, (pane) => {
 // Source stays a reading column — Inner Observation likewise gets real
 // estate as reference material rather than a cramped side column. A single
 // remaining pane just takes the full row and caps its own measure.
-const gridColsClass = computed(() =>
-  paneOrder.value.length === 3
-    ? "lg:grid-cols-[0.8fr_1.1fr_1.1fr]"
-    : paneOrder.value.length === 2
-      ? "lg:grid-cols-[0.85fr_1.15fr]"
-      : "lg:grid-cols-[1fr]",
+//
+// The third pane is collapsible (`useReaderThirdPane`), so what the grid
+// has to lay out at `lg:` is the pane count MINUS a closed third pane, plus
+// the always-present `auto` rail that carries its toggle. Below `lg` none
+// of this applies — the track is a flex row of slides and every pane the
+// chapter has is a slide, open or not.
+const { open: thirdPaneOpen } = useReaderThirdPane();
+
+const hasThirdPane = computed(() =>
+  paneOrder.value.includes("inner-observation"),
 );
+
+/** Columns actually drawn at `lg:` — a closed third pane occupies none. */
+const desktopColumnCount = computed(
+  () =>
+    paneOrder.value.length -
+    (hasThirdPane.value && !thirdPaneOpen.value ? 1 : 0),
+);
+
+// Written as whole literal class names, never assembled from pieces:
+// Tailwind generates utilities by scanning source text, so a template
+// literal like `lg:grid-cols-[...${rail}]` produces a class that exists in
+// the DOM and in no stylesheet — the grid silently falls back to one
+// column. The trailing `auto` track is the toggle rail, present at `lg:`
+// whenever there is a third pane to toggle (open or closed).
+const gridColsClass = computed(() => {
+  if (!hasThirdPane.value) {
+    return desktopColumnCount.value === 2
+      ? "lg:grid-cols-[0.85fr_1.15fr]"
+      : "lg:grid-cols-[1fr]";
+  }
+
+  if (desktopColumnCount.value >= 3)
+    return "lg:grid-cols-[0.8fr_1.1fr_1.1fr_auto]";
+  if (desktopColumnCount.value === 2)
+    return "lg:grid-cols-[0.85fr_1.15fr_auto]";
+  return "lg:grid-cols-[1fr_auto]";
+});
 </script>
 
 <template>
@@ -294,16 +325,28 @@ const gridColsClass = computed(() =>
     >
       <slot name="commentary" />
     </div>
+    <!-- `lg:hidden` when closed, never `v-if`: this is the same DOM node as
+         the mobile track's third slide, and unmounting it would drop its
+         scroll position and re-mount it on every crossing of the `lg`
+         breakpoint. Below `lg` it is always a slide, open or not — the
+         collapse is a desktop affordance, because that is where the width
+         it gives back exists. -->
     <div
-      v-if="paneOrder.includes('inner-observation')"
+      v-if="hasThirdPane"
       id="reader-inner-observation-pane"
       ref="innerObservationRef"
       data-pane="inner-observation"
       class="h-full min-h-0 w-full min-w-0 shrink-0 snap-start snap-always scroll-mt-4"
+      :class="!thirdPaneOpen && 'lg:hidden'"
     >
       <slot name="inner-observation" />
     </div>
+
+    <ReaderThirdPaneRail v-if="hasThirdPane" />
   </div>
 
-  <ReaderMobilePanePill :panes="paneOrder" />
+  <ReaderMobilePanePill
+    :panes="paneOrder"
+    :third-pane-label-key="thirdPaneLabelKey"
+  />
 </template>

--- a/app/components/reader/ReaderPane.vue
+++ b/app/components/reader/ReaderPane.vue
@@ -36,7 +36,11 @@ const containerRef = provideReaderPaneContainer();
         :meta="meta"
         class="flex-1"
         @update:model-value="(value) => emit('update:modelValue', value)"
-      />
+      >
+        <template v-if="$slots.title" #title>
+          <slot name="title" />
+        </template>
+      </ReaderPaneHeader>
 
       <slot name="toast" />
     </header>

--- a/app/components/reader/ReaderPaneHeader.vue
+++ b/app/components/reader/ReaderPaneHeader.vue
@@ -60,9 +60,15 @@ const onLanguageChange = (event: Event) => {
 
 <template>
   <div class="flex flex-wrap items-center justify-between gap-2">
-    <h2 class="tes-eyebrow">
-      {{ title }}
-    </h2>
+    <!-- The third pane replaces the single layer title with a tablist
+         (Inner Observation / Questions / Answers), so it supplies its own
+         heading. Every other pane names exactly one layer and takes the
+         default. -->
+    <slot name="title">
+      <h2 class="tes-eyebrow">
+        {{ title }}
+      </h2>
+    </slot>
 
     <div class="flex items-center gap-2">
       <span

--- a/app/components/reader/ReaderShell.vue
+++ b/app/components/reader/ReaderShell.vue
@@ -26,7 +26,7 @@
 // duplicate rendering of the panes.
 import type { PaneId } from "~/utils/readerAnchorState";
 
-const props = defineProps<{ panes: PaneId[] }>();
+const props = defineProps<{ panes: PaneId[]; thirdPaneLabelKey?: string }>();
 
 const hasPane = (pane: PaneId) => props.panes.includes(pane);
 
@@ -39,7 +39,10 @@ useReaderState();
       <slot name="toolbar" />
     </div>
 
-    <ReaderMobileSwipePanes :panes="panes">
+    <ReaderMobileSwipePanes
+      :panes="panes"
+      :third-pane-label-key="thirdPaneLabelKey"
+    >
       <template #source>
         <slot name="source" />
       </template>

--- a/app/components/reader/ThirdPaneRail.vue
+++ b/app/components/reader/ThirdPaneRail.vue
@@ -1,0 +1,51 @@
+<script setup lang="ts">
+// The third pane's toggle, as a slim always-present grid track on the
+// inline-end edge of the desktop panes layout.
+//
+// It is a column in the grid rather than a floating button on purpose. A
+// `position: fixed` control would have to be placed against a containing
+// block that panes mode has already been burned by once (issue 122 — a
+// fixed bottom bar came to rest a strip above the real bottom edge on
+// Firefox for Android), and it would overlap the text it sits on top of. A
+// track costs a few rem of width, always resolves correctly, and gives the
+// closed pane a visible edge to reopen from — a collapsed pane with no
+// persistent affordance is a feature nobody finds twice.
+//
+// `lg:` only: below it the third pane is a swipe slide reached from
+// `MobilePanePill`, and there is nothing to collapse.
+const { open, toggle } = useReaderThirdPane();
+
+const { t } = useI18n();
+
+const label = computed(() =>
+  open.value ? t("reader.thirdPane.collapse") : t("reader.thirdPane.expand"),
+);
+</script>
+
+<template>
+  <div
+    class="hidden lg:flex lg:h-full lg:shrink-0 lg:items-start lg:justify-center lg:border-s lg:border-(--border) lg:py-2.5"
+  >
+    <button
+      type="button"
+      class="tes-icon-btn"
+      :aria-expanded="open"
+      aria-controls="reader-inner-observation-pane"
+      :title="label"
+      @click="toggle"
+    >
+      <span class="sr-only">{{ label }}</span>
+      <!-- One chevron asset, rotated, rather than two icons. Closed, it
+           points inline-START (the direction the pane will come from when
+           it opens); open, inline-END (the direction it will go back). The
+           `rtl:` pair mirrors both, because "inline-start" is the right-hand
+           side in Hebrew and a chevron that ignored that would point at the
+           wrong edge of the screen. -->
+      <span
+        aria-hidden="true"
+        class="tes-icon tes-icon-chevron-down h-4 w-4"
+        :class="open ? '-rotate-90 rtl:rotate-90' : 'rotate-90 rtl:-rotate-90'"
+      />
+    </button>
+  </div>
+</template>

--- a/app/components/reader/ThirdPaneTabs.vue
+++ b/app/components/reader/ThirdPaneTabs.vue
@@ -1,0 +1,140 @@
+<script setup lang="ts">
+// The third pane's tablist: Inner Observation / Questions / Answers.
+//
+// It sits in the pane header where every other pane prints a single layer
+// title, because that is what it is — the third pane names three layers
+// instead of one, and the reader picks between them.
+//
+// Only the tabs the part actually HAS are rendered. Five parts have no
+// Inner Observation (Baal HaSulam wrote none — see `ReaderLayerAbsenceNote`),
+// and those parts get a two-tab pane rather than a tab that opens onto an
+// explanation. The explanation stays where it already was: the footnote in
+// the Source pane.
+//
+// Keyboard: ArrowLeft/ArrowRight move between tabs and activate as they go
+// (`aria-selected` follows focus), which is the pattern for a tablist whose
+// panels are cheap to show. Combined with the roving `tabindex` below, Tab
+// moves past the whole tablist rather than through each of its buttons.
+//
+// The handler sits on each tab, not on the `role="tablist"` container: only
+// a focusable element may carry key handling (the container is not one, and
+// `vuejs-accessibility/interactive-supports-focus` says so), and the tab is
+// where the focus actually is when the key is pressed.
+//
+// `dir="rtl"` is resolved through the element's own computed direction
+// rather than hardcoding left = previous: in Hebrew the visually-previous
+// tab is the one to the right.
+import type { ThirdPaneTab } from "~/composables/useReaderThirdPane";
+
+const props = defineProps<{
+  tabs: ThirdPaneTab[];
+  active: ThirdPaneTab;
+}>();
+
+const emit = defineEmits<{ select: [tab: ThirdPaneTab] }>();
+
+const { t } = useI18n();
+
+const LABEL_KEYS: Record<ThirdPaneTab, string> = {
+  "inner-observation": "reader.pane.innerObservation",
+  questions: "reader.pane.questions",
+  answers: "reader.pane.answers",
+};
+
+const tabId = (tab: ThirdPaneTab) => `reader-third-pane-tab-${tab}`;
+
+// Every other pane prints an <h2> naming its layer, and readers who
+// navigate by heading rely on that. Replacing this pane's heading with a
+// tablist would have quietly removed it from that list, so the heading
+// stays — visually hidden, since the tabs already say the same thing on
+// screen — and labels the tablist rather than repeating itself in an
+// `aria-label`.
+const HEADING_ID = "reader-third-pane-heading";
+
+// Named from static message keys rather than joined with `Intl.ListFormat`:
+// this string is server-rendered and then hydrated, and Node and the browser
+// carry independent ICU/CLDR versions — the exact trap that made
+// `NATIVE_LANGUAGE_NAMES` a fixed table instead of `Intl.DisplayNames`. A
+// conjunction that differed between the two would be a hydration mismatch in
+// the pane header.
+//
+// Two shapes occur in the corpus: every part has Questions and Answers
+// (issue #91 consolidated them to one chapter per kind), and eleven of the
+// sixteen also have Inner Observation. A single remaining tab falls back to
+// its own label so this can never name a tab the part does not have.
+const headingText = computed(() => {
+  if (props.tabs.length === 1)
+    return t(LABEL_KEYS[props.tabs[0] as ThirdPaneTab]);
+  return props.tabs.includes("inner-observation")
+    ? t("reader.pane.thirdPaneTablist")
+    : t("reader.pane.thirdPaneTablistQaOnly");
+});
+
+const rootRef = ref<HTMLElement | null>(null);
+
+const focusTab = (tab: ThirdPaneTab) => {
+  rootRef.value
+    ?.querySelector<HTMLButtonElement>(`#${CSS.escape(tabId(tab))}`)
+    ?.focus();
+};
+
+const onKeydown = (event: KeyboardEvent) => {
+  if (event.key !== "ArrowLeft" && event.key !== "ArrowRight") return;
+
+  // In an RTL pane, ArrowLeft means "the tab drawn to the left", which is
+  // the NEXT one in reading order. Resolve against the element's own
+  // computed direction so this follows the locale without a prop.
+  const rtl =
+    rootRef.value && getComputedStyle(rootRef.value).direction === "rtl";
+  const forward = rtl ? event.key === "ArrowLeft" : event.key === "ArrowRight";
+
+  const index = props.tabs.indexOf(props.active);
+  if (index === -1) return;
+
+  const next =
+    props.tabs[
+      (index + (forward ? 1 : -1) + props.tabs.length) % props.tabs.length
+    ];
+  if (!next) return;
+
+  event.preventDefault();
+  emit("select", next);
+  void nextTick(() => focusTab(next));
+};
+</script>
+
+<template>
+  <div class="flex flex-wrap items-center gap-1">
+    <h2 :id="HEADING_ID" class="sr-only">
+      {{ headingText }}
+    </h2>
+
+    <div
+      ref="rootRef"
+      role="tablist"
+      :aria-labelledby="HEADING_ID"
+      class="flex flex-wrap items-center gap-1"
+    >
+      <button
+        v-for="tab in tabs"
+        :id="tabId(tab)"
+        :key="tab"
+        type="button"
+        role="tab"
+        :aria-selected="tab === active"
+        :aria-controls="`reader-third-pane-panel-${tab}`"
+        :tabindex="tab === active ? 0 : -1"
+        class="tes-third-pane-tab"
+        :class="
+          tab === active
+            ? 'tes-third-pane-tab-active'
+            : 'text-(--text-muted) hover:text-(--text-primary)'
+        "
+        @click="emit('select', tab)"
+        @keydown="onKeydown"
+      >
+        {{ t(LABEL_KEYS[tab]) }}
+      </button>
+    </div>
+  </div>
+</template>

--- a/app/composables/useChapterContent.ts
+++ b/app/composables/useChapterContent.ts
@@ -25,7 +25,7 @@
  *
  * Only loads the `source`/`commentary` layers — the reader no longer has a
  * summary pane (the layer is effectively dead: exactly 1 file exists across
- * the whole corpus) and `useInnerObservationContent` covers the part-scoped
+ * the whole corpus) and `usePartScopedSections` covers the part-scoped
  * Inner Observation reference pane separately, so nothing here needs the
  * `summary` layer any more. `loadLayerFile` is exported for that composable
  * to reuse — same per-part lazy chunk maps, not a second set of

--- a/app/composables/usePartScopedSections.ts
+++ b/app/composables/usePartScopedSections.ts
@@ -66,7 +66,7 @@ import type {
   TocChapter,
 } from "~~/shared/types/content";
 
-export interface InnerObservationSection {
+export interface PartScopedSection {
   chapterId: string;
   title: TocChapter["title"];
   itemsByVersion: Record<string, ChapterLayerFile<SourceSegment> | null>;
@@ -78,21 +78,19 @@ export interface InnerObservationSection {
  * never to be shown as "none available"). Parts with no Inner Observation
  * chapters start, and stay, `"ready"`.
  */
-export type InnerObservationLoadState = "pending" | "ready" | "failed";
+export type PartSectionsLoadState = "pending" | "ready" | "failed";
 
 export interface InnerObservationContent {
   /** Union of every section's available source versions, first-seen order. */
   versions: ComputedRef<string[]>;
   /** Empty until the bodies have loaded in the browser — see the module doc. */
-  sections: ComputedRef<InnerObservationSection[]>;
+  sections: ComputedRef<PartScopedSection[]>;
   /** Lets the pane tell "not loaded yet" and "load failed" from "genuinely empty". */
-  state: ComputedRef<InnerObservationLoadState>;
+  state: ComputedRef<PartSectionsLoadState>;
 }
 
 /** Union of the source versions the ToC lists for these chapters, first-seen order. */
-export const innerObservationVersionIds = (
-  chapters: TocChapter[],
-): string[] => {
+export const partScopedVersionIds = (chapters: TocChapter[]): string[] => {
   const versionIds: string[] = [];
   for (const chapter of chapters) {
     for (const versionId of chapter.availableVersions.source) {
@@ -105,7 +103,7 @@ export const innerObservationVersionIds = (
 const loadSections = async (
   partId: string,
   chapters: TocChapter[],
-): Promise<InnerObservationSection[]> =>
+): Promise<PartScopedSection[]> =>
   await Promise.all(
     chapters.map(async (chapter) => {
       const chapterSlug = chapter.id.split("/")[1] as string;
@@ -130,31 +128,40 @@ const loadSections = async (
     }),
   );
 
-// One in-flight/settled load per part, shared by every chapter page of that
-// part: moving to `onMounted` means the page remounts (`key: route.fullPath`)
-// on every chapter navigation, and without this each one would re-walk the
-// part's loader map and re-await ten already-imported modules on every
-// chapter step within a part whose Inner Observation is, by definition,
-// unchanged. It does not skip the skeleton — `state` still starts
-// `"pending"` on each remount and is only settled from inside the mounted
-// handler — it just makes that skeleton resolve in a microtask off an
-// already-settled promise rather than after a fresh walk, so no skeleton
-// frame reaches the screen. A rejected load is evicted so a failure isn't
-// cached forever — the part's next chapter re-attempts it.
-const sectionsByPart = new Map<string, Promise<InnerObservationSection[]>>();
+// One in-flight/settled load per part AND chapter set, shared by every
+// chapter page of that part: moving to `onMounted` means the page remounts
+// (`key: route.fullPath`) on every chapter navigation, and without this each
+// one would re-walk the part's loader map and re-await ten already-imported
+// modules on every chapter step within a part whose part-scoped sections
+// are, by definition, unchanged. It does not skip the skeleton — `state`
+// still starts `"pending"` on each remount and is only settled from inside
+// the mounted handler — it just makes that skeleton resolve in a microtask
+// off an already-settled promise rather than after a fresh walk, so no
+// skeleton frame reaches the screen. A rejected load is evicted so a failure
+// isn't cached forever — the part's next chapter re-attempts it.
+//
+// Keyed by the chapter ids, not by `partId` alone: the third pane calls this
+// three times for the SAME part (Inner Observation, Questions, Answers), and
+// a part-only key would hand the second and third callers the first one's
+// essays.
+const sectionsByKey = new Map<string, Promise<PartScopedSection[]>>();
+
+const cacheKeyFor = (partId: string, chapters: TocChapter[]): string =>
+  `${partId}|${chapters.map((chapter) => chapter.id).join(",")}`;
 
 const loadPartSections = (
   partId: string,
   chapters: TocChapter[],
-): Promise<InnerObservationSection[]> => {
-  const cached = sectionsByPart.get(partId);
+): Promise<PartScopedSection[]> => {
+  const key = cacheKeyFor(partId, chapters);
+  const cached = sectionsByKey.get(key);
   if (cached) return cached;
 
   const pending = loadSections(partId, chapters).catch((error: unknown) => {
-    sectionsByPart.delete(partId);
+    sectionsByKey.delete(key);
     throw error;
   });
-  sectionsByPart.set(partId, pending);
+  sectionsByKey.set(key, pending);
   return pending;
 };
 
@@ -179,18 +186,16 @@ const loadPartSections = (
  * pre-mount mode ("panes") and load on every viewport. The watch below makes
  * that a lost optimisation rather than a bug.
  */
-export const useInnerObservationContent = (
+export const usePartScopedSections = (
   partId: string,
   chapters: TocChapter[],
   enabled: () => boolean = () => true,
 ): InnerObservationContent => {
-  const versionIds = innerObservationVersionIds(chapters);
+  const versionIds = partScopedVersionIds(chapters);
   const hasChapters = chapters.length > 0;
 
-  const sections = shallowRef<InnerObservationSection[]>([]);
-  const state = ref<InnerObservationLoadState>(
-    hasChapters ? "pending" : "ready",
-  );
+  const sections = shallowRef<PartScopedSection[]>([]);
+  const state = ref<PartSectionsLoadState>(hasChapters ? "pending" : "ready");
 
   const load = async () => {
     state.value = "pending";

--- a/app/composables/useReaderThirdPane.ts
+++ b/app/composables/useReaderThirdPane.ts
@@ -1,0 +1,143 @@
+/**
+ * The third pane's two pieces of reader-owned state: whether it is open on
+ * desktop, and which of its tabs is showing.
+ *
+ * **Why it collapses at all.** Panes mode used to be a fixed three-column
+ * grid (`0.8fr 1.1fr 1.1fr`), so Inner Light — the layer read straight
+ * through — permanently shared the viewport with reference material that is
+ * consulted occasionally. Closing the third pane hands that width back.
+ *
+ * **Why it pushes rather than floats.** Same reasoning that settled the
+ * mobile chrome in issue 113: a *deliberate tap* is allowed to reflow the
+ * page, so the pane can stay in normal flow and simply stop rendering. That
+ * is one grid-template change and one boolean, against the measured
+ * absolute positioning an overlay would need — and the first attempt at
+ * overlaying reader chrome (PR 114) was reverted for exactly that
+ * complexity. A floating panel would also be wrong on its own terms here:
+ * it would cover the end of the Inner Light column mid-read.
+ *
+ * **Why `display: none` and not `v-if`.** The third pane is the same DOM
+ * node as the mobile swipe track's third slide (see `MobileSwipePanes` for
+ * why the two layouts deliberately share one set of slot instances). A
+ * `v-if` would unmount it, taking its scroll position — and, crossing the
+ * `lg` breakpoint, remounting it on every viewport change. Closing hides it
+ * at `lg:` only; below `lg` it is always the third slide, tabs and all.
+ *
+ * Both values are persisted for the same reason `useCollapsedReaderChrome`
+ * persists its boolean: these are preferences, not gestures. Someone who
+ * wants the width should get it on every chapter, and someone consulting
+ * the Questions tab should still be on it after turning the page.
+ *
+ * Provide/inject singleton, same shape as `useCollapsedReaderChrome` — the
+ * rail owns the toggle and the pane reads the tab, and they are not in each
+ * other's subtree.
+ */
+import { useLocalStorage } from "@vueuse/core";
+import type { ComputedRef, InjectionKey } from "vue";
+
+export const THIRD_PANE_TABS = [
+  "inner-observation",
+  "questions",
+  "answers",
+] as const;
+
+export type ThirdPaneTab = (typeof THIRD_PANE_TABS)[number];
+
+const OPEN_STORAGE_KEY = "readtes:reader-third-pane-open";
+const TAB_STORAGE_KEY = "readtes:reader-third-pane-tab";
+
+/**
+ * Open by default: the pane is what the reader had before this became
+ * collapsible, and a reader who has never touched the control should not
+ * have to discover it to find Inner Observation where it has always been.
+ */
+const DEFAULT_OPEN = true;
+
+export interface ReaderThirdPane {
+  open: ComputedRef<boolean>;
+  toggle: () => void;
+  /**
+   * The persisted tab, which is NOT necessarily one this chapter's part
+   * offers — five parts have no Inner Observation. Callers resolve it
+   * against the tabs actually available via `resolveThirdPaneTab`.
+   */
+  tab: ComputedRef<ThirdPaneTab>;
+  setTab: (tab: ThirdPaneTab) => void;
+}
+
+const READER_THIRD_PANE_KEY: InjectionKey<ReaderThirdPane> =
+  Symbol("reader-third-pane");
+
+const isThirdPaneTab = (value: unknown): value is ThirdPaneTab =>
+  THIRD_PANE_TABS.includes(value as ThirdPaneTab);
+
+/**
+ * The tab to actually show: the reader's persisted choice when this part
+ * offers it, otherwise the first tab it does offer.
+ *
+ * Kept a pure function, and separate from the persisted value, so that
+ * landing on a part with no Inner Observation shows Questions *without*
+ * overwriting a reader's standing preference — they get Inner Observation
+ * back on the next part that has one.
+ */
+export const resolveThirdPaneTab = (
+  preferred: ThirdPaneTab,
+  available: ThirdPaneTab[],
+): ThirdPaneTab | null => {
+  if (available.length === 0) return null;
+  return available.includes(preferred)
+    ? preferred
+    : (available[0] as ThirdPaneTab);
+};
+
+const createReaderThirdPane = (): ReaderThirdPane => {
+  const persistedOpen = useLocalStorage<boolean>(
+    OPEN_STORAGE_KEY,
+    DEFAULT_OPEN,
+  );
+  const persistedTab = useLocalStorage<string>(
+    TAB_STORAGE_KEY,
+    THIRD_PANE_TABS[0],
+  );
+
+  // Gates the persisted read until after mount, same reason as
+  // `useCollapsedReaderChrome`/`useReadingPreferences`: prerendering has no
+  // `localStorage`, so consulting it during the first client render would
+  // diverge from the prerendered HTML and fail hydration.
+  const hydrated = ref(false);
+  onMounted(() => {
+    hydrated.value = true;
+  });
+
+  const open = computed(() =>
+    hydrated.value ? persistedOpen.value : DEFAULT_OPEN,
+  );
+
+  const tab = computed<ThirdPaneTab>(() => {
+    if (!hydrated.value) return THIRD_PANE_TABS[0];
+    // A hand-edited or stale `localStorage` value must not put the pane in
+    // a state no tab matches.
+    return isThirdPaneTab(persistedTab.value)
+      ? persistedTab.value
+      : THIRD_PANE_TABS[0];
+  });
+
+  const toggle = () => {
+    persistedOpen.value = !open.value;
+  };
+
+  const setTab = (next: ThirdPaneTab) => {
+    persistedTab.value = next;
+  };
+
+  return { open, toggle, tab, setTab };
+};
+
+export const useReaderThirdPane = (): ReaderThirdPane => {
+  const existing = inject(READER_THIRD_PANE_KEY, null);
+  if (existing) return existing;
+
+  const state = createReaderThirdPane();
+  provide(READER_THIRD_PANE_KEY, state);
+  return state;
+};

--- a/app/composables/useThirdPaneTabContent.ts
+++ b/app/composables/useThirdPaneTabContent.ts
@@ -1,0 +1,143 @@
+/**
+ * Content for the third pane's three tabs — Inner Observation, Questions,
+ * Answers — resolved down to whatever the active tab needs to render.
+ *
+ * All three are part-scoped in the same way (see `usePartScopedSections`):
+ * they are not per-chapter layer files, they are other chapters of the same
+ * part, identical no matter which chapter is open. That shared shape is why
+ * one composable serves all three rather than the page growing three copies
+ * of the same forty lines.
+ *
+ * **One language for the pane, not one per tab.** The reader's per-pane
+ * control chooses a *language*, never an edition (that decision is why
+ * `resolveVersionForLanguage` exists at all) — and the third pane is one
+ * pane. So a single language preference is resolved against whichever tab
+ * is showing, which means switching tabs keeps you in the language you were
+ * reading and does not silently drop you into another.
+ *
+ * **Only the active tab is fetched.** `usePartScopedSections` must be called
+ * unconditionally — it is a composable — so all three calls are made, each
+ * with an `enabled` gate that is true only for the tab actually being
+ * shown. A reader who never opens Questions never downloads it, and the
+ * previous behaviour for Inner Observation (fetched whenever panes mode was
+ * active) becomes strictly narrower rather than wider.
+ */
+import type { ComputedRef, Ref } from "vue";
+import type { InnerObservationSectionView } from "~/components/reader/InnerObservationPane.vue";
+import type { PartSectionsLoadState } from "~/composables/usePartScopedSections";
+import { usePartScopedSections } from "~/composables/usePartScopedSections";
+import type { ThirdPaneTab } from "~/composables/useReaderThirdPane";
+import type { VersionsById } from "~/utils/readerVersions";
+import type { ContentVersion, TocChapter } from "~~/shared/types/content";
+
+export interface ThirdPaneTabChapters {
+  innerObservation: TocChapter[];
+  questions: TocChapter[];
+  answers: TocChapter[];
+}
+
+export interface ThirdPaneTabContent {
+  /** Language codes offered for the active tab. */
+  languageOptions: ComputedRef<string[]>;
+  language: Ref<string | null>;
+  /** Version metadata for the active tab, for the provenance badge and `dir`. */
+  meta: ComputedRef<ContentVersion | null>;
+  sections: ComputedRef<InnerObservationSectionView[]>;
+  state: ComputedRef<PartSectionsLoadState>;
+}
+
+export const useThirdPaneTabContent = (
+  partId: string,
+  chapters: ThirdPaneTabChapters,
+  activeTab: ComputedRef<ThirdPaneTab | null>,
+  enabled: () => boolean,
+  versionsById: ComputedRef<VersionsById>,
+  locale: Ref<string> | ComputedRef<string>,
+): ThirdPaneTabContent => {
+  const gateFor = (tab: ThirdPaneTab) => () =>
+    enabled() && activeTab.value === tab;
+
+  const innerObservation = usePartScopedSections(
+    partId,
+    chapters.innerObservation,
+    gateFor("inner-observation"),
+  );
+  const questions = usePartScopedSections(
+    partId,
+    chapters.questions,
+    gateFor("questions"),
+  );
+  const answers = usePartScopedSections(
+    partId,
+    chapters.answers,
+    gateFor("answers"),
+  );
+
+  const active = computed(() => {
+    if (activeTab.value === "questions") return questions;
+    if (activeTab.value === "answers") return answers;
+    return innerObservation;
+  });
+
+  const versionIds = computed(() => active.value.versions.value);
+
+  const languageOptions = computed(() =>
+    paneLanguageOptions(versionIds.value, locale.value, versionsById.value),
+  );
+
+  // Not persisted across chapters, same as the pane's language always was:
+  // it re-resolves from the locale whenever the available versions change,
+  // and only holds a reader's explicit pick for as long as that pick is
+  // still offered.
+  const language = ref<string | null>(null);
+  watch(
+    versionIds,
+    (ids) => {
+      if (
+        language.value &&
+        resolveVersionForLanguage(ids, language.value, versionsById.value)
+      ) {
+        return;
+      }
+      language.value = resolveDefaultLanguage(
+        ids,
+        locale.value,
+        versionsById.value,
+      );
+    },
+    { immediate: true },
+  );
+
+  const versionId = computed(() =>
+    language.value
+      ? resolveVersionForLanguage(
+          versionIds.value,
+          language.value,
+          versionsById.value,
+        )
+      : null,
+  );
+
+  const meta = computed(() =>
+    versionId.value ? (versionsById.value.get(versionId.value) ?? null) : null,
+  );
+
+  const sections = computed<InnerObservationSectionView[]>(() =>
+    active.value.sections.value
+      .map((section) => ({
+        chapterId: section.chapterId,
+        title: section.title,
+        items: versionId.value
+          ? (section.itemsByVersion[versionId.value]?.items ?? [])
+          : [],
+      }))
+      // A section whose *selected* version has no items would render as a
+      // bare heading with nothing under it — drop it; the sections that do
+      // have text in this version carry the tab.
+      .filter((section) => section.items.length > 0),
+  );
+
+  const state = computed(() => active.value.state.value);
+
+  return { languageOptions, language, meta, sections, state };
+};

--- a/app/pages/read/[part]/[chapter].vue
+++ b/app/pages/read/[part]/[chapter].vue
@@ -2,7 +2,7 @@
 // The reader: Source | Inner Light | Inner Observation for one chapter (two
 // panes when the part has no Inner Observation — see below), with two-way
 // anchor sync between Source and Inner Light. Inner Observation is
-// part-scoped and never anchor-synced — see `useInnerObservationContent`.
+// part-scoped and never anchor-synced — see `usePartScopedSections`.
 // Resolves the chapter from its part's `content/toc.parts/<partId>.json` by
 // route params — an unknown part or chapter 404s, the same way
 // `/volumes/[volume]` does.
@@ -79,7 +79,6 @@ const innerObservationChapters = innerObservationChaptersInPart(
   partFile.chapters,
 );
 const hasInnerObservation = innerObservationChapters.length > 0;
-const panes = resolveReaderPanes({ hasCommentary, hasInnerObservation });
 
 const readerLanguages = useReaderLanguages(chapter, versions.value);
 // Study mode below `lg`, panes at/above it by default — original is an
@@ -92,7 +91,7 @@ const { mode } = useReaderMode();
 // Deliberately not awaited and deliberately not server-rendered: the bodies
 // load in the browser, from the part's own content chunks, once per part
 // rather than being inlined into every chapter page's HTML — see
-// `useInnerObservationContent`. Only `versions` (ToC-derived, so identical
+// `usePartScopedSections`. Only `versions` (ToC-derived, so identical
 // on both sides of hydration) is available during prerendering.
 //
 // The gate reads `mode`, which only resolves to the real viewport once
@@ -106,16 +105,61 @@ const { mode } = useReaderMode();
 // Panes mode is the only one of the three that renders an Inner Observation
 // pane at all, so on a phone (study by default) this gate is the difference
 // between fetching the part's whole essay set and fetching none of it.
-const {
-  versions: innerObservationVersions,
-  sections: innerObservationRawSections,
-  state: innerObservationState,
-} = useInnerObservationContent(
-  partId,
-  innerObservationChapters,
-  () => mode.value === "panes",
-);
 const versionsById = computed(() => buildVersionsById(versions.value));
+
+// The third pane's own state: collapsed-or-not (desktop) and which tab.
+// Both persisted — see `useReaderThirdPane` for why it pushes the columns
+// rather than floating over them.
+const { tab: preferredThirdPaneTab, setTab: setThirdPaneTab } =
+  useReaderThirdPane();
+
+const thirdPaneChapters = {
+  innerObservation: innerObservationChapters,
+  questions: questionsChaptersInPart(partFile.chapters),
+  answers: answersChaptersInPart(partFile.chapters),
+};
+
+// Static for the page: the part's chapter list does not change under it,
+// and `panes` below is resolved once at setup from the same fact. Inner
+// Observation leads when it exists — it is the layer this pane has always
+// been, and the one the printed book pairs with the text.
+const availableThirdPaneTabs: ThirdPaneTab[] = [
+  ...(thirdPaneChapters.innerObservation.length > 0
+    ? (["inner-observation"] as const)
+    : []),
+  ...(thirdPaneChapters.questions.length > 0 ? (["questions"] as const) : []),
+  ...(thirdPaneChapters.answers.length > 0 ? (["answers"] as const) : []),
+];
+
+// The persisted tab is a standing preference, not a per-part fact: on a
+// part with no Inner Observation this falls through to Questions WITHOUT
+// overwriting the preference, so the reader gets Inner Observation back on
+// the next part that has one.
+const activeThirdPaneTab = computed(() =>
+  resolveThirdPaneTab(preferredThirdPaneTab.value, availableThirdPaneTabs),
+);
+
+const panes = resolveReaderPanes({
+  hasCommentary,
+  hasThirdPane: availableThirdPaneTabs.length > 0,
+});
+
+// The mobile pill names the third pane. It is space-constrained chrome, so
+// it takes the short form ("Q & A") where the pane's own heading takes the
+// full one — but it must never name a part after Inner Observation when
+// that part has none.
+const thirdPaneLabelKey = availableThirdPaneTabs.includes("inner-observation")
+  ? "reader.mobilePane.innerObservation"
+  : "reader.mobilePane.questionsAnswers";
+
+const thirdPane = useThirdPaneTabContent(
+  partId,
+  thirdPaneChapters,
+  activeThirdPaneTab,
+  () => mode.value === "panes",
+  versionsById,
+  locale,
+);
 
 const sourceLanguageOptions = computed(() =>
   paneLanguageOptions(sourceVersions.value, locale.value, versionsById.value),
@@ -127,14 +171,6 @@ const commentaryLanguageOptions = computed(() =>
     versionsById.value,
   ),
 );
-const innerObservationLanguageOptions = computed(() =>
-  paneLanguageOptions(
-    innerObservationVersions.value,
-    locale.value,
-    versionsById.value,
-  ),
-);
-
 const metaFor = (versionId: string | null) =>
   versionId ? (versionsById.value.get(versionId) ?? null) : null;
 
@@ -157,64 +193,6 @@ const commentaryFile = computed(() =>
 
 const sourceSegments = computed(() => sourceFile.value?.items ?? []);
 const commentaryItems = computed(() => commentaryFile.value?.items ?? []);
-
-// Inner Observation has no persisted language preference of its own
-// (unlike source/commentary via `useReaderLanguages`) — there's exactly
-// one pane for it, so nothing needs remembering across chapters; it just
-// follows the same default rule, recomputed whenever the part's available
-// versions load.
-const innerObservationLanguage = ref<string | null>(null);
-watch(
-  innerObservationVersions,
-  (ids) => {
-    if (
-      innerObservationLanguage.value &&
-      resolveVersionForLanguage(
-        ids,
-        innerObservationLanguage.value,
-        versionsById.value,
-      )
-    ) {
-      return;
-    }
-    innerObservationLanguage.value = resolveDefaultLanguage(
-      ids,
-      locale.value,
-      versionsById.value,
-    );
-  },
-  { immediate: true },
-);
-
-const innerObservationVersion = computed(() =>
-  innerObservationLanguage.value
-    ? resolveVersionForLanguage(
-        innerObservationVersions.value,
-        innerObservationLanguage.value,
-        versionsById.value,
-      )
-    : null,
-);
-
-const innerObservationMeta = computed(() =>
-  metaFor(innerObservationVersion.value),
-);
-const innerObservationSections = computed(() =>
-  innerObservationRawSections.value
-    .map((section) => ({
-      chapterId: section.chapterId,
-      title: section.title,
-      items: innerObservationVersion.value
-        ? (section.itemsByVersion[innerObservationVersion.value]?.items ?? [])
-        : [],
-    }))
-    // A section whose *selected* version has no items would render as a
-    // bare heading with nothing under it — drop it; the sections that do
-    // have text in this version carry the pane. (If none do, the pane
-    // falls back to `innerObservationEmpty` — the honest wording there,
-    // since this pane only renders for parts that do have one.)
-    .filter((section) => section.items.length > 0),
-);
 
 const { prev, next } = prevNextChapterLinks(volumes.value, partFile, chapterId);
 
@@ -337,7 +315,11 @@ useLocalizedSeo({
 
 <template>
   <div class="contents">
-    <ReaderShell v-if="mode === 'panes'" :panes="panes">
+    <ReaderShell
+      v-if="mode === 'panes'"
+      :panes="panes"
+      :third-pane-label-key="thirdPaneLabelKey"
+    >
       <template #toolbar>
         <ReaderToolbar
           :chapter-title="chapterTitle"
@@ -405,21 +387,40 @@ useLocalizedSeo({
         </ReaderPane>
       </template>
 
-      <template v-if="hasInnerObservation" #inner-observation>
+      <template v-if="availableThirdPaneTabs.length > 0" #inner-observation>
         <ReaderPane
           :title="t('reader.pane.innerObservation')"
-          :language-options="innerObservationLanguageOptions"
-          :model-value="innerObservationLanguage"
-          :meta="innerObservationMeta"
+          :language-options="thirdPane.languageOptions.value"
+          :model-value="thirdPane.language.value"
+          :meta="thirdPane.meta.value"
           @update:model-value="
-            (language) => (innerObservationLanguage = language)
+            (language) => (thirdPane.language.value = language)
           "
         >
-          <ReaderInnerObservationPane
-            :sections="innerObservationSections"
-            :state="innerObservationState"
-            @reload="reloadNuxtApp({ force: true })"
-          />
+          <!-- The tablist stands in for the single layer title every other
+               pane prints — this pane names three layers, so the reader
+               picks between them from the heading position. -->
+          <template #title>
+            <ReaderThirdPaneTabs
+              v-if="activeThirdPaneTab"
+              :tabs="availableThirdPaneTabs"
+              :active="activeThirdPaneTab"
+              @select="setThirdPaneTab"
+            />
+          </template>
+
+          <div
+            v-if="activeThirdPaneTab"
+            :id="`reader-third-pane-panel-${activeThirdPaneTab}`"
+            role="tabpanel"
+            :aria-labelledby="`reader-third-pane-tab-${activeThirdPaneTab}`"
+          >
+            <ReaderInnerObservationPane
+              :sections="thirdPane.sections.value"
+              :state="thirdPane.state.value"
+              @reload="reloadNuxtApp({ force: true })"
+            />
+          </div>
         </ReaderPane>
       </template>
     </ReaderShell>

--- a/app/utils/content-loaders/index.ts
+++ b/app/utils/content-loaders/index.ts
@@ -9,7 +9,7 @@
  *
  * Resolved modules are cached in `resolvedModules` keyed by `partId` so
  * loading a second chapter from the same part (the common case — a reader
- * page's own part, then `useInnerObservationContent`'s part-scoped pane)
+ * page's own part, then `usePartScopedSections`'s part-scoped pane)
  * doesn't re-run `import()` for a module already resolved.
  */
 type PartContentModules = Record<string, () => Promise<{ default: unknown }>>;

--- a/app/utils/readerAnchorState.ts
+++ b/app/utils/readerAnchorState.ts
@@ -7,7 +7,7 @@
 /**
  * The reader panes an anchor can originate from / target. Only "source" and
  * "commentary" ever actually activate an anchor — Inner Observation carries
- * no anchors at all (see `useInnerObservationContent`) — but it still needs
+ * no anchors at all (see `usePartScopedSections`) — but it still needs
  * a `PaneId` of its own so it counts as a swipeable slide in mobile panes
  * mode (`~/utils/mobilePaneSync`).
  */

--- a/app/utils/readerPanes.ts
+++ b/app/utils/readerPanes.ts
@@ -24,17 +24,34 @@ import type { PaneId } from "~/utils/readerAnchorState";
 export interface ReaderPaneAvailability {
   /** The chapter has at least one commentary (Inner Light) version. */
   hasCommentary: boolean;
-  /** The chapter's part has `kind: "inner-observation"` chapters. */
-  hasInnerObservation: boolean;
+  /**
+   * The chapter's part has content for at least one of the third pane's
+   * tabs — Inner Observation, Questions, or Answers.
+   *
+   * This used to be `hasInnerObservation` alone, and the pane vanished for
+   * the five parts Baal HaSulam wrote no Inner Observation for. Since the
+   * pane became tabbed, every part has Questions and Answers (issue #91
+   * consolidated them to one chapter per kind), so in practice this is now
+   * always true — it stays a parameter rather than becoming an assumption
+   * because "every part has a Q&A table" is a fact about the corpus, not
+   * about the layout, and the layout should not silently break if a future
+   * part arrives without one.
+   *
+   * The absence of Inner Observation specifically is still told to the
+   * reader, unchanged, by `ReaderLayerAbsenceNote` in the Source pane —
+   * those parts simply get a two-tab third pane rather than a tab that
+   * opens onto an apology.
+   */
+  hasThirdPane: boolean;
 }
 
 export const resolveReaderPanes = ({
   hasCommentary,
-  hasInnerObservation,
+  hasThirdPane,
 }: ReaderPaneAvailability): PaneId[] =>
   PANE_ORDER.filter(
     (pane) =>
       pane === "source" ||
       (pane === "commentary" && hasCommentary) ||
-      (pane === "inner-observation" && hasInnerObservation),
+      (pane === "inner-observation" && hasThirdPane),
   );

--- a/app/utils/toc.ts
+++ b/app/utils/toc.ts
@@ -11,6 +11,7 @@
  * per-volume-skeleton/per-part shapes instead.
  */
 import type {
+  ChapterKind,
   TocChapter,
   TocPartFile,
   TocPartSkeleton,
@@ -56,7 +57,7 @@ export const findChapterInPart = (
  * Inner Observation pane/mobile slide: absent entirely for five parts (5,
  * 11, 14, 15, 16 — confirmed against KabbalahMedia's own source, not a gap
  * in our import), present but never chapter-scoped for the rest — see
- * `useInnerObservationContent`.
+ * `usePartScopedSections`.
  */
 export const innerObservationChaptersInPart = (
   chapters: TocChapter[],
@@ -64,6 +65,53 @@ export const innerObservationChaptersInPart = (
   chapters
     .filter((chapter) => chapter.kind === "inner-observation")
     .sort((a, b) => a.number - b.number);
+
+/**
+ * The kinds behind the third pane's Questions and Answers tabs, in the order
+ * the printed book asks them: terminology first, then topics, then part 6's
+ * Cause and Effect (the only part that has one).
+ *
+ * Listed explicitly rather than matched on a `questions-`/`answers-` prefix:
+ * `ChapterKind` is a closed enum, and a prefix test would silently adopt any
+ * future kind that happened to start with the same word into a reader pane
+ * nobody had decided it belonged in.
+ */
+const QUESTION_KINDS: ChapterKind[] = [
+  "questions-terminology",
+  "questions-topics",
+  "questions-cause-effect",
+];
+
+const ANSWER_KINDS: ChapterKind[] = [
+  "answers-terminology",
+  "answers-topics",
+  "answers-cause-effect",
+];
+
+const chaptersOfKinds = (
+  chapters: TocChapter[],
+  kinds: ChapterKind[],
+): TocChapter[] =>
+  chapters
+    .filter((chapter) => kinds.includes(chapter.kind))
+    .sort(
+      (a, b) =>
+        kinds.indexOf(a.kind) - kinds.indexOf(b.kind) || a.number - b.number,
+    );
+
+/**
+ * A part's question chapters, for the third pane's Questions tab.
+ *
+ * Every one of the 16 parts has these (issue #91 consolidated them to one
+ * chapter per kind), which is what lets the third pane exist even for the
+ * five parts with no Inner Observation at all.
+ */
+export const questionsChaptersInPart = (chapters: TocChapter[]): TocChapter[] =>
+  chaptersOfKinds(chapters, QUESTION_KINDS);
+
+/** A part's answer chapters, for the third pane's Answers tab. */
+export const answersChaptersInPart = (chapters: TocChapter[]): TocChapter[] =>
+  chaptersOfKinds(chapters, ANSWER_KINDS);
 
 /** Original mode's Prev/Next pagination position within a part. */
 export interface PartPaginationPosition {

--- a/i18n/locales/en.json
+++ b/i18n/locales/en.json
@@ -33,7 +33,11 @@
     "pane": {
       "source": "The Ari's Text",
       "innerLight": "Inner Light",
-      "innerObservation": "Inner Observation"
+      "innerObservation": "Inner Observation",
+      "questions": "Questions",
+      "answers": "Answers",
+      "thirdPaneTablist": "Inner Observation, Questions, and Answers",
+      "thirdPaneTablistQaOnly": "Questions and Answers"
     },
     "paneLanguageLabel": "Language: {pane}",
     "sefariaTranslated": "Sefaria translation",
@@ -101,7 +105,8 @@
       "label": "Reader pane",
       "source": "The Ari's Text",
       "innerLight": "Inner Light",
-      "innerObservation": "Inner Observation"
+      "innerObservation": "Inner Observation",
+      "questionsAnswers": "Q & A"
     },
     "commentarySheet": {
       "title": "Commentary on seif {n}",
@@ -129,6 +134,10 @@
       "language": {
         "label": "Language"
       }
+    },
+    "thirdPane": {
+      "collapse": "Hide the Inner Observation pane",
+      "expand": "Show the Inner Observation pane"
     }
   },
   "home": {

--- a/i18n/locales/he.json
+++ b/i18n/locales/he.json
@@ -33,7 +33,11 @@
     "pane": {
       "source": "כתבי האר״י",
       "innerLight": "אור פנימי",
-      "innerObservation": "הסתכלות פנימית"
+      "innerObservation": "הסתכלות פנימית",
+      "questions": "שאלות",
+      "answers": "תשובות",
+      "thirdPaneTablist": "הסתכלות פנימית, שאלות ותשובות",
+      "thirdPaneTablistQaOnly": "שאלות ותשובות"
     },
     "paneLanguageLabel": "שפה: {pane}",
     "sefariaTranslated": "תרגום ספריא",
@@ -101,7 +105,8 @@
       "label": "חלונית הקורא",
       "source": "כתבי האר״י",
       "innerLight": "אור פנימי",
-      "innerObservation": "הסתכלות פנימית"
+      "innerObservation": "הסתכלות פנימית",
+      "questionsAnswers": "שאלות ותשובות"
     },
     "commentarySheet": {
       "title": "פירוש על סעיף {n}",
@@ -129,6 +134,10 @@
       "language": {
         "label": "שפה"
       }
+    },
+    "thirdPane": {
+      "collapse": "הסתרת חלונית ההסתכלות הפנימית",
+      "expand": "הצגת חלונית ההסתכלות הפנימית"
     }
   },
   "home": {

--- a/tests/e2e/reader.spec.ts
+++ b/tests/e2e/reader.spec.ts
@@ -40,11 +40,20 @@ test("serves the aligned English reader and synchronizes Ari anchors", async ({
       .getByRole("heading", { name: "Inner Light", exact: true })
       .first(),
   ).toBeVisible();
+  // The third pane names three layers, so its heading is the tablist's
+  // (screen-reader-only) label and the visible title is the selected tab.
   await expect(
-    innerObservation
-      .getByRole("heading", { name: "Inner Observation", exact: true })
-      .first(),
-  ).toBeVisible();
+    innerObservation.getByRole("heading", {
+      name: "Inner Observation, Questions, and Answers",
+      exact: true,
+    }),
+  ).toBeAttached();
+  await expect(
+    innerObservation.getByRole("tab", {
+      name: "Inner Observation",
+      exact: true,
+    }),
+  ).toHaveAttribute("aria-selected", "true");
   await expect(source.locator("li[data-seif]").first()).toContainText(
     "emanated beings",
   );
@@ -124,11 +133,16 @@ test("serves the Hebrew reader with RTL panes", async ({ page }) => {
       .first(),
   ).toBeVisible();
   await expect(
+    page.locator("#reader-inner-observation-pane").getByRole("heading", {
+      name: "הסתכלות פנימית, שאלות ותשובות",
+      exact: true,
+    }),
+  ).toBeAttached();
+  await expect(
     page
       .locator("#reader-inner-observation-pane")
-      .getByRole("heading", { name: "הסתכלות פנימית", exact: true })
-      .first(),
-  ).toBeVisible();
+      .getByRole("tab", { name: "הסתכלות פנימית", exact: true }),
+  ).toHaveAttribute("aria-selected", "true");
 });
 
 test.describe("Q&A cross-references (issue #91)", () => {

--- a/tests/unit/inner-observation-not-prerendered.spec.ts
+++ b/tests/unit/inner-observation-not-prerendered.spec.ts
@@ -81,11 +81,11 @@ const InnerObservationSubtree = defineComponent({
   // `async setup` + `await` on purpose, even though the composable is
   // synchronous: `await` on a non-promise is a no-op, but if the composable
   // ever goes back to resolving the bodies in setup (its shape before this
-  // change — the page did `await useInnerObservationContent(...)` from its
+  // change — the page did `await usePartScopedSections(...)` from its
   // own `<script setup>`) the server render will wait for them and the
   // assertions below will see the essays in the HTML.
   async setup() {
-    const { sections, state } = await useInnerObservationContent(
+    const { sections, state } = await usePartScopedSections(
       PART_ID,
       innerObservationChapters,
     );
@@ -123,7 +123,7 @@ describe("guardrail: Inner Observation essays are never server-rendered", () => 
     expect(html).toContain('data-state="pending"');
   });
 
-  it("never awaits useInnerObservationContent in the chapter page", () => {
+  it("never awaits usePartScopedSections in the chapter page", () => {
     const page = readFileSync(
       join(process.cwd(), "app/pages/read/[part]/[chapter].vue"),
       "utf-8",
@@ -132,7 +132,7 @@ describe("guardrail: Inner Observation essays are never server-rendered", () => 
     // Awaiting it again would only reintroduce SSR'd bodies if the composable
     // also went back to loading in setup, but the two always regressed
     // together and the `await` is the visible half.
-    expect(page).not.toMatch(/await\s+useInnerObservationContent\s*\(/);
+    expect(page).not.toMatch(/await\s+usePartScopedSections\s*\(/);
   });
 });
 

--- a/tests/unit/inner-observation-pane.spec.ts
+++ b/tests/unit/inner-observation-pane.spec.ts
@@ -61,7 +61,7 @@ describe("InnerObservationPane", () => {
     expect(wrapper.text().toLowerCase()).toContain("no inner observation");
   });
 
-  // The bodies are client-loaded (see `useInnerObservationContent`), so
+  // The bodies are client-loaded (see `usePartScopedSections`), so
   // "nothing here yet" is the state every first paint starts in — it must
   // not read as "this part has none".
   it("shows a decorative skeleton, not the empty state, while the bodies are pending", async () => {

--- a/tests/unit/part-scoped-sections.spec.ts
+++ b/tests/unit/part-scoped-sections.spec.ts
@@ -7,7 +7,7 @@ import type {
   TocChapter,
 } from "~~/shared/types/content";
 
-// `useInnerObservationContent` reuses `useChapterContent`'s per-file lazy
+// `usePartScopedSections` reuses `useChapterContent`'s per-file lazy
 // loader; stubbing it keeps this spec about *when* the bodies are fetched
 // (never during setup/SSR, once per part after mount, never at all while the
 // pane's mode isn't showing) rather than about the committed corpus. The
@@ -58,7 +58,7 @@ const mountHost = async (
 ) => {
   const Host = defineComponent({
     setup() {
-      const content = useInnerObservationContent(partId, chapters, enabled);
+      const content = usePartScopedSections(partId, chapters, enabled);
       // Captured synchronously in `setup` — i.e. what the prerendered HTML
       // and the client's hydrating render both resolve to.
       const preMount = {
@@ -81,10 +81,10 @@ beforeEach(() => {
   loadLayerFile.mockReset();
 });
 
-describe("innerObservationVersionIds", () => {
+describe("partScopedVersionIds", () => {
   it("unions the ToC's source versions across sections, in first-seen order", () => {
     expect(
-      innerObservationVersionIds([
+      partScopedVersionIds([
         innerObservationChapter("part-01/inner-observation-01", [
           "he-jerusalem-1956",
           "en-bb",
@@ -98,11 +98,11 @@ describe("innerObservationVersionIds", () => {
   });
 
   it("returns an empty list for a part with no Inner Observation chapters", () => {
-    expect(innerObservationVersionIds([])).toEqual([]);
+    expect(partScopedVersionIds([])).toEqual([]);
   });
 });
 
-describe("useInnerObservationContent (hydration)", () => {
+describe("usePartScopedSections (hydration)", () => {
   it("fetches no bodies during setup, then loads them after mount", async () => {
     resolveTo("part-90");
 
@@ -213,7 +213,7 @@ describe("useInnerObservationContent (hydration)", () => {
   });
 });
 
-describe("useInnerObservationContent (mode gate)", () => {
+describe("usePartScopedSections (mode gate)", () => {
   it("fetches nothing while the pane's mode isn't showing", async () => {
     resolveTo("part-95");
 

--- a/tests/unit/reader-panes.spec.ts
+++ b/tests/unit/reader-panes.spec.ts
@@ -4,25 +4,29 @@ import { resolveReaderPanes } from "~/utils/readerPanes";
 describe("resolveReaderPanes", () => {
   it("returns all three panes when every layer exists", () => {
     expect(
-      resolveReaderPanes({ hasCommentary: true, hasInnerObservation: true }),
+      resolveReaderPanes({ hasCommentary: true, hasThirdPane: true }),
     ).toEqual(["source", "commentary", "inner-observation"]);
   });
 
   it("drops Inner Light when the chapter has no commentary edition", () => {
     expect(
-      resolveReaderPanes({ hasCommentary: false, hasInnerObservation: true }),
+      resolveReaderPanes({ hasCommentary: false, hasThirdPane: true }),
     ).toEqual(["source", "inner-observation"]);
   });
 
-  it("drops Inner Observation when the part has none", () => {
+  // The third pane is tabbed (Inner Observation / Questions / Answers), so
+  // a part with no Inner Observation still has one — it just opens on
+  // Questions. This case is what happens if a part ever has none of the
+  // three, which no part in the corpus does today.
+  it("drops the third pane when the part has none of its three tabs", () => {
     expect(
-      resolveReaderPanes({ hasCommentary: true, hasInnerObservation: false }),
+      resolveReaderPanes({ hasCommentary: true, hasThirdPane: false }),
     ).toEqual(["source", "commentary"]);
   });
 
   it("collapses to a lone Source pane when both layers are absent", () => {
     expect(
-      resolveReaderPanes({ hasCommentary: false, hasInnerObservation: false }),
+      resolveReaderPanes({ hasCommentary: false, hasThirdPane: false }),
     ).toEqual(["source"]);
   });
 });

--- a/tests/unit/reader-third-pane.spec.ts
+++ b/tests/unit/reader-third-pane.spec.ts
@@ -1,0 +1,179 @@
+// The third pane became collapsible and tabbed (Inner Observation /
+// Questions / Answers). Three things here break silently if they regress:
+// the persisted state must survive a visit without being consulted during
+// the first render (prerendering has no `localStorage` — the hydration trap
+// `useCollapsedReaderChrome` documents); a persisted tab a given part does
+// not offer must fall through WITHOUT being overwritten; and the tablist
+// must only ever offer tabs the part actually has.
+import { mountSuspended } from "@nuxt/test-utils/runtime";
+import { beforeEach, describe, expect, it } from "vitest";
+import { defineComponent, nextTick } from "vue";
+import ThirdPaneTabs from "~/components/reader/ThirdPaneTabs.vue";
+import {
+  resolveThirdPaneTab,
+  type ThirdPaneTab,
+} from "~/composables/useReaderThirdPane";
+
+const OPEN_STORAGE_KEY = "readtes:reader-third-pane-open";
+const TAB_STORAGE_KEY = "readtes:reader-third-pane-tab";
+
+const Host = defineComponent({
+  setup: () => ({ pane: useReaderThirdPane() }),
+  render: () => null,
+});
+
+describe("useReaderThirdPane", () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  // Open by default: the pane is what the reader had before it became
+  // collapsible, and nobody should have to discover a control to find
+  // Inner Observation where it has always been.
+  it("starts open, on the first tab", async () => {
+    const wrapper = await mountSuspended(Host);
+
+    expect(wrapper.vm.pane.open.value).toBe(true);
+    expect(wrapper.vm.pane.tab.value).toBe("inner-observation");
+  });
+
+  it("toggles, and writes the choice to storage", async () => {
+    const wrapper = await mountSuspended(Host);
+
+    wrapper.vm.pane.toggle();
+    await nextTick();
+
+    expect(wrapper.vm.pane.open.value).toBe(false);
+    expect(localStorage.getItem(OPEN_STORAGE_KEY)).toBe("false");
+  });
+
+  it("restores a closed pane and a chosen tab on a later visit", async () => {
+    localStorage.setItem(OPEN_STORAGE_KEY, "false");
+    localStorage.setItem(TAB_STORAGE_KEY, "answers");
+
+    const wrapper = await mountSuspended(Host);
+    await nextTick();
+
+    expect(wrapper.vm.pane.open.value).toBe(false);
+    expect(wrapper.vm.pane.tab.value).toBe("answers");
+  });
+
+  // A hand-edited or stale value must not put the pane in a state no tab
+  // matches — it would render a tablist with nothing selected.
+  it("falls back to the first tab for an unrecognised stored value", async () => {
+    localStorage.setItem(TAB_STORAGE_KEY, "not-a-tab");
+
+    const wrapper = await mountSuspended(Host);
+    await nextTick();
+
+    expect(wrapper.vm.pane.tab.value).toBe("inner-observation");
+  });
+});
+
+describe("resolveThirdPaneTab", () => {
+  it("keeps the reader's tab when the part offers it", () => {
+    expect(
+      resolveThirdPaneTab("answers", [
+        "inner-observation",
+        "questions",
+        "answers",
+      ]),
+    ).toBe("answers");
+  });
+
+  // The five parts with no Inner Observation. The preference is NOT
+  // rewritten — the reader gets it back on the next part that has one.
+  it("falls through to the first available tab when the part lacks it", () => {
+    expect(
+      resolveThirdPaneTab("inner-observation", ["questions", "answers"]),
+    ).toBe("questions");
+  });
+
+  it("resolves to nothing when the part offers no tab at all", () => {
+    expect(resolveThirdPaneTab("questions", [])).toBeNull();
+  });
+});
+
+describe("ThirdPaneTabs", () => {
+  const mountTabs = (tabs: ThirdPaneTab[], active: ThirdPaneTab) =>
+    mountSuspended(ThirdPaneTabs, { props: { tabs, active } });
+
+  it("renders one tab per available layer, and marks the active one", async () => {
+    const wrapper = await mountTabs(
+      ["inner-observation", "questions", "answers"],
+      "questions",
+    );
+
+    const tabs = wrapper.findAll('[role="tab"]');
+    expect(tabs).toHaveLength(3);
+    expect(tabs[1]!.attributes("aria-selected")).toBe("true");
+    expect(tabs[0]!.attributes("aria-selected")).toBe("false");
+  });
+
+  // A part with no Inner Observation gets a two-tab pane, never a tab that
+  // opens onto an explanation — that explanation stays in the Source pane's
+  // footnote, where it already was.
+  it("offers only the tabs it was given", async () => {
+    const wrapper = await mountTabs(["questions", "answers"], "questions");
+
+    expect(wrapper.findAll('[role="tab"]')).toHaveLength(2);
+    expect(
+      wrapper.findAll('[role="tab"]').map((tab) => tab.text()),
+    ).not.toContain("Inner Observation");
+    // ...and the heading must not name a tab this part does not have.
+    expect(wrapper.get("h2").text()).toBe("Questions and Answers");
+  });
+
+  it("emits the tab a click selects", async () => {
+    const wrapper = await mountTabs(
+      ["inner-observation", "questions"],
+      "inner-observation",
+    );
+
+    await wrapper.findAll('[role="tab"]')[1]!.trigger("click");
+
+    expect(wrapper.emitted("select")?.[0]).toEqual(["questions"]);
+  });
+
+  // Roving tabindex: only the active tab is in the tab order, so Tab moves
+  // past the whole tablist rather than through each of its buttons.
+  it("keeps only the active tab reachable by Tab", async () => {
+    const wrapper = await mountTabs(
+      ["inner-observation", "questions", "answers"],
+      "answers",
+    );
+
+    const tabs = wrapper.findAll('[role="tab"]');
+    expect(tabs.map((tab) => tab.attributes("tabindex"))).toEqual([
+      "-1",
+      "-1",
+      "0",
+    ]);
+  });
+
+  it("moves to the next tab on ArrowRight, and wraps at the end", async () => {
+    const wrapper = await mountTabs(
+      ["inner-observation", "questions", "answers"],
+      "answers",
+    );
+
+    await wrapper
+      .findAll('[role="tab"]')[2]!
+      .trigger("keydown", { key: "ArrowRight" });
+
+    expect(wrapper.emitted("select")?.[0]).toEqual(["inner-observation"]);
+  });
+
+  it("moves to the previous tab on ArrowLeft", async () => {
+    const wrapper = await mountTabs(
+      ["inner-observation", "questions", "answers"],
+      "questions",
+    );
+
+    await wrapper
+      .findAll('[role="tab"]')[1]!
+      .trigger("keydown", { key: "ArrowLeft" });
+
+    expect(wrapper.emitted("select")?.[0]).toEqual(["inner-observation"]);
+  });
+});


### PR DESCRIPTION
Closes #165.

## What changed

Panes mode was a fixed three-column grid (`0.8fr 1.1fr 1.1fr`), so Inner
Light — the layer you read straight through — permanently shared the
viewport with reference material that is consulted occasionally. **The
third pane now collapses, and Inner Light takes that width back.**

It also became **tabbed**. Questions and Answers were reachable only at
their own URLs, so consulting one meant leaving the chapter. They are now
the pane's second and third tabs.

Every part has Questions and Answers (#91 consolidated them to one chapter
per kind), so **the five parts with no Inner Observation — 5, 11, 14, 15,
16 — get a third pane for the first time** instead of none at all.

## Why it pushes rather than floats

Same reasoning that settled the mobile chrome in #113/#119: a *deliberate
tap* is allowed to reflow, so the pane stays in normal flow and simply
stops rendering. That is one grid-template change and one boolean, against
the measured absolute positioning an overlay needs — and the first attempt
at overlaying reader chrome (#114) was reverted for exactly that
complexity.

An overlay would also be wrong on its own terms: it would cover the end of
the Inner Light column mid-read, which is the column this exists to widen.

## Structure

| file | role |
|---|---|
| `useReaderThirdPane` | persisted open state + active tab, same shape as `useCollapsedReaderChrome` including its post-mount hydration gate |
| `ThirdPaneTabs` | the tablist, in the pane header; roving tabindex, arrow keys resolved through the element's own `direction` so RTL is not reversed |
| `ThirdPaneRail` | the toggle, as a slim `auto` grid track on the inline-end edge |
| `useThirdPaneTabContent` | one language for the pane resolved against the active tab; only the active tab is fetched |

`useInnerObservationContent` → **`usePartScopedSections`**, which is what
it always was — it takes any part-scoped chapter list. Its cache is now
keyed by chapter ids: three tabs of one part would otherwise all have
received the first one's essays.

## Two things worth a reviewer's eye

**`display: none`, never `v-if`.** The third pane is the same DOM node as
the mobile track's third slide — `MobileSwipePanes` deliberately shares one
set of slot instances between the two layouts. A `v-if` would drop its
scroll position and remount it on every crossing of the `lg` breakpoint.

**The pane keeps an `<h2>`,** visually hidden. Replacing it with a tablist
would have quietly removed this pane from heading navigation. It names only
the tabs the part actually has, from static message keys rather than
`Intl.ListFormat` — Node and the browser carry independent ICU versions,
which is the trap `NATIVE_LANGUAGE_NAMES` exists for.

The mobile pill now takes a label for the third pane rather than
hardcoding "Inner Observation", which would have named five parts after
content they do not contain. They show "Q & A" — the short form, because
that bar is space-constrained chrome; the pane's own heading takes the full
"Questions and Answers".

## Verification

`task check` green — lint, format:check, typecheck, validate:content, 987
unit tests, full `generate`, fonts, 10/10 Playwright e2e.

Also driven in a real browser against the built output, not just asserted:

- **1440px** — open, collapsed (Inner Light visibly wider), Questions tab
  loading the numbered question list, Answers tab
- **1440px, part 14** — two tabs, no Inner Observation, third pane present
  where there was none
- **1440px, Hebrew** — panes and rail mirrored, tabs in RTL order, chevron
  pointing at the correct edge
- **390px** — third slide tabbed, rail correctly absent, pill reading
  "Q & A" on part 14

Two e2e assertions changed: they asserted an `<h2>` named "Inner
Observation" in that pane, which is now the tablist's hidden label plus a
selected tab. They assert both.

## What a reviewer should double-check

The **tab set and its order** is my call, not yours — Inner Observation,
then Questions, then Answers. And "Q & A" in the mobile pill is the one
piece of new terminology here; if you want it spelled out or named
differently, that is a one-line message change.